### PR TITLE
Include spot instances in EC2 cluster cost

### DIFF
--- a/charts/chargeback-operator/templates/custom-resources/report-queries/aws-billing.yaml
+++ b/charts/chargeback-operator/templates/custom-resources/report-queries/aws-billing.yaml
@@ -19,12 +19,12 @@ spec:
     type: timestamp
   - name: period_stop
     type: timestamp
-  - name: partition_start
-    type: timestamp
-  - name: partition_stop
-    type: timestamp
   - name: period_cost
     type: double
+  - name: partition_start
+    type: string
+  - name: partition_stop
+    type: string
   query: |
     WITH resource_id_list AS (
       SELECT resource_id


### PR DESCRIPTION
The format for spot instances is `RunInstances:SV006` and not just `RunInstances`. There are other formats too according to https://forums.aws.amazon.com/message.jspa?messageID=351957

This _should_ fix [MC-145 - aws-ec2-cluster-cost doesn't have data](https://jira.coreos.com/projects/MC/issues/MC-145) 