### PR TITLE
pkg/chargeback: Stop inserting data into promsum and truncating the table.

### DIFF
--- a/pkg/chargeback/datastores.go
+++ b/pkg/chargeback/datastores.go
@@ -10,7 +10,6 @@ import (
 	cbTypes "github.com/coreos-inc/kube-chargeback/pkg/apis/chargeback/v1alpha1"
 	"github.com/coreos-inc/kube-chargeback/pkg/aws"
 	"github.com/coreos-inc/kube-chargeback/pkg/hive"
-	"github.com/coreos-inc/kube-chargeback/pkg/presto"
 )
 
 func (c *Chargeback) runReportDataStoreWorker() {
@@ -87,27 +86,6 @@ func (c *Chargeback) handlePromsumDataStore(logger log.FieldLogger, dataStore *c
 		logger.Debugf("creating local table %s", tableName)
 		// store the data locally
 		err := hive.CreateLocalPromsumTable(c.hiveQueryer, tableName)
-		if err != nil {
-			return err
-		}
-
-		// There's currently a strange issue where selects in presto will fail
-		// unless an insert has been made first. Don't ask me why.
-
-		// After creating foobar via the hive cli:
-
-		//presto:default> select * from foobar;
-
-		//Query 20171025_185138_00002_cu5nq, FAILED, 1 node
-		//Splits: 16 total, 0 done (0.00%)
-		//0:05 [0 rows, 0B] [0 rows/s, 0B/s]
-
-		//Query 20171025_185138_00002_cu5nq failed: Partition location does not exist: file:/user/hive/warehouse/foobar
-		_, err = presto.ExecuteSelect(c.prestoConn, fmt.Sprintf("INSERT INTO %s VALUES (0.0,null,0.0,map(ARRAY[],ARRAY[]))", tableName))
-		if err != nil {
-			return err
-		}
-		_, err = presto.ExecuteSelect(c.prestoConn, fmt.Sprintf("DELETE FROM %s", tableName))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Persistence has been figuring out, meaning the insertion is no longer
needed, and we also no longer need to truncate data out of the
datastore.