### PR TITLE
hack/deploy.sh: Handle missing container status

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -61,7 +61,7 @@ else
     echo "Skipping install"
 fi
 
-until [ "$(kubectl -n $CHARGEBACK_NAMESPACE get pods -l app=chargeback-helm-operator -o json | jq '.items | map(.status.containerStatuses[] | .ready) | all' -r)" == "true" ]; do
+until [ "$(kubectl -n $CHARGEBACK_NAMESPACE get pods -l app=chargeback-helm-operator -o json | jq '.items | map(try(.status.containerStatuses[].ready) // false) | all' -r)" == "true" ]; do
     echo 'waiting for chargeback-helm-operator pods to be ready'
     sleep 5
 done
@@ -74,7 +74,7 @@ until [ "$(kubectl -n $CHARGEBACK_NAMESPACE get pods -o json | jq '.items | leng
 done
 echo "all of the chargeback pods have been started"
 
-until [ "$(kubectl -n $CHARGEBACK_NAMESPACE get pods  -o json | jq '.items | map(.status.containerStatuses | if . == null then [{ready: false}] else . end | .[].ready) | all' -r)" == "true" ]; do
+until [ "$(kubectl -n $CHARGEBACK_NAMESPACE get pods  -o json | jq '.items | map(try(.status.containerStatuses[].ready) // false) | all' -r)" == "true" ]; do
     echo 'waiting for all pods to be ready'
     sleep 10
 done


### PR DESCRIPTION
This was fixed previously, but only in one spot, this makes it a little
less verbose using try/catch