### PR TITLE
manifests: Fix report queries to provide correct values

### DIFF
--- a/manifests/custom-resources/report-queries/pod-cpu-usage-by-namespace.yaml
+++ b/manifests/custom-resources/report-queries/pod-cpu-usage-by-namespace.yaml
@@ -14,29 +14,31 @@ spec:
     type: timestamp
   - name: data_end
     type: timestamp
-  - name: cpu_usage_core_seconds
+  - name: pod_request_cpu_core_seconds
     type: double
   query: |
     WITH usage_period AS (
         SELECT labels['namespace'] as namespace,
+            labels,
             amount,
+            timeprecision,
             split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as provider_id,
             "timestamp"
         FROM {{ dataStoreTableName "pod-request-cpu-cores" }}
     ),
     computed_usage AS (
         SELECT namespace,
-            avg(amount) as total_amount,
-            min("timestamp") as data_start,
-            max("timestamp") as data_end
+            labels,
+            amount * timeprecision as usage_amount,
+            "timestamp"
         FROM usage_period
-        WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
-        AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
-        GROUP BY namespace
     )
     SELECT namespace,
-            data_start,
-            data_end,
-            total_amount * date_diff('second', data_start, data_end) as cpu_usage_core_seconds
+            min("timestamp") as data_start,
+            max("timestamp") as data_end,
+            sum(usage_amount) as cpu_usage_core_seconds
     FROM computed_usage
-    ORDER BY namespace, data_start, data_end
+    WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
+    AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
+    GROUP BY namespace
+    ORDER BY namespace

--- a/manifests/custom-resources/report-queries/pod-cpu-usage-by-node.yaml
+++ b/manifests/custom-resources/report-queries/pod-cpu-usage-by-node.yaml
@@ -29,6 +29,7 @@ spec:
             labels['node'] as node,
             labels,
             amount,
+            timeprecision,
             split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as provider_id,
             "timestamp"
         FROM {{ dataStoreTableName "pod-request-cpu-cores" }}
@@ -39,20 +40,19 @@ spec:
             node,
             provider_id,
             labels,
-            avg(amount) as total_amount,
-            min("timestamp") as data_start,
-            max("timestamp") as data_end
+            amount * timeprecision as usage_amount,
+            "timestamp"
         FROM usage_period
-        WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
-        AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
-        GROUP BY pod, namespace, node, provider_id, labels
     )
     SELECT pod,
             namespace,
             node,
             provider_id,
-            data_start,
-            data_end,
-            total_amount * date_diff('second', data_start, data_end) as cpu_usage_core_seconds
+            min("timestamp") as data_start,
+            max("timestamp") as data_end,
+            sum(usage_amount) as cpu_usage_core_seconds
     FROM computed_usage
-    ORDER BY pod, namespace, node, provider_id, data_start, data_end
+    WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
+    AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
+    GROUP BY pod, namespace, node, provider_id
+    ORDER BY pod, namespace, node, provider_id

--- a/manifests/custom-resources/report-queries/pod-memory-usage-by-namespace.yaml
+++ b/manifests/custom-resources/report-queries/pod-memory-usage-by-namespace.yaml
@@ -14,29 +14,31 @@ spec:
     type: timestamp
   - name: data_end
     type: timestamp
-  - name: memory_usage_byte_seconds
+  - name: pod_request_memory_byte_seconds
     type: double
   query: |
     WITH usage_period AS (
         SELECT labels['namespace'] as namespace,
+            labels,
             amount,
+            timeprecision,
             split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as provider_id,
             "timestamp"
         FROM {{ dataStoreTableName "pod-request-memory-bytes" }}
     ),
     computed_usage AS (
         SELECT namespace,
-            avg(amount) as total_amount,
-            min("timestamp") as data_start,
-            max("timestamp") as data_end
+            labels,
+            amount * timeprecision as usage_amount,
+            "timestamp"
         FROM usage_period
-        WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
-        AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
-        GROUP BY namespace
     )
     SELECT namespace,
-            data_start,
-            data_end,
-            total_amount * date_diff('second', data_start, data_end) as memory_usage_byte_seconds
+            min("timestamp") as data_start,
+            max("timestamp") as data_end,
+            sum(usage_amount) as memory_usage_byte_seconds
     FROM computed_usage
-    ORDER BY namespace, data_start, data_end
+    WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
+    AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
+    GROUP BY namespace
+    ORDER BY namespace

--- a/manifests/custom-resources/report-queries/pod-memory-usage-by-node.yaml
+++ b/manifests/custom-resources/report-queries/pod-memory-usage-by-node.yaml
@@ -29,6 +29,7 @@ spec:
             labels['node'] as node,
             labels,
             amount,
+            timeprecision,
             split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as provider_id,
             "timestamp"
         FROM {{ dataStoreTableName "pod-request-memory-bytes" }}
@@ -39,20 +40,19 @@ spec:
             node,
             provider_id,
             labels,
-            avg(amount) as total_amount,
-            min("timestamp") as data_start,
-            max("timestamp") as data_end
+            amount * timeprecision as usage_amount,
+            "timestamp"
         FROM usage_period
-        WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
-        AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
-        GROUP BY pod, namespace, node, provider_id, labels
     )
     SELECT pod,
             namespace,
             node,
             provider_id,
-            data_start,
-            data_end,
-            total_amount * date_diff('second', data_start, data_end) as memory_usage_byte_seconds
+            min("timestamp") as data_start,
+            max("timestamp") as data_end,
+            sum(usage_amount) as memory_usage_byte_seconds
     FROM computed_usage
-    ORDER BY pod, namespace, node, provider_id, data_start, data_end
+    WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
+    AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
+    GROUP BY pod, namespace, node, provider_id
+    ORDER BY pod, namespace, node, provider_id


### PR DESCRIPTION
Was previously using the AVG function which only provided correct
results for the by-node reports, and only if the value never changed.

This uses the timeprecision (promtheus step size) to get the usage for
each row, then sums those to get the total usage.