### PR TITLE
Support distribution with GNU cp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: fmt chargeback-image
 
 dist: Documentation manifests examples hack/*.sh
 	mkdir -p $@
-	cp -Lr $? $@
+	cp -r $? $@
 
 dist.zip: dist
 	zip -r $@ $?


### PR DESCRIPTION
A flag (`-L`) was used that is not supported by at least some versions of GNU cp. This is removed as the functionality it offered, deep copying links as files, is no longer required.