### PR TITLE
manifests/pkg: add aws billing correlation reports

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -67,7 +67,20 @@ your Prometheus operator.
 By default the data that chargeback collects and generates is ephemeral, and
 will not survive restarts of the hive pod it deploys. To make this data
 persistent by storing it in S3, follow the instructions in the [storing data in
-S3 document][Storing-Data-In-S3.md] before proceeding with these instructions.
+S3 document](Storing-Data-In-S3.md) before proceeding with these instructions.
+
+### AWS Billing Correlation
+
+Chargeback is able to correlate cluster usage information with [AWS detailed
+billing information][AWS-billing], attaching a dollar amount to resource usage.
+For clusters running in EC2, this can be enabled by setting the bucket and
+prefix in `manifests/custom-resources/datastores/aws-billing.yaml` to match the
+location billing reports are configured to be stored, and having the
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables set with
+credentials capable of accessing the bucket when the install command is run.
+
+If the AWS Cost and Usage Reports are not enabled on your account, instructions
+to enable them can be found [here][enable-aws-billing].
 
 ### Run the install script
 
@@ -99,25 +112,5 @@ $ kubectl get pods -n $CHARGEBACK_NAMESPACE -l app=chargeback -o name | cut -d/ 
 For instructions on using chargeback, please read the documentation on [using
 chargeback](Using-chargeback.md)
 
-### AWS Billing data setup
-
-**AWS billing reports were temporarily removed from chargeback due to a
-refactor, the following documentation is left in for when this functionality is
-restored**
-
-* Setup hourly billing reports in the AWS console by following [these](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-reports-gettingstarted-turnonreports.html) instructions. Be sure to note the bucket, report prefix, and report name specified here.
-
-* Create AWS access key with permissions for the bucket given above. The required permissions are:
-```
-s3:DeleteObject
-s3:GetObject
-s3:GetObjectAcl1
-s3:PutObject
-s3:PutObjectAcl
-s3:GetBucketAcl
-s3:ListBucket
-s3:GetBucketLocation
-```
-
-Once you have an `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` refer to
-[Set AWS Credentials](set-aws-credentials) and [Set AWS region](set-aws-region) for configuring.
+[AWS-billing]: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-reports-costusage.html
+[enable-aws-billing]: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-reports-gettingstarted-turnonreports.html

--- a/manifests/custom-resources/prom-queries/node-allocatable.yaml
+++ b/manifests/custom-resources/prom-queries/node-allocatable.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "node-allocatable-memory-bytes"
 spec:
   query: |
-    kube_node_status_allocatable_memory_bytes
+    kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) kube_node_info
 
 ---
 
@@ -14,4 +14,4 @@ metadata:
   name: "node-allocatable-cpu-cores"
 spec:
   query: |
-    kube_node_status_allocatable_cpu_cores
+    kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) kube_node_info

--- a/manifests/custom-resources/prom-queries/node-capacity.yaml
+++ b/manifests/custom-resources/prom-queries/node-capacity.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "node-capacity-memory-bytes"
 spec:
   query: |
-    kube_node_status_capacity_memory_bytes
+    kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) kube_node_info
 
 ---
 
@@ -14,4 +14,4 @@ metadata:
   name: "node-capacity-cpu-cores"
 spec:
   query: |
-    kube_node_status_capacity_cpu_cores
+    kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) kube_node_info

--- a/manifests/custom-resources/report-queries/aws-billing.yaml
+++ b/manifests/custom-resources/report-queries/aws-billing.yaml
@@ -1,0 +1,66 @@
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "aws-ec2-billing-data"
+spec:
+  reportDataStores:
+  - "aws-billing"
+  reportQueries:
+  - "node-allocatable-memory"
+  columns:
+  - name: resource_id
+    type: string
+  - name: period_start
+    type: timestamp
+  - name: period_stop
+    type: timestamp
+  - name: partition_start
+    type: timestamp
+  - name: partition_stop
+    type: timestamp
+  - name: period_cost
+    type: double
+  query: |
+    WITH resource_id_list AS (
+      SELECT resource_id
+      FROM {{ generationQueryViewName "node-allocatable-memory" }}
+      GROUP BY resource_id
+    )
+    SELECT lineItem_resourceId as resource_id,
+           lineItem_UsageStartDate as period_start,
+           lineItem_UsageEndDate as period_stop,
+           lineItem_BlendedCost as period_cost,
+           billing_period_start as partition_start,
+           billing_period_end as partition_stop
+    FROM {{ dataStoreTableName "aws-billing" }} as aws_billing
+    INNER JOIN resource_id_list
+    ON aws_billing.lineItem_resourceId = resource_id_list.resource_id
+    WHERE position('.csv' IN aws_billing."$path") != 0 -- This prevents JSON manifest files from being loaded.
+    AND lineitem_productcode = 'AmazonEC2'
+    AND lineItem_operation = 'RunInstances'
+    AND lineItem_UsageStartDate IS NOT NULL
+    AND lineItem_UsageEndDate IS NOT NULL
+---
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "aws-cluster-cost"
+spec:
+  reportQueries:
+  - "aws-ec2-billing-data"
+  view:
+    disabled: true
+  columns:
+  - name: data_start
+    type: timestamp
+  - name: data_stop
+    type: timestamp
+  - name: cluster_cost
+    type: double
+  query: |
+    WITH aws_billing_filtered AS ( {{ filterAWSData .Report "aws-ec2-billing-data" }} )
+    SELECT
+        min(period_start) as data_start,
+        max(period_stop) as data_stop,
+        sum(period_cost * period_percent) as cluster_cost
+    from aws_billing_filtered

--- a/manifests/custom-resources/report-queries/node-cpu-usage.yaml
+++ b/manifests/custom-resources/report-queries/node-cpu-usage.yaml
@@ -12,6 +12,8 @@ spec:
     type: map(varchar, varchar)
   - name: node_capacity_cpu_cores
     type: double
+  - name: resource_id
+    type: string
   - name: timeprecision
     type: double
   - name: node_capacity_cpu_core_seconds
@@ -22,6 +24,7 @@ spec:
       SELECT labels['node'] as node,
           labels,
           amount as node_capacity_cpu_cores,
+          split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as resource_id,
           timeprecision,
           amount * timeprecision as node_capacity_cpu_core_seconds,
           "timestamp"
@@ -43,6 +46,8 @@ spec:
     type: map(varchar, varchar)
   - name: node_allocatable_cpu_cores
     type: double
+  - name: resource_id
+    type: string
   - name: timeprecision
     type: double
   - name: node_allocatable_cpu_core_seconds
@@ -53,6 +58,7 @@ spec:
       SELECT labels['node'] as node,
           labels,
           amount as node_allocatable_cpu_cores,
+          split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as resource_id,
           timeprecision,
           amount * timeprecision as node_allocatable_cpu_core_seconds,
           "timestamp"

--- a/manifests/custom-resources/report-queries/node-memory-usage.yaml
+++ b/manifests/custom-resources/report-queries/node-memory-usage.yaml
@@ -12,6 +12,8 @@ spec:
     type: map(varchar, varchar)
   - name: node_capacity_memory_bytes
     type: double
+  - name: resource_id
+    type: string
   - name: timeprecision
     type: double
   - name: node_capacity_memory_byte_seconds
@@ -22,6 +24,7 @@ spec:
       SELECT labels['node'] as node,
           labels,
           amount as node_capacity_memory_bytes,
+          split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as resource_id,
           timeprecision,
           amount * timeprecision as node_capacity_memory_byte_seconds,
           "timestamp"
@@ -43,6 +46,8 @@ spec:
     type: map(varchar, varchar)
   - name: node_allocatable_memory_bytes
     type: double
+  - name: resource_id
+    type: string
   - name: timeprecision
     type: double
   - name: node_allocatable_memory_byte_seconds
@@ -53,6 +58,7 @@ spec:
       SELECT labels['node'] as node,
           labels,
           amount as node_allocatable_memory_bytes,
+          split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as resource_id,
           timeprecision,
           amount * timeprecision as node_allocatable_memory_byte_seconds,
           "timestamp"

--- a/manifests/custom-resources/report-queries/pod-cpu-usage-aws-billing.yaml
+++ b/manifests/custom-resources/report-queries/pod-cpu-usage-aws-billing.yaml
@@ -1,0 +1,67 @@
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "pod-cpu-usage-aws-billing"
+spec:
+  reportQueries:
+  - "pod-request-cpu-usage"
+  - "node-allocatable-cpu"
+  - "aws-ec2-billing-data"
+  view:
+    disabled: true
+  columns:
+  - name: pod
+    type: string
+  - name: namespace
+    type: string
+  - name: node
+    type: string
+  - name: data_start
+    type: timestamp
+  - name: data_end
+    type: timestamp
+  - name: pod_request_cpu_core_seconds
+    type: double
+  - name: pod_cpu_usage_percent
+    type: double
+  - name: pod_cost
+    type: double
+  query: |
+    WITH aws_billing_filtered AS (
+        {{ filterAWSData .Report "aws-ec2-billing-data" }}
+    ),
+    aws_billing_sum AS (
+        SELECT sum(aws_billing_filtered.period_cost * aws_billing_filtered.period_percent) as cluster_cost
+        FROM aws_billing_filtered
+    ),
+    node_cpu_allocatable AS (
+      SELECT min("timestamp") as node_allocatable_data_start,
+        max("timestamp") as node_allocatable_data_end,
+        sum(node_allocatable_cpu_core_seconds) as node_allocatable_cpu_core_seconds
+      FROM {{ generationQueryViewName "node-allocatable-cpu" }}
+        WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
+        AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
+    ),
+    pod_cpu_consumption AS (
+      SELECT pod,
+             namespace,
+             node,
+             min("timestamp") as data_start,
+             max("timestamp") as data_end,
+             sum(pod_request_cpu_core_seconds) as pod_request_cpu_core_seconds
+      FROM {{ generationQueryViewName "pod-request-cpu-usage" }}
+      WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
+      AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
+      GROUP BY pod, namespace, node
+    ),
+    cluster_usage AS (
+        SELECT pod_cpu_consumption.*,
+               pod_cpu_consumption.pod_request_cpu_core_seconds / node_cpu_allocatable.node_allocatable_cpu_core_seconds as pod_cpu_usage_percent
+        FROM pod_cpu_consumption
+        CROSS JOIN node_cpu_allocatable
+        ORDER BY pod_cpu_consumption.pod_request_cpu_core_seconds DESC
+    )
+    SELECT cluster_usage.*,
+           aws_billing_sum.cluster_cost * cluster_usage.pod_cpu_usage_percent as pod_cost
+    FROM cluster_usage
+    CROSS JOIN aws_billing_sum

--- a/manifests/custom-resources/report-queries/pod-memory-usage-aws.yaml
+++ b/manifests/custom-resources/report-queries/pod-memory-usage-aws.yaml
@@ -1,0 +1,67 @@
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "pod-memory-usage-aws-billing"
+spec:
+  reportQueries:
+  - "pod-request-memory-usage"
+  - "node-allocatable-memory"
+  - "aws-ec2-billing-data"
+  view:
+    disabled: true
+  columns:
+  - name: pod
+    type: string
+  - name: namespace
+    type: string
+  - name: node
+    type: string
+  - name: data_start
+    type: timestamp
+  - name: data_end
+    type: timestamp
+  - name: pod_request_memory_byte_seconds
+    type: double
+  - name: pod_memory_usage_percent
+    type: double
+  - name: pod_cost
+    type: double
+  query: |
+    WITH aws_billing_filtered AS (
+        {{ filterAWSData .Report "aws-ec2-billing-data"}}
+    ),
+    aws_billing_sum AS (
+        SELECT sum(aws_billing_filtered.period_cost * aws_billing_filtered.period_percent) as cluster_cost
+        FROM aws_billing_filtered
+    ),
+    node_memory_allocatable AS (
+      SELECT min("timestamp") as node_allocatable_data_start,
+        max("timestamp") as node_allocatable_data_end,
+        sum(node_allocatable_memory_byte_seconds) as node_allocatable_memory_byte_seconds
+      FROM {{ generationQueryViewName "node-allocatable-memory" }}
+        WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
+        AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
+    ),
+    pod_memory_consumption AS (
+      SELECT pod,
+             namespace,
+             node,
+             min("timestamp") as data_start,
+             max("timestamp") as data_end,
+             sum(pod_request_memory_byte_seconds) as pod_request_memory_byte_seconds
+      FROM {{ generationQueryViewName "pod-request-memory-usage" }}
+      WHERE "timestamp" >= timestamp '{{.Report.StartPeriod | prestoTimestamp }}'
+      AND "timestamp" <= timestamp '{{ .Report.EndPeriod | prestoTimestamp }}'
+      GROUP BY pod, namespace, node
+    ),
+    cluster_usage AS (
+        SELECT pod_memory_consumption.*,
+               pod_memory_consumption.pod_request_memory_byte_seconds / node_memory_allocatable.node_allocatable_memory_byte_seconds as pod_memory_usage_percent
+        FROM pod_memory_consumption
+        CROSS JOIN node_memory_allocatable
+        ORDER BY pod_memory_consumption.pod_request_memory_byte_seconds DESC
+    )
+    SELECT cluster_usage.*,
+           aws_billing_sum.cluster_cost * cluster_usage.pod_memory_usage_percent as pod_cost
+    FROM cluster_usage
+    CROSS JOIN aws_billing_sum

--- a/manifests/custom-resources/reports/cluster-cost-aws.yaml
+++ b/manifests/custom-resources/reports/cluster-cost-aws.yaml
@@ -1,0 +1,11 @@
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: Report
+metadata:
+  name: aws-cluster-cost
+spec:
+  reportingStart: '2017-01-01T00:00:00Z'
+  reportingEnd: '2017-12-30T23:59:59Z'
+  generationQuery: "aws-cluster-cost"
+  runImmediately: true
+  output:
+    local: {}

--- a/manifests/custom-resources/reports/pod-cpu-usage-aws-billing.yaml
+++ b/manifests/custom-resources/reports/pod-cpu-usage-aws-billing.yaml
@@ -1,0 +1,11 @@
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: Report
+metadata:
+  name: pod-cpu-usage-aws-billing
+spec:
+  reportingStart: '2017-01-01T00:00:00Z'
+  reportingEnd: '2017-12-30T23:59:59Z'
+  generationQuery: "pod-cpu-usage-aws-billing"
+  runImmediately: true
+  output:
+    local: {}

--- a/manifests/custom-resources/reports/pod-memory-usage-aws-billing.yaml
+++ b/manifests/custom-resources/reports/pod-memory-usage-aws-billing.yaml
@@ -1,0 +1,11 @@
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: Report
+metadata:
+  name: pod-memory-usage-aws-billing
+spec:
+  reportingStart: '2017-01-01T00:00:00Z'
+  reportingEnd: '2017-12-30T23:59:59Z'
+  generationQuery: "pod-memory-usage-aws-billing"
+  runImmediately: true
+  output:
+    local: {}

--- a/pkg/chargeback/templates.go
+++ b/pkg/chargeback/templates.go
@@ -20,6 +20,8 @@ var templateFuncMap = template.FuncMap{
 	"prestoTimestamp":           prestoTimestamp,
 	"dataStoreTableName":        dataStoreTableName,
 	"generationQueryViewName":   generationQueryViewName,
+	"billingPeriodFormat":       billingPeriodFormat,
+	"filterAWSData":             filterAWSData,
 }
 
 type templateInfo struct {
@@ -76,4 +78,36 @@ func hiveAWSPartitionTimestamp(date time.Time) string {
 
 func prestoTimestamp(date time.Time) string {
 	return date.Format(PrestoTimestampFormat)
+}
+
+func filterAWSData(r *reportTemplateInfo, awsBillingDatastoreName string) string {
+	start := prestoTimestamp(r.StartPeriod)
+	stop := prestoTimestamp(r.EndPeriod)
+	partitionStart := hiveAWSPartitionTimestamp(r.StartPeriod)
+	partitionStop := hiveAWSPartitionTimestamp(r.EndPeriod)
+	return fmt.Sprintf(`
+        SELECT aws_billing.*,
+               CASE
+                   -- AWS data covers entire reporting period
+                   WHEN (aws_billing.period_start <= timestamp '%s') AND ( timestamp '%s' <= aws_billing.period_stop)
+                       THEN cast(date_diff('millisecond', timestamp '%s', timestamp '%s') as double) / cast(date_diff('millisecond', aws_billing.period_start, aws_billing.period_stop) as double)
+
+                   -- AWS data covers start to middle
+                   WHEN (aws_billing.period_start <= timestamp '%s')
+                       THEN cast(date_diff('millisecond', timestamp '%s', aws_billing.period_stop) as double) / cast(date_diff('millisecond', aws_billing.period_start, aws_billing.period_stop) as double)
+
+                   -- AWS data covers middle to end
+                   WHEN ( timestamp '%s' <= aws_billing.period_stop)
+                       THEN cast(date_diff('millisecond', aws_billing.period_start, timestamp '%s') as double) / cast(date_diff('millisecond', aws_billing.period_start, aws_billing.period_stop) as double)
+
+                   ELSE 1
+               END as period_percent
+        FROM %s as aws_billing
+
+        -- make sure the partition overlaps with our range
+        WHERE (partition_stop >= '%s' AND partition_start <= '%s')
+
+        -- make sure lineItem entries overlap with our range
+        AND (period_stop >= timestamp '%s' AND period_start <= timestamp '%s')
+`, start, stop, start, stop, start, start, stop, stop, generationQueryViewName(awsBillingDatastoreName), partitionStart, partitionStop, start, stop)
 }

--- a/pkg/chargeback/util.go
+++ b/pkg/chargeback/util.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos-inc/kube-chargeback/pkg/hive"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,6 +28,10 @@ func reportTableName(reportName string) string {
 
 func generationQueryViewName(queryName string) string {
 	return fmt.Sprintf("view_%s", resourceNameReplacer.Replace(queryName))
+}
+
+func billingPeriodFormat(date time.Time) string {
+	return date.Format(hive.HiveDateStringLayout)
 }
 
 func truncateToMinute(t time.Time) time.Time {

--- a/pkg/hive/aws.go
+++ b/pkg/hive/aws.go
@@ -51,7 +51,7 @@ func CreateAWSUsageTable(queryer Queryer, tableName, bucket, prefix string, mani
 		}
 	}
 
-	query := createTable(tableName, location, awsUsageSerde, awsUsageSerdeProps, columns, awsPartitions, true, true)
+	query := createTable(tableName, location, awsUsageSerde, "textfile", awsUsageSerdeProps, columns, awsPartitions, true, true)
 	return queryer.Query(query)
 }
 

--- a/pkg/hive/promsum.go
+++ b/pkg/hive/promsum.go
@@ -15,13 +15,13 @@ func CreatePromsumTable(queryer Queryer, tableName, bucket, prefix string) error
 	if err != nil {
 		return err
 	}
-	query := createTable(tableName, location, "", nil, promsumColumns, nil, false, true)
+	query := createTable(tableName, location, "", "", nil, promsumColumns, nil, false, true)
 	return queryer.Query(query)
 }
 
 // CreateLocalPromsumTable instantiates a new external Hive table for Prometheus
 // observation data stored locally
 func CreateLocalPromsumTable(queryer Queryer, tableName string) error {
-	query := createTable(tableName, "", "", nil, promsumColumns, nil, false, true)
+	query := createTable(tableName, "", "", "", nil, promsumColumns, nil, false, true)
 	return queryer.Query(query)
 }

--- a/pkg/hive/query.go
+++ b/pkg/hive/query.go
@@ -22,7 +22,7 @@ func dropTable(name string, ignoreNotExists, purge bool) string {
 
 // createTable returns a query for a CREATE statement which instantiates a new external Hive table.
 // If is external is set, an external Hive table will be used.
-func createTable(name, location, serdeFmt string, serdeProps map[string]string, columns, partitions []Column, external, ignoreExists bool) string {
+func createTable(name, location, serdeFmt, format string, serdeProps map[string]string, columns, partitions []Column, external, ignoreExists bool) string {
 	columnsStr := fmtColumnText(columns)
 
 	tableType := ""
@@ -47,13 +47,16 @@ func createTable(name, location, serdeFmt string, serdeProps map[string]string, 
 	if location != "" {
 		location = fmt.Sprintf(`LOCATION "%s"`, location)
 	}
+	if format != "" {
+		format = fmt.Sprintf("STORED AS %s", format)
+	}
 	return fmt.Sprintf(
 		`CREATE %s TABLE %s
 %s (%s) %s
-%s %s`,
+%s %s %s`,
 		tableType, ifNotExists,
 		name, columnsStr, partitionedBy,
-		serdeFormatStr, location,
+		serdeFormatStr, format, location,
 	)
 }
 

--- a/pkg/hive/result.go
+++ b/pkg/hive/result.go
@@ -14,7 +14,7 @@ func CreateReportTable(queryer Queryer, tableName, bucket, prefix string, column
 		return err
 	}
 
-	query = createTable(tableName, location, "", nil, columns, nil, false, false)
+	query = createTable(tableName, location, "", "", nil, columns, nil, false, false)
 	return queryer.Query(query)
 }
 
@@ -25,6 +25,6 @@ func CreateLocalReportTable(queryer Queryer, tableName string, columns []Column)
 		return err
 	}
 
-	query = createTable(tableName, "", "", nil, columns, nil, false, true)
+	query = createTable(tableName, "", "", "", nil, columns, nil, false, true)
 	return queryer.Query(query)
 }


### PR DESCRIPTION
Adds the pod-memory-usage-aws report query, which can associate memory
usage information with AWS detailed billing reports stored in S3.

Notable changes to help with this:
- added the billingPeriodFormat function to the templates for
  string-based date comparison when processing AWS billing reports
- added a field to createTable to specify format type, because AWS
  billing reports need `textfile` and not `ORC`
- adding a group_left on kube_node_info to all node queries so the
  resource_id can be fetched