### PR TITLE
Fix update strategy

### DIFF
--- a/charts/chargeback-operator/templates/chargeback-deployment.yaml
+++ b/charts/chargeback-operator/templates/chargeback-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
 {{- block "extraMetadata" . }}
 {{- end }}
 spec:
+  strategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
   template:
     metadata:
       labels:
@@ -21,8 +23,6 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
     spec:
-      strategy:
-{{ toYaml .Values.updateStrategy | indent 8 }}
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
```
$ k logs -f chargeback-helm-operator-7b7f57cf57-q28zl chargeback-helm-operator
Running helm upgrade for release tectonic-chargeback
Release "tectonic-chargeback" does not exist. Installing it now.
2018/04/19 23:32:03 warning: skipped value for chargeback-operator: Not a table.
Error: error validating "": error validating data: found invalid field strategy for v1.PodSpec
```