### PR TITLE
charts/chargeback-operator: Use recreate update strategy for deployment

### DIFF
--- a/charts/chargeback-operator/templates/chargeback-deployment.yaml
+++ b/charts/chargeback-operator/templates/chargeback-deployment.yaml
@@ -21,6 +21,8 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
     spec:
+      strategy:
+{{ toYaml .Values.updateStrategy | indent 8 }}
       securityContext:
         runAsNonRoot: true
       containers:

--- a/charts/chargeback-operator/values.yaml
+++ b/charts/chargeback-operator/values.yaml
@@ -39,3 +39,5 @@ resources:
     memory: "100Mi"
     cpu: "100m"
 
+updateStrategy:
+  type: Recreate


### PR DESCRIPTION
Currently the operator doesn't become ready/healthy until it's leader,
meaning rolling updates never proceed due to the old pod not being
killed and losing leadership until the new pod is healthy.