### PR TITLE
Documentation: update for alpha

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -2,8 +2,8 @@
 
 Chargeback consists of a few components:
 
-- A chargeback pod which generates reports based on the collected usage
-  information.
+- A chargeback pod which aggregates Prometheus data and generates reports based
+  on the collected usage information.
 - Hive and Presto clusters, used by the chargeback pod to perform queries on the
   collected usage data.
 
@@ -12,14 +12,13 @@ Chargeback consists of a few components:
 In order to install and use chargeback the following components will be
 necessary:
 
-- AWS credentials with permission to write to and read from an S3 bucket.
 - A tectonic installed Kubernetes cluster, of version 1.8.0 or greater, or with
   a Tectonic Prometheus Operator to be of version 1.6.0 or greater (Prometheus
   operator v0.13).
 - A properly configured kubectl to access the Kubernetes cluster.
 
-To alter the version of the Tectonic Prometheus operator to be 1.6.0, run the following
-command:
+To alter the version of the Tectonic Prometheus operator to be 1.6.0, run the
+following command:
 
 ```
 kubectl -n tectonic-system patch deploy tectonic-prometheus-operator -p '{"spec":{"template":{"spec":{"containers":[{"name":"tectonic-prometheus-operator","image":"quay.io/coreos/tectonic-prometheus-operator:v1.6.0"}]}}}}'
@@ -28,42 +27,17 @@ kubectl -n tectonic-system patch deploy tectonic-prometheus-operator -p '{"spec"
 Once the operator changes the version of the `kube-state-metrics` pod to 1.0.1,
 chargeback installation may proceed.
 
-## Modify Chargeback data stores
-
-Chargeback has a few CRDs that are installed to control what types of reports
-can be generated. More information on this is available in the [documentation on
-Chargeback's CRD model][crd-model], but the data stores must be modified to
-point to a valid S3 bucket.
-
-Modify the `bucket` and `prefix` keys in the files from
-`manifests/custom-resources/datastores` to match where the collected usage
-data should be stored.
-
-As an example:
-
-```
-apiVersion: chargeback.coreos.com/prealpha
-kind: ReportDataStore
-metadata:
-    name: "default-datastore"
-    labels:
-        tectonic-chargeback: "true"
-spec:
-    storage:
-        type: "s3"
-        format: "json"
-        bucket: "chargeback-datastore"
-        prefix: "promsum/memory_by_pod"
-    queries:
-    - "get-memory-by-pod"
-```
-
-## Have a namespace for Chargeback to run in
+## Modifying default values
 
 Chargeback will install into an existing namespace. Without configuration, the
 default is currently `team-chargeback`.
 
-If a different namespace should be used, or you need to customize the location of the docker pull-secret to pull the chargeback docker images, you can override the following environment variables (defaults are used in the example):
+Chargeback also assumes it needs a docker pull secret to pull images, which
+defaults to a secret named `coreos-pull-secret` in the `tectonic-system`
+namespace.
+
+To change either of these, override the following environment variables
+(defaults are used in the example):
 
 ```
 export CHARGEBACK_NAMESPACE=team-chargeback
@@ -73,27 +47,20 @@ export PULL_SECRET=coreos-pull-secret
 
 ## Prometheus location
 
-If Prometheus was setup by Tectonic and is running within the tectonic-system namespace, then you can skip this section.
+If Prometheus was setup by Tectonic and is running within the tectonic-system
+namespace, then you can skip this section.
 
-If you're running the Prometheus operator yourself (not using the Tectonic one), then you need to configure the `prometheus-url` in `manifests/chargeback/chargeback-config.yaml` to match the service created by your Prometheus operator.
+If you're running the Prometheus operator yourself (not using the Tectonic one),
+then you need to configure the `prometheus-url` in
+`manifests/chargeback/chargeback-config.yaml` to match the service created by
+your Prometheus operator.
 
-## Set AWS Credentials
+## Storing data in S3
 
-The install script will detect if AWS credentials are stored in the environment
-variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, and ask if these
-credentials should be used to create a secret in Kubernetes for Chargeback to
-use.
-
-This is recommended, but if these variables are not set the install script
-will print out instructions indicating which file you need to modify and create
-before running `install.sh`.
-
-## Set AWS region
-
-Chargeback currently need to be configured to use a specific AWS region. This is
-only temporary, and this requirement should be removed in the future. Until
-then, change the `aws-region` value in
-`manifests/chargeback/chargeback-config.yaml`.
+By default the data that chargeback collects and generates is ephemeral, and
+will not survive restarts of the hive pod it deploys. To make this data
+persistent by storing it in S3, follow the instructions in the [storing data in
+S3 document][Storing-Data-In-S3.md] before proceeding with these instructions.
 
 ## Run the install script
 
@@ -110,15 +77,14 @@ kubectl get pods -n $CHARGEBACK_NAMESPACE -l app=chargeback -o name | cut -d/ -f
 ## Generating reports
 
 With Chargeback now successfully installed, reports may be generated. Note that
-with the default configuration, chargeback will need to run for some time
-(potentially up to 10 minutes) for enough usage data to be built up to generate
-a report. Reports can be generated by creating report objects in Kubernetes in
-the same namespace as Chargeback. Some examples of report objects exist in the
+with the default configuration, chargeback will need to run for some time for
+enough usage data to be built up to generate a report. Reports can be generated
+by creating report objects in Kubernetes in the same namespace as Chargeback.
+Some examples of report objects exist in the
 `manifests/custom-resources/reports` directory.
 
-To deploy an example pod usage by memory report, first modify
-`manifests/custom-resources/reports/pod-memory-usage-by-node.yaml` and set your `bucket` and
-`reportStart`/`reportEnd`, then create the report in Kubernetes:
+To deploy an example pod usage by memory report, create the report in
+Kubernetes:
 
 ```
 kubectl -n $CHARGEBACK_NAMESPACE create -f manifests/custom-resources/reports/pod-memory-usage-by-node.yaml
@@ -136,6 +102,27 @@ flag:
 ```
 kubectl -n $CHARGEBACK_NAMESPACE get report pod-memory-usage -o json
 ```
+
+## Viewing reports
+
+Once a report is finished the results can be fetched using an HTTP API available
+via the chargeback pod.
+
+First, set up a port forward via `kubectl` to the pod:
+
+```
+kubectl get pods -n $CHARGEBACK_NAMESPACE -l app=chargeback -o name | cut -d/ -f2 | xargs -I{} kubectl -n $CHARGEBACK_NAMESPACE port-forward {} 8080
+```
+
+And then `curl` can be used (or a web browser) to access finished reports by
+name:
+
+```
+curl "localhost:8080/api/v1/reports/get?name=pod-memory-usage-by-node&format=csv"
+```
+
+The `name` parameter in the URL can be any report that is in the finished state,
+and the `format` parameter can be either `csv` or `json`.
 
 ## Uninstall
 
@@ -166,5 +153,3 @@ s3:GetBucketLocation
 
 Once you have an `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` refer to
 [Set AWS Credentials](set-aws-credentials) and [Set AWS region](set-aws-region) for configuring.
-
-[crd-model]: CRD-Model.md

--- a/Documentation/Storing-Data-In-S3.md
+++ b/Documentation/Storing-Data-In-S3.md
@@ -1,0 +1,88 @@
+# Storing Data in S3
+
+Chargeback supports storing collected usage information and generated reports in
+S3. Data stored locally in the cluster (which is the default) will not survive
+restarts of the hive pod. By configuring chargeback to store data in S3, this
+data will become persistent.
+
+## Set AWS Credentials
+
+The install script will detect if AWS credentials are stored in the environment
+variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, and ask if these
+credentials should be used to create a secret in Kubernetes for Chargeback to
+use. This is required to access S3 buckets.
+
+## Set AWS region
+
+Chargeback currently need to be configured to use a specific AWS region. This is
+only temporary, and this requirement should be removed in the future. Until
+then, change the `aws-region` value in
+`manifests/chargeback/chargeback-config.yaml`.
+
+## Modify Chargeback data stores
+
+Chargeback has a few CRDs that are installed to control what types of reports
+can be generated. More information on this is available in the [documentation on
+Chargeback's CRD model][crd-model], but in summary the data store CRDs describe
+where data for a given Prometheus query should be stored. These data stores can
+be modified to point to a S3 bucket instead of local storage.
+
+The default data stores shipped with chargeback are located in
+`manifests/custom-resources/datastores`. For each data store with a `promsum`
+section, replace:
+
+```
+storage:
+  local: {}
+```
+
+with:
+
+```
+storage:
+  s3:
+    bucket: MY-BUCKET-NAME
+    prefix: MY-PREFIX
+```
+
+As an example, here's the `pod-cpu-usage.yaml` file after being modified to
+store data in the `chargeback` bucket under the `promsum/cpu_by_pod` prefix:
+
+```
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportDataStore
+metadata:
+  name: "pod-cpu-usage"
+  labels:
+    tectonic-chargeback: "true"
+spec:
+  promsum:
+    queries:
+    - "get-cpu-by-pod"
+  storage:
+    s3:
+      bucket: chargeback
+      prefix: promsum/cpu_by_pod
+```
+
+## Set an output location on reports
+
+Reports also must specify to put report results in S3 if they shouldn't be
+stored locally in the cluster. To alter the example reports in
+`manifests/custom-resources/reports` to store data in S3, replace:
+
+```
+output:
+  local: {}
+```
+
+with:
+
+```
+output:
+  s3:
+    bucket: MY-BUCKET-NAME
+    prefix: MY-PREFIX
+```
+
+[crd-model]: CRD-Model.md


### PR DESCRIPTION
A non-comprehensive list of the changes:
- no longer describes S3 as being required
- adds instructions to configure chargeback to use S3
- updates the CRDs to reflect the current files in `manifests/`