### PR TITLE
manifests/custom-resources/reports: set runImmediately to true

### DIFF
--- a/manifests/custom-resources/reports/pod-cpu-usage-by-namespace.yaml
+++ b/manifests/custom-resources/reports/pod-cpu-usage-by-namespace.yaml
@@ -6,6 +6,6 @@ spec:
   reportingStart: '2017-01-01T00:00:00Z'
   reportingEnd: '2017-12-30T23:59:59Z'
   generationQuery: "pod-cpu-usage-by-namespace"
-  runImmediately: false
+  runImmediately: true
   output:
     local: {}

--- a/manifests/custom-resources/reports/pod-cpu-usage-by-node.yaml
+++ b/manifests/custom-resources/reports/pod-cpu-usage-by-node.yaml
@@ -6,6 +6,6 @@ spec:
   reportingStart: '2017-01-01T00:00:00Z'
   reportingEnd: '2017-12-30T23:59:59Z'
   generationQuery: "pod-cpu-usage-by-node"
-  runImmediately: false
+  runImmediately: true
   output:
     local: {}

--- a/manifests/custom-resources/reports/pod-memory-usage-by-namespace.yaml
+++ b/manifests/custom-resources/reports/pod-memory-usage-by-namespace.yaml
@@ -6,6 +6,6 @@ spec:
   reportingStart: '2017-01-01T00:00:00Z'
   reportingEnd: '2017-12-30T23:59:59Z'
   generationQuery: "pod-memory-usage-by-namespace"
-  runImmediately: false
+  runImmediately: true
   output:
     local: {}

--- a/manifests/custom-resources/reports/pod-memory-usage-by-node.yaml
+++ b/manifests/custom-resources/reports/pod-memory-usage-by-node.yaml
@@ -6,6 +6,6 @@ spec:
   reportingStart: '2017-01-01T00:00:00Z'
   reportingEnd: '2017-12-30T23:59:59Z'
   generationQuery: "pod-memory-usage-by-node"
-  runImmediately: false
+  runImmediately: true
   output:
     local: {}


### PR DESCRIPTION
I forgot to invert this flag on the example manifests when I inverted the flag meaning.