### PR TITLE
Empty string report status defaults to waiting

### DIFF
--- a/pkg/chargeback/v1/types.go
+++ b/pkg/chargeback/v1/types.go
@@ -41,8 +41,8 @@ type ReportTemplateSpec struct {
 
 // +k8s:deepcopy-gen=true
 type ReportStatus struct {
-	Phase  ReportPhase `json:"phase"`
-	Output string      `json:"output"`
+	Phase  ReportPhase `json:"phase,omitempty"`
+	Output string      `json:"output,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true
@@ -62,6 +62,8 @@ func (p *ReportPhase) UnmarshalText(text []byte) error {
 	case ReportPhaseWaiting:
 	case ReportPhaseStarted:
 	case ReportPhaseError:
+	case ReportPhase(""): // default to waiting
+		phase = ReportPhaseWaiting
 	default:
 		return fmt.Errorf("'%s' is not a ReportPhase", phase)
 	}


### PR DESCRIPTION
A behavior wasn't specified for when the Phase within `ReportStatus` was an empty string causing an error. This was not an issue for user clients because they omit this but the Cron operator was Marshalling empty fields for Phase. This has been changed also.