### PR TITLE
Modify storage to use newline delimited JSON

### DIFF
--- a/images/promsum/IMAGE
+++ b/images/promsum/IMAGE
@@ -1,2 +1,2 @@
-quay.io/coreos/promsum:0.2
+quay.io/coreos/promsum:0.3
 

--- a/manifests/chargeback/example-report.yaml
+++ b/manifests/chargeback/example-report.yaml
@@ -7,11 +7,11 @@ spec:
   reportingEnd: '2017-07-29T00:00:00Z'
   chargeback:
     bucket: coreos-team-chargeback
-    prefix: july-pod-data/kube-chargeback/407374e/
+    prefix: august-promsum-data
   aws:
     bucket: coreos-team-chargeback
     reportName: team-chargeback-testing
     reportPrefix: coreos-detailed-billing/coreosinc/coreos-detailed-billing-001
   output:
     bucket: coreos-team-chargeback
-    prefix: billingReport2
+    prefix: billingReport4

--- a/manifests/promsum/promsum.yaml
+++ b/manifests/promsum/promsum.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: promsum
-        image: quay.io/coreos/promsum:0.2
+        image: quay.io/coreos/promsum:0.3
         imagePullPolicy: Always
         env:
         - name: "POLL_INTERVAL"
@@ -35,7 +35,7 @@ spec:
         - name: "S3_BUCKET"
           value: "coreos-team-chargeback"
         - name: "S3_PATH"
-          value: "july-pod-data"
+          value: "august-promsum-data"
         - name: "QUERY"
           value: "(kube_pod_container_resource_requests_memory_bytes / on(node) group_left kube_node_status_capacity_memory_bytes) * on(node) group_left(provider_id) kube_node_info"
       restartPolicy: Always

--- a/pkg/promsum/store.go
+++ b/pkg/promsum/store.go
@@ -1,6 +1,7 @@
 package promsum
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
@@ -196,37 +197,46 @@ func decodeRelevantRecords(data []byte, rng cb.Range) ([]BillingRecord, error) {
 	defer gzIn.Close()
 
 	var allRecords []BillingRecord
-	if err = json.NewDecoder(gzIn).Decode(&allRecords); err != nil {
-		return nil, fmt.Errorf("could not decode record data: %v", err)
-	}
 
-	records := allRecords[:0]
-	for _, r := range allRecords {
+	scanner := bufio.NewScanner(gzIn)
+	var r BillingRecord
+	for scanner.Scan() {
+		if err = json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			return nil, fmt.Errorf("could not decode record data: %v", err)
+		}
+
 		if rng.Within(r.Start) || rng.Within(r.End) {
-			records = append(records, r)
+			allRecords = append(allRecords, r)
 		}
 	}
-	return records, nil
+	return allRecords, nil
 }
 
 // encodeRecords marshals and compresses billing records into bytes.
 func encodeRecords(records []BillingRecord, name string) (data []byte, err error) {
-	if data, err = json.Marshal(&records); err != nil {
-		return
-	}
-
-	var buf bytes.Buffer
-	gzOut := gzip.NewWriter(&buf)
+	buf := new(bytes.Buffer)
+	gzOut := gzip.NewWriter(buf)
 
 	// set metadata in gzip header
 	gzOut.Name = name
 	gzOut.Comment = StorageComment
 	gzOut.ModTime = time.Now().UTC()
 
-	// compress record data
-	if _, err = gzOut.Write(data); err != nil {
-		return
+	// write records
+	for l, r := range records {
+		if data, err = json.Marshal(&r); err == nil {
+			if _, err = gzOut.Write(data); err != nil {
+				return nil, fmt.Errorf("error (line %d) encoding: %v", l, err)
+			}
+
+			if _, err = fmt.Fprintln(gzOut); err != nil {
+				return nil, fmt.Errorf("error (line %d) encoding: %v", l, err)
+			}
+		} else {
+			return nil, fmt.Errorf("error (line %d) encoding: %v", l, err)
+		}
 	}
+
 	err = gzOut.Close()
 	data = buf.Bytes()
 	return


### PR DESCRIPTION
Hive requires that JSON tables use a newline as the delimiter between rows. This PR implements a compatible encoding/decoding scheme.