### PR TITLE
Add LOG_REPORT envvar for logging report objects

### DIFF
--- a/cmd/chargeback/operator.go
+++ b/cmd/chargeback/operator.go
@@ -1,16 +1,28 @@
 package main
 
 import (
-	"github.com/coreos-inc/kube-chargeback/pkg/chargeback"
 	"io/ioutil"
+	"os"
+	"strconv"
+
+	"github.com/coreos-inc/kube-chargeback/pkg/chargeback"
 )
 
 var (
 	HiveHost   = "hive:10000"
 	PrestoHost = "presto:8080"
+
+	logReport bool
 )
 
 func main() {
+	if logReportEnv := os.Getenv("LOG_REPORT"); logReportEnv != "" {
+		var err error
+		logReport, err = strconv.ParseBool(logReportEnv)
+		if err != nil {
+			panic(err)
+		}
+	}
 	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		panic(err)
@@ -19,6 +31,7 @@ func main() {
 		Namespace:  string(namespace),
 		HiveHost:   HiveHost,
 		PrestoHost: PrestoHost,
+		LogReport:  logReport,
 	}
 
 	op, err := chargeback.New(cfg)

--- a/pkg/chargeback/operator.go
+++ b/pkg/chargeback/operator.go
@@ -26,6 +26,7 @@ type Config struct {
 
 	HiveHost   string
 	PrestoHost string
+	LogReport  bool
 }
 
 func init() {
@@ -34,10 +35,13 @@ func init() {
 }
 
 func New(cfg Config) (*Chargeback, error) {
+	log.Debugf("Config: %+v", cfg)
+
 	op := &Chargeback{
 		namespace:  cfg.Namespace,
 		hiveHost:   cfg.HiveHost,
 		prestoHost: cfg.PrestoHost,
+		logReport:  cfg.LogReport,
 	}
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -85,6 +89,7 @@ type Chargeback struct {
 	namespace  string
 	hiveHost   string
 	prestoHost string
+	logReport  bool
 }
 
 func (c *Chargeback) Run(stopCh <-chan struct{}) error {

--- a/pkg/chargeback/query.go
+++ b/pkg/chargeback/query.go
@@ -1,6 +1,7 @@
 package chargeback
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"time"
@@ -92,10 +93,18 @@ func (c *Chargeback) handleAddReport(obj interface{}) {
 		return
 	}
 
-	err = generateReport(logger, report, genQuery, rng, promsumTable, hiveCon, prestoCon)
+	results, err := generateReport(logger, report, genQuery, rng, promsumTable, hiveCon, prestoCon)
 	if err != nil {
 		c.setError(logger, report, fmt.Errorf("Report execution failed: %v", err))
 		return
+	}
+	if c.logReport {
+		resultsJSON, err := json.MarshalIndent(results, "", " ")
+		if err != nil {
+			c.setError(logger, report, fmt.Errorf("Unable to marshal report into JSON: %v", err))
+			return
+		}
+		logger.Debugf("results: %s", string(resultsJSON))
 	}
 
 	// update status


### PR DESCRIPTION
I found this useful for debugging and validating the results without having to
check s3. Additionally, this same code should work when if we want to
potentially create a report result CRD which has the actual report output.