### PR TITLE
Implement variable recording interval precision

### DIFF
--- a/cmd/promsum/bill.go
+++ b/cmd/promsum/bill.go
@@ -11,7 +11,7 @@ import (
 )
 
 // bill generates billing records and persists them.
-func bill(prom promV1.API, store promsum.Store, query, subject string, rng promsum.Range, maxPeriod time.Duration) (err error) {
+func bill(prom promV1.API, store promsum.Store, query, subject string, rng promsum.Range, timePrecision time.Duration) (err error) {
 	var billingRecords []promsum.BillingRecord
 	for {
 		billingRecords, err = store.Read(rng, query, subject)
@@ -33,7 +33,7 @@ func bill(prom promV1.API, store promsum.Store, query, subject string, rng proms
 
 		// attempt to create billing record for every period
 		for _, rng := range gaps {
-			records, err := promsum.Meter(prom, query, rng)
+			records, err := promsum.Meter(prom, query, rng, timePrecision)
 			if err != nil {
 				log.Printf("Failed to generate billing report for query '%s' in the range %v to %v: %v",
 					query, rng.Start, rng.End, err)

--- a/cmd/promsum/main.go
+++ b/cmd/promsum/main.go
@@ -13,14 +13,14 @@ import (
 
 var (
 	before        time.Duration
-	maxPeriodSize time.Duration
+	timePrecision time.Duration
 	subject       string
 	storageDir    string
 )
 
 func init() {
 	flag.DurationVar(&before, "before", 1*time.Hour, "duration before present to start collect billing data")
-	flag.DurationVar(&maxPeriodSize, "max-period", 20*time.Minute, "duration after a range gets broken into another range")
+	flag.DurationVar(&timePrecision, "precision", time.Second, "unit of time used for stored amounts")
 	flag.StringVar(&subject, "subject", fmt.Sprintf("%x", time.Now().Second()), "name used to group billing data")
 	flag.StringVar(&storageDir, "path", "./data", "system path to read/write billing data")
 
@@ -51,15 +51,18 @@ func main() {
 	}
 
 	log.Println("Testing metering...")
-	records, err := promsum.Meter(prom, query, billingRng)
+	records, err := promsum.Meter(prom, query, billingRng, timePrecision)
 	if err != nil {
 		log.Fatalf("Failed to meter for %v for query '%s': %v", billingRng, query, err)
 	}
 
+	var total float64
 	fmt.Println("Produced records:")
 	for _, r := range records {
 		log.Println("- ", r)
+		total += r.Amount
 	}
+	fmt.Printf("Total usage over %v: %f\n", billingRng, total)
 
 	log.Println("Testing storage...")
 	store, err := promsum.NewFileStore(storageDir)
@@ -67,7 +70,7 @@ func main() {
 		log.Fatal("Could not setup file storage: ", err)
 	}
 
-	err = bill(prom, store, query, subject, billingRng, maxPeriodSize)
+	err = bill(prom, store, query, subject, billingRng, timePrecision)
 	if err != nil {
 		log.Fatalf("Failed to bill for period %v to %v for query '%s': %v",
 			billingRng.Start, billingRng.End, query, err)

--- a/pkg/promsum/meter.go
+++ b/pkg/promsum/meter.go
@@ -12,9 +12,12 @@ import (
 
 // Meter creates a billing record for a given range and Prometheus query. It does this by summing usage
 // between each Prometheus instant vector by multiplying rate against against the length of the interval.
-func Meter(prom v1.API, pqlQuery string, rng Range) ([]BillingRecord, error) {
+// Amounts will be rounded to the nearest unit of time specified by timePrecision.
+func Meter(prom v1.API, pqlQuery string, rng Range, timePrecision time.Duration) ([]BillingRecord, error) {
 	if prom == nil {
 		return nil, errors.New("prometheus API was nil")
+	} else if timePrecision < PromTimePrecision {
+		return nil, fmt.Errorf("prometheous only supports precision down to the %v", PromTimePrecision)
 	}
 
 	pRng := v1.Range{
@@ -39,7 +42,7 @@ func Meter(prom v1.API, pqlQuery string, rng Range) ([]BillingRecord, error) {
 		for i := 1; i < len(sampleStream.Values); i++ {
 			start, end := sampleStream.Values[i-1], sampleStream.Values[i]
 
-			total, err := CalculateUsage(start, end)
+			total, err := CalculateUsage(start, end, timePrecision)
 			if err != nil {
 				return nil, fmt.Errorf("can't calculate usage for range %v to %v for query '%s': %v",
 					start.Timestamp, end.Timestamp, pqlQuery, err)
@@ -64,9 +67,10 @@ func Meter(prom v1.API, pqlQuery string, rng Range) ([]BillingRecord, error) {
 }
 
 // CalculateUsage determines how much of a resource was used between two instances of a SamplePair. Usage is determined
-// by the simple average of the values of the samples divided by the duration of the period in milliseconds.
+// by the simple average of the values of the samples divided by the duration of the period in milliseconds. Amounts
+// will be rounded to the nearest unit of time specified by timePrecision.
 // The start sample must come before the end sample.
-func CalculateUsage(start, end model.SamplePair) (float64, error) {
+func CalculateUsage(start, end model.SamplePair, timePrecision time.Duration) (float64, error) {
 	if end.Timestamp.Before(start.Timestamp) {
 		return 0, fmt.Errorf("start (%v) must be before end (%d)", int64(start.Timestamp), int64(end.Timestamp))
 	}
@@ -79,5 +83,6 @@ func CalculateUsage(start, end model.SamplePair) (float64, error) {
 	duration := endTime - startTime
 	total := avg * float64(duration)
 
-	return total, nil
+	// adjust for precision
+	return total / float64(timePrecision/PromTimePrecision), nil
 }

--- a/pkg/promsum/meter_test.go
+++ b/pkg/promsum/meter_test.go
@@ -16,13 +16,13 @@ func TestMeterQueryError(t *testing.T) {
 	}
 
 	rng := Range{Start: time.Unix(0, 0), End: time.Unix(100, 0)}
-	_, err := Meter(prom, "bad query", rng)
+	_, err := Meter(prom, "bad query", rng, PromTimePrecision)
 	if err == nil {
 		t.Error("metering should have failed due to error")
 	}
 
 	// check handling when prom is nil
-	_, err = Meter(nil, "cluster_namespace_controller_pod_container:memory_usage:bytes", rng)
+	_, err = Meter(nil, "cluster_namespace_controller_pod_container:memory_usage:bytes", rng, PromTimePrecision)
 	if err == nil {
 		t.Error("error should be returned if prometheus API is nil")
 	}
@@ -40,6 +40,7 @@ func TestMeterScalarQuery(t *testing.T) {
 		End:   end.Round(PromTimePrecision),
 	}
 	query := int64(2)
+	timePrecision := time.Second
 
 	// scalar queries will always return the same value
 	prom.responseCh <- mockPromResponse{
@@ -59,7 +60,7 @@ func TestMeterScalarQuery(t *testing.T) {
 		},
 	}
 	queryStr := fmt.Sprintf("%d", query)
-	records, err := Meter(prom, queryStr, rng)
+	records, err := Meter(prom, queryStr, rng, timePrecision)
 	if err != nil {
 		t.Error("unexpected error: ", err)
 		return
@@ -78,8 +79,11 @@ func TestMeterScalarQuery(t *testing.T) {
 			t.Errorf("returned query does not match request: want %s, got %s", queryStr, record.Query)
 		}
 
-		duration := rng.End.Sub(rng.Start).Nanoseconds() / int64(time.Millisecond)
+		duration := rng.End.Sub(rng.Start).Nanoseconds() / int64(PromTimePrecision)
 		expectedTotal := float64(duration * query)
+
+		// adjust for desired precision
+		expectedTotal = expectedTotal / float64(timePrecision/PromTimePrecision)
 		if record.Amount != expectedTotal {
 			t.Errorf("amount billed does not match expected: want %f, got %f", expectedTotal, record.Amount)
 		}


### PR DESCRIPTION
Allows for the unit of time amounts are recorded to be customizable. The actual amount calculation is calculated in milliseconds (prom's smallest unit of precision) and rounded to the desired precision.

promsum executable is updated with a flag to specify precision, it presently defaults to 1s.