### PR TITLE
charts/chargeback-operator: Fix pod cpu/memory usage PrometheusQueries

### DIFF
--- a/charts/chargeback-operator/templates/custom-resources/prom-queries/pod-cpu-usage.yaml
+++ b/charts/chargeback-operator/templates/custom-resources/prom-queries/pod-cpu-usage.yaml
@@ -36,4 +36,4 @@ metadata:
 {{- end }}
 spec:
   query: |
-    label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") * on (pod, namespace) group_left(node) kube_pod_info
+    label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") * on (pod, namespace) group_left(node) kube_pod_info{pod_ip!="",node!="",host_ip!=""}

--- a/charts/chargeback-operator/templates/custom-resources/prom-queries/pod-memory-usage.yaml
+++ b/charts/chargeback-operator/templates/custom-resources/prom-queries/pod-memory-usage.yaml
@@ -36,4 +36,4 @@ metadata:
 {{- end }}
 spec:
   query: |
-    sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) * on (pod, namespace) group_left(node) kube_pod_info
+    sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) * on (pod, namespace) group_left(node) kube_pod_info{pod_ip!="",node!="",host_ip!=""}


### PR DESCRIPTION
The pod_ip, node, and host_ip labels can be empty from the kube_pod_info
metric, meaning that matching on the pod, namespace labels isn't
necessarily enough to match to a single vector from kube_pod_info.

This happens when a pod isn't scheduled, or fully initialized yet, and
kube-state-metrics sees the pod state with those fields unset.

To handle this, we exclude the kube_pod_info time series where those
labels are empty, since we're only using it to add the node name into
the final result.