### PR TITLE
charts/tectonic-chargeback: Fix empty value for chargeback-operator chart

### DIFF
--- a/charts/tectonic-chargeback/values.yaml
+++ b/charts/tectonic-chargeback/values.yaml
@@ -1,5 +1,3 @@
-chargeback-operator:
-
 presto:
   presto:
     securityContext:


### PR DESCRIPTION
Was causing helm to produce the following log message:
"warning: skipped value for chargeback-operator: Not a table."