### PR TITLE
Jenkinsfile: Don't error if unable to clean up openshift namespace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -380,7 +380,7 @@ podTemplate(
             throw e
         } finally {
             archiveArtifacts artifacts: "test_output/**", onlyIfSuccessful: false
-            step([$class: "TapPublisher", testResults: "test_output/**/*.tap", failIfNoResults: false])
+            step([$class: "TapPublisher", testResults: "test_output/**/*.tap", failIfNoResults: false, planRequired: false])
             container('docker') {
                 sh """#!/bin/bash
                 (docker ps -q | xargs docker kill) || true


### PR DESCRIPTION
Temporary work around until the cluster is back up.