### PR TITLE
charts/chargeback-operator: Handle multiple kube_node_info metrics for same node

### DIFF
--- a/charts/chargeback-operator/templates/custom-resources/prom-queries/node-allocatable.yaml
+++ b/charts/chargeback-operator/templates/custom-resources/prom-queries/node-allocatable.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
 spec:
   query: |
-    kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) kube_node_info
+    kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
 
 ---
 
@@ -22,4 +22,4 @@ metadata:
 {{- end }}
 spec:
   query: |
-    kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) kube_node_info
+    kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)

--- a/charts/chargeback-operator/templates/custom-resources/prom-queries/node-capacity.yaml
+++ b/charts/chargeback-operator/templates/custom-resources/prom-queries/node-capacity.yaml
@@ -8,8 +8,7 @@ metadata:
 {{- end }}
 spec:
   query: |
-    kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) kube_node_info
-
+    kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
 ---
 
 apiVersion: chargeback.coreos.com/v1alpha1
@@ -22,4 +21,4 @@ metadata:
 {{- end }}
 spec:
   query: |
-    kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) kube_node_info
+    kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)


### PR DESCRIPTION
If a node updates then the labels on the metric change, and this results
in there being a many to many relationship, which breaks the group_left
vector matching operator.

Fix it by using the max() aggregation function on the node and
provider_id labels to ensure we only ever get one vector for a given
node.