### PR TITLE
pkg/chargeback,charts: Replace hiveAWSPartitionTimestamp template function with billingPeriodTimestamp

### DIFF
--- a/charts/metering-operator/templates/custom-resources/report-queries/aws-billing.yaml
+++ b/charts/metering-operator/templates/custom-resources/report-queries/aws-billing.yaml
@@ -92,7 +92,7 @@ spec:
         FROM {| generationQueryViewName "aws-ec2-billing-data-raw" |} as aws_billing
 
         -- make sure the partition overlaps with our range
-        WHERE (partition_stop >= '{| .Report.StartPeriod | hiveAWSPartitionTimestamp |}' AND partition_start <= '{| .Report.EndPeriod | hiveAWSPartitionTimestamp |}')
+        WHERE (partition_stop >= '{| .Report.StartPeriod | billingPeriodTimestamp |}' AND partition_start <= '{| .Report.EndPeriod | billingPeriodTimestamp |}')
 
         -- make sure lineItem entries overlap with our range
         AND (usage_end_date >= timestamp '{| .Report.StartPeriod | prestoTimestamp |}' AND usage_start_date <= timestamp '{| .Report.EndPeriod | prestoTimestamp |}')

--- a/pkg/chargeback/prestotables.go
+++ b/pkg/chargeback/prestotables.go
@@ -175,8 +175,8 @@ func getDesiredPartitions(prestoTable *cbTypes.PrestoTable, datasource *cbTypes.
 			return nil, err
 		}
 		p := cbTypes.PrestoTablePartition{
-			Start:    manifest.BillingPeriod.Start.Format(hive.HiveDateStringLayout),
-			End:      manifest.BillingPeriod.End.Format(hive.HiveDateStringLayout),
+			Start:    billingPeriodTimestamp(manifest.BillingPeriod.Start.Time),
+			End:      billingPeriodTimestamp(manifest.BillingPeriod.End.Time),
 			Location: location,
 		}
 		desiredPartitions = append(desiredPartitions, p)

--- a/pkg/chargeback/templates.go
+++ b/pkg/chargeback/templates.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/chargeback/v1alpha1"
-	"github.com/operator-framework/operator-metering/pkg/hive"
 )
 
 const (
@@ -27,11 +26,10 @@ type reportTemplateInfo struct {
 
 func newQueryTemplate(queryTemplate string) (*template.Template, error) {
 	var templateFuncMap = template.FuncMap{
-		"hiveAWSPartitionTimestamp":   hiveAWSPartitionTimestamp,
 		"prestoTimestamp":             prestoTimestamp,
 		"dataSourceTableName":         dataSourceTableName,
 		"generationQueryViewName":     generationQueryViewName,
-		"billingPeriodFormat":         billingPeriodFormat,
+		"billingPeriodTimestamp":      billingPeriodTimestamp,
 		"renderReportGenerationQuery": renderReportGenerationQuery,
 	}
 
@@ -80,12 +78,4 @@ func renderReportGenerationQuery(generationQueryName string, templateInfo *templ
 		return "", fmt.Errorf("unable to render query %s, err: %v", generationQueryName, err)
 	}
 	return renderedQuery, nil
-}
-
-func hiveAWSPartitionTimestamp(date time.Time) string {
-	return date.Format(hive.HiveDateStringLayout)
-}
-
-func prestoTimestamp(date time.Time) string {
-	return date.Format(PrestoTimestampFormat)
 }

--- a/pkg/chargeback/util.go
+++ b/pkg/chargeback/util.go
@@ -35,8 +35,12 @@ func prestoTableResourceNameFromKind(kind, name string) string {
 	return strings.ToLower(fmt.Sprintf("%s-%s", kind, name))
 }
 
-func billingPeriodFormat(date time.Time) string {
+func billingPeriodTimestamp(date time.Time) string {
 	return date.Format(hive.HiveDateStringLayout)
+}
+
+func prestoTimestamp(date time.Time) string {
+	return date.Format(PrestoTimestampFormat)
 }
 
 func truncateToMinute(t time.Time) time.Time {


### PR DESCRIPTION
The timestamp used here is actually not hive specific, and its actually
just how the AWS billing period is represented in both the bucket and in
the timestamps within the JSON manifest. So instead of using a confusing
name, remove it, and replace it's usage with something more descriptive
to what it's actually for.