### PR TITLE
Add architecture documentation

### DIFF
--- a/Documentation/metering-architecture.md
+++ b/Documentation/metering-architecture.md
@@ -1,0 +1,130 @@
+# Operator Metering Architecture
+
+Operator metering is composed of 3 major components:
+
+- `metering-operator`: A Kubernetes operator written in Go that uses custom resources as the way users request reports.
+- [Presto][presto-overview]: A distributed SQL Database written in Java, designed for doing big data and analytical queries.
+- [Hive][hive-overview]: A data warehousing application the facilitates reading, writing, and managing data already residing in a distributed storage location.
+  - Presto has a dependency on Hive, and uses Hive for keeping metadata about the data Presto is working with.
+
+## How it works
+
+Internally, Operator Metering uses a database called [Presto][presto-overview] to do analytical querying on collected data using SQL.
+This means that in this document when terms like `tables`, `views`, `SQL`, `statement`, or `query` are used, we're referring to these in the context of the Presto database, and we're using SQL as the primary method of doing analysis and reporting on the data that Operator Metering collects.
+
+The best way to describe how metering works is to describe it in terms of events and reactions, because the primary interaction with Operator Metering is through Kubernetes custom resources, and the metering operator's job is to react to changes in these resources.
+
+To briefly summarize how metering works, it watches for a number of custom resources for changes.
+Most of these custom resources are what you might consider configuration, and allow for developers or end-users to extend what kind of data the operator can access, collect, report on, and in the case of reports, how to calculate the reports.
+Upon being notified that a particular resource has been created, the operator uses all of these resources to create tables or views in Presto, and eventually execute user-defined SQL queries on the data it has access to, or has collected, storing the data for retrieval as a report CSV or JSON file later.
+
+The end goal of all of this is that Operator Metering provides building blocks for doing custom reporting and metering on any data that we can store into Presto.
+Currently this is primarily focused on making Prometheus metrics and billing data accessible, but in the future we can expect other integrations to be added that allow accessing data stored in other locations.
+
+The rest of this document covers how each custom resource that metering consumes operates individually, and how they're related to each other.
+
+## How the operator handles custom resources
+
+There are 6 custom resources that Operator Metering defines that you need to be aware of:
+
+- `StorageLocations`: Provides a place to store data. Is used by `ReportDataSources`, `Reports`, and `ScheduledReports`.
+- `ReportDataSources`: Controls what data is collected (Prometheus data, AWS billing data), and where it's stored
+- `ReportPrometheusQueries`: Controls how Prometheus data is collected
+- `ReportGenerationQueries`: Controls how we query the data we've collected and is what a `Report` or `ScheduledReport` references to control what it's reporting on.
+- `Reports` and `ScheduledReports`: Causes reports to be generated using the `ReportGenerationQuery` configured. This is the primary resource an end-user of Operator Metering would interact with.
+
+In the sections below, we will cover these resources in more detail.
+
+### StorageLocation
+
+For user-docs containing a description of the fields, and examples, see [StorageLocations][storagelocations].
+
+A `StorageLocation` roughly maps to a [connector in Presto][presto-connector], which is effectively how Presto adapts to other datasources like Hive (and thus HDFS), S3 which we support. This also means we can eventually others too, such as PostgreSQL.
+
+In terms of Operator Metering, a `StorageLocation` is intended to abstract some of those details away and expose the minimum configuration required to expose where data is actually persisted at.
+Today there is the concept of an `local` StorageLocation which is hard-coded to mean an HDFS cluster within the Kubernetes namespace, and it has a lot of hard-coded assumptions to how to communicate with this HDFS cluster. There is also an `s3` StorageLocation which allows connecting Presto to an S3 bucket. In both cases, the data is persisted as RCBinary files in either S3 or HDFS via Presto.
+
+### ReportDataSource
+
+For user-docs containing a description of the fields, and examples, see [ReportDataSources][reportdatasources].
+
+A `ReportDataSource` instructs the metering operator to create a database table for either storing Prometheus metric data (in a specified StorageLocation), or a table pointing at an S3 bucket containing AWS Cost and Usage reports.
+
+#### Promsum ReportDataSources
+
+A `promsum` ReportDataSource configures the metering-operator to periodically poll Prometheus for metrics.
+
+When the ReportDataSource is created, the metering operator does the following:
+
+- Checks if this `ReportDataSource` has a table created for it yet, and if not, create the table.
+  - The underlying storage for this Presto table is controlled using the `StorageLocation` configuration in `spec.promsum.storage`, which controls what options to use when creating the Presto table, such what Presto connector is used.
+
+Additionally, in the background the metering-operator is periodically, listing all `ReportDataSources` and if the `promsum` section is specified, does the following:
+
+- Check if the table for this ReportDataSource exists, if it doesn't, it will skip the ReportDataSource, until the next poll for all `ReportDataSources` again.
+- Retrieve the query specified in the `ReportPrometheusQuery` named by the ReportDataSources `spec.promsum.query` field.
+- Execute the Prometheus query against the Prometheus server.
+- After receiving the metrics results, it then stores the data into a Presto table.
+  - Currently this is done using an `INSERT` query using Presto, but this is subject to change as other `StorageLocations` are added.
+
+Currently all promsum ReportDataSources are collected at the same time in parallel.
+Metric resolution, and poll interval is controlled at a global level on the metering operator via the `Metering` resource's `spec.metering-operator.config` section.
+
+#### AWSBilling ReportDataSources
+
+An `awsBilling` ReportDataSource configures the metering-operator to periodically scan the specified AWS S3 bucket for [AWS Cost and Usage reports][AWS-billing].
+
+When the ReportDataSource is created, the metering operator does the following:
+
+- Checks if this `ReportDataSource` has a table created for it yet, and if not, create the table.
+  - In the case of an `awsBilling` ReportDataSource, the operator creates the table using Hive. When creating the table, it is configured to point at the S3 Bucket configured in the `spec.awsBilling` section and to read gzipped CSV files (`.csv.gz`, the file format the cost and usage reports are in).
+
+Additionally, in the background the metering-operator is periodically, listing all `ReportDataSources` and if the `awsBilling` section is specified, does the following:
+
+- Check if the table for this ReportDataSource exists, if it doesn't, it will skip the ReportDataSource, until the next poll for all `ReportDataSources` again.
+- Scan the configured S3 bucket for the cost usage report JSON manifests. There is a manifest for each billing period, and each manifest contains information about what reports are the most up-to-date for a given billing period.
+- For each manifest, the operator determines which S3 directory contains the most up to date report files for the billing period, and then creates a partition in the table, pointing at the directory containing the cost & usage reports. If the partition already exists for the specified billing period, the operator will remove it and replace it with the more up to date S3 directory.
+
+This results in a table that has multiple partitions in it, one partition per AWS billing period, and each partition points to an S3 directory containing the most up to date billing information for that billing period.
+
+By default, Operator Metering has an section in the `Metering` resource for configuring an awsBilling `ReportDataSource`, so you generally shouldn't need to create one directly.
+For more details on configuring this read the [AWS billing correlation section in the Metering Configuration doc][metering-aws-billing-conf].
+
+### ReportPrometheusQuery
+
+For user-docs containing a description of the fields, and examples, see [ReportPrometheusQueries][reportprometheusqueries].
+
+A `ReportPrometheusQuery` is basically just a Prometheus query. All `ReportPrometheusQueries` in the namespace of the operator are available for use in a `ReportDataSource`.
+
+### ReportGenerationQuery
+
+For user-docs containing a description of the fields, and examples, see [ReportGenerationQueries][reportgenerationqueries].
+
+When the metering operator sees a new `ReportGenerationQuery` in it's namespace, it will check if the `spec.view.disabled` field is true, if it is, it doesn't do anything with these queries on creation.
+If it's false, then it will create a database view.
+
+### Report and ScheduledReport
+
+For user-docs containing a description of the fields, and examples, see [Reports and ScheduledReports][reports].
+
+When a `Report` or `ScheduledReport` is created, and it sees the creation event, it does the following to generate the results:
+
+- Retrieve the `ReportGenerationQuery` for the Report/ScheduledReport.
+- For each `ReportGenerationQuery` from the `spec.reportQueries` and `spec.dynamicReportQueries` fields, retrieve them, and then do the same for each of those queries until we have all the required `ReportGenerationQueries`
+- Validate the `ReportDataSources` that each query depends on has it's table created.
+- Update the Report/ScheduledReport status to indicate we're beginning to generate the report.
+- Evaluate the `ReportGenerationQuery` template, passing the StartPeriod & EndPeriod into the template context.
+- Create a database table using Hive named after the Report/ScheduledReport. This table is either configured to use HDFS or S3 based on the Report/ScheduledReport's StorageLocation.
+- Execute the query using Presto.
+- Update the Report/ScheduledReports status that everything succeeded.
+
+[presto-overview]: https://prestodb.io/docs/current/overview/use-cases.html
+[hive-overview]: https://cwiki.apache.org/confluence/display/Hive/Home#Home-ApacheHive
+[presto-connector]: https://prestodb.io/docs/current/overview/concepts.html#connector
+[AWS-billing]: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-reports-costusage.html
+[metering-aws-billing-conf]: metering-config.md#aws-billing-correlation
+[storagelocations]: storagelocations.md
+[reportdatasources]: reportdatasources.md
+[reportprometheusqueries]: reportprometheusqueries.md
+[reportgenerationqueries]: reportgenerationqueries.md
+[reports]: report.md

--- a/Documentation/reportdatasources.md
+++ b/Documentation/reportdatasources.md
@@ -1,0 +1,60 @@
+# Report Data Sources
+
+A `ReportDataSource` is a custom resource that represents how to store data, such as where it should be stored, and in some cases, how the data is to be collected.
+
+There are currently two types of ReportDataSource's, `promsum`, and `awsBilling`.
+Each has a corresponding configuration section within the `spec` of a `ReportDataSource`.
+The main effect that creating a ReportDataSource has is that it causes the metering operator to create a table in Presto. Depending on the type of ReportDataSource it then may do other additional tasks. For `promsum` data sources the operator periodically collects metrics and stores them in the table.
+For `awsBilling`, the operator configures the table to point at an S3 bucket containing [AWS Cost and Usage reports][AWS-billing], making these reports exposed as a database table.
+To read more details on how the different ReportDataSources work, read the [metering architecture document][architecture].
+
+## Fields
+
+- `promsum`: If this section is present, then the `ReportDataSource` will be configured to periodically poll Prometheus for metrics using the specified `ReportPrometheusQuery`.
+ - `query`: The name of the `ReportPrometheusQuery` resource.
+ - `storage`: This section controls the `StorageLocation` options, allowing you to control on a per ReportDataSource level, where data is stored.
+   - `storageLocationName`: The name of the `StorageLocation` resource to use.
+   - `spec`: If `storageLocationName` is not set, then this section is used to control the storage location settings. See the [StorageLocation documentation][storage-locations] for details on what can be specified here. Anything valid in a `StorageLocation`'s `spec` is valid here.
+- `awsBilling`:
+  - `source`:
+    - `bucket`: Bucket name to store data into.
+    - `prefix`: Path within the bucket where to store data.
+
+## Example ReportDataSource
+
+Below is an example of one of the built-in `ReportDataSource` resources that is installed with Operator Metering by default.
+This example doesn't specify a `spec.storage` section, which will result in it using the [default StorageLocation resource][default-storage-location].
+
+```
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportDataSource
+metadata:
+  name: "pod-request-memory-bytes"
+  labels:
+    operator-metering: "true"
+spec:
+  promsum:
+    query: "pod-request-memory-bytes"
+```
+
+This example is a slightly modified version of the one above that does set the `storage` to the `StorageLocation` with a `metadata.name` of "local".
+
+```
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportDataSource
+metadata:
+  name: "pod-request-memory-bytes-custom-storage-location"
+  labels:
+    operator-metering: "true"
+spec:
+  promsum:
+    query: "pod-request-memory-bytes"
+    storage:
+      storageLocationName: local
+```
+
+[storage-locations]: storagelocations.md
+[AWS-billing]: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-reports-costusage.html
+[metering-aws-billing-conf]: metering-config.md#aws-billing-correlation
+[default-storage-location]: storagelocations.md#default-storagelocation
+[architecture]: metering-architecture.md

--- a/Documentation/reportgenerationqueries.md
+++ b/Documentation/reportgenerationqueries.md
@@ -1,0 +1,151 @@
+# Report Generation Queries
+
+Customizing how Operator Metering generates reports is done using a custom resource called a `ReportGenerationQuery`.
+
+These `ReportGenerationQuery` resources control the SQL queries that can be used to produce a report.
+When writing a [report](report.md) you can specify the query it will use by setting the `spec.generationQuery` field to `metadata.name` of any `ReportGenerationQuery` in the metering-operator's namespace.
+
+## Fields
+
+- `query`: A [SQL SELECT statement][presto-select]. This SQL statement supports [go templates][go-templates] and provides additional custom functions specific to Operator Metering (defined in the [templating](#templating) section below).
+- `columns`: A list of columns that match the schema of the results of the query. The order of these columns must match the order of the columns returned by the SELECT statement. Columns have 3 fields, `name`, `type`, and `unit`. Each field is covered in more detail below.
+  - `name`: This is the name of the column returned in the `SELECT` statement.
+  - `type`: This is the [Hive][hive-types] column type. Currently due to implementation details, column types are expressed using hive types. In the future, this will likely be switched to using the Presto native types. This also has an effect that queries with columns containing complex types such as `maps` or `arrays` cannot be used by `Reports` or `ScheduledReports`.
+  - `unit`:
+- `reportDataSources`: This is a list of `ReportDataSource` resources that this this `ReportGenerationQuery` depends on. These data sources can be referenced as database tables in the `query` using the `dataSourceTableName` template function.
+- `reportQueries`: This is a list of other `ReportGenerationQuery` resources that this `ReportGenerationQuery` depends on that have `view.disabled` set to false. Queries in this list can be re-used by querying the database view created, and using `generationQueryViewName` templating function to reference the view by name.
+- `dynamicReportQueries`: This is a list of other `ReportGenerationQuery` resources that this `ReportGenerationQuery` depends on, that have `view.disabled` set to true, these are queries that depend on the `.Report` variable. Queries in the list can be re-used by injecting them into the current query using the `renderReportGenerationQuery` template function.
+- `view`: This section controls options related to creating a view from the `query` when the `ReportGenerationQuery` resource is created.
+    - `view.disabled`: This is false by default, and if set to true, it will prevent the default behavior of creating a database view using the contents of the `query`. This cannot be true if `dynamicReportQueries` is non-empty or if the `query` depends on the `.Report` templating variables.
+
+## Templating
+
+Because much of the type of analysis being done depends on user-input, and because we want to enable users to re-use queries with copying & pasting things around, Operator Metering supports the [go templating language][go-templates] to dynamically generate the SQL statements contained within the `spec.query` field of `ReportGenerationQuery`.
+For example, when generating a report, the query needs to know what time range to consider when producing a report, so this is information is exposed within the template context as variables you can use and refeference with various [template functions](#template-functions).
+Most of these functions are for referring to other resources such as `ReportDataSources` or `ReportGenerationQueries` as either tables, views, or sub-queries, and for formatting various types for use within the SQL query.
+
+### Template variables
+
+- `Report`: This object has two fields, `StartPeriod` and `EndPeriod` which are the value of the `spec.reportingStart` and `spec.reportingEnd` for a `Report`. For a `ScheduledReport` the values map to the specific period being collected when the `ScheduledReport` runs.
+  - `StartPeriod`: A [time.Time][go-time] object that is generally used to filter the results of a `SELECT` query using a `WHERE` clause.
+  - `EndPeriod`: A [time.Time][go-time] object that is generally used to filter the results of a `SELECT` query using a `WHERE` clause.
+- `DynamicDependentQueries`: This is a list of `ReportGenerationQuery` objects that were listed in the `spec.dynamicReportQueries` field. Generally this list isn't directly referenced in query, but is used indirectly with the `renderReportGenerationQuery` [template function](#template-functions).
+
+### Template functions
+
+Below is a list of the available template functions and descriptions on what they do.
+
+- `dataSourceTableName`: Takes a one argument, a string representing a `ReportDataSource` name and outputs a string which is the corresponding table name of the `ReportDataSource` specified.
+- `generationQueryViewName`: Takes one argument, a string representing a `ReportGenerationQuery` name and outputs a string which is the corresponding view name of the `ReportGenerationQuery` specified.
+- `renderReportGenerationQuery`: Takes two arguments, a string representing a `ReportGenerationQuery` name, the template context (usually this is just `.` in the template), and returns a string containing the specified `ReportGenerationQuery` in it's rendered form, using the 2nd argument as the context for the template rendering.
+- `prestoTimestamp`: Takes a [time.Time][go-time] object as the argument, and outputs a string timestamp. Usually this is used on `.Report.StartPeriod` and `.Report.EndPeriod`.
+- `billingPeriodFormat`: Takes a [time.Time][go-time] object as the argument, and outputs a string timestamp that can be used for comparing to `awsBilling` an ReportDataSource's `partition_start` and `partition_stop` columns.
+
+## Example ReportGenerationQueries
+
+Before going into examples, there's an important convention that all the built-in `ReportGenerationQueries` follow that is worth calling out, as these examples will demonstrate them heavily.
+
+The convention I am referring to is the fact that there are quite a few ReportGenerationQueries suffixed with `-raw` in their `metadata.name`.
+These queries are not intended to be used by Reports, or ScheduledReports, but are intended to be purely for re-use.
+Currently, these queries suffixed with `-raw` in their name are generally only ever used as database views that are referenced in other queries.
+Additionally, due to implementation reasons, the `types` within the `columns` are using [Hive column types][hive-types] instead of the Presto column types.
+This has a negative effect the results in being unable to use `ReportGenerationQueries` containing with complex types (array, maps) with `Reports` and `ScheduledReports`, which is why the `ReportGenerationQueries` that are _not_ suffixed in `-raw` never expose those types in their output.
+
+
+The example below is a built-in `ReportGenerationQuery` that is installed with Operator Metering by default.
+The query is not intended to be used by Reports, but instead is intended to be re-used by other `ReportGenerationQueries`, which is why it only does simple extraction of fields, and calculations.
+
+The important things to note with this query is that it's querying a database table containing Prometheus metric data for the `pod-request-memory-bytes` `ReportDataSource`, and it's getting the table name using the `dataSourceTableName` template function.
+
+```yaml
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "pod-memory-request-raw"
+spec:
+  reportDataSources:
+  - "pod-request-memory-bytes"
+  columns:
+  - name: pod
+    type: string
+    unit: kubernetes_pod
+  - name: namespace
+    type: string
+    unit: kubernetes_namespace
+  - name: node
+    type: string
+    unit: kubernetes_node
+  - name: labels
+    type: map(varchar, varchar)
+    tableHidden: true
+  - name: pod_request_memory_bytes
+    type: double
+    unit: bytes
+  - name: timeprecision
+    type: double
+    unit: seconds
+  - name: pod_request_memory_byte_seconds
+    type: double
+    unit: byte_seconds
+  - name: timestamp
+    type: timestamp
+    unit: date
+  query: |
+      SELECT labels['pod'] as pod,
+          labels['namespace'] as namespace,
+          element_at(labels, 'node') as node,
+          labels,
+          amount as pod_request_memory_bytes,
+          timeprecision,
+          amount * timeprecision as pod_request_memory_byte_seconds,
+          "timestamp"
+      FROM {| dataSourceTableName "pod-request-memory-bytes" |}
+      WHERE element_at(labels, 'node') IS NOT NULL
+```
+
+This next example is also one of the built-in `ReportGenerationQueries`.
+This example, unlike the previous is designed to be used with Reports and ScheduledReports.
+It summarizes the information exposed in the example above by Kubernetes namespace, and reduces the output fields down to the ones that matter for this specific use-case.
+
+The important things to note with this example is that it's depending on the previous `ReportGenerationQuery` and referencing the database view by using the `generationQueryViewName` template function.
+
+```yaml
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "namespace-memory-request"
+spec:
+  reportQueries:
+  - "pod-memory-request-raw"
+  view:
+    disabled: true
+  columns:
+  - name: namespace
+    type: string
+    unit: kubernetes_namespace
+  - name: data_start
+    type: timestamp
+    unit: date
+  - name: data_end
+    type: timestamp
+    unit: date
+  - name: pod_request_memory_byte_seconds
+    type: double
+    unit: byte_seconds
+  query: |
+    SELECT namespace,
+            min("timestamp") as data_start,
+            max("timestamp") as data_end,
+            sum(pod_request_memory_byte_seconds) as pod_request_memory_byte_seconds
+    FROM {| generationQueryViewName "pod-memory-request-raw" |}
+    WHERE "timestamp" >= timestamp '{|.Report.StartPeriod | prestoTimestamp |}'
+    AND "timestamp" <= timestamp '{| .Report.EndPeriod | prestoTimestamp |}'
+    GROUP BY namespace
+    ORDER BY pod_request_memory_byte_seconds DESC
+```
+
+[presto-select]: https://prestodb.io/docs/current/sql/select.html
+[hive-types]: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types#LanguageManualTypes-Overview
+[presto-functions]: https://prestodb.io/docs/current/functions.html
+[go-templates]: https://golang.org/pkg/text/template/
+[go-time]: https://golang.org/pkg/time/#Time

--- a/Documentation/reportprometheusqueries.md
+++ b/Documentation/reportprometheusqueries.md
@@ -1,0 +1,35 @@
+# Report Prometheus Queries
+
+A lot of the flexibility in Operator Metering is in the ability to customize what data is collected by writing Custom Prometheus Queries in a custom resource called a `ReportPrometheusQuery`.
+
+These `ReportPrometheusQuery` resources allow you to control what Prometheus queries the operator executes periodically, and makes the data collected by the query available as another database table that can be reported on by [ReportGenerationQueries](reportgenerationqueries.md).
+
+## Fields
+
+All fields that can be controlled on an individual `ReportPrometheusQuery` level are contained in the `spec` section of the resource.
+
+- `query`: A string containing the Prometheus Query to be executed by the operator. For details on writing Prometheus queries read the official [Querying Prometheus documentation][querying-prometheus].
+
+## Example ReportPrometheusQuery
+
+The example resource below is installed by default when installing Operator Metering.
+
+```yaml
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: ReportPrometheusQuery
+metadata:
+  name: "pod-request-memory-bytes"
+  labels:
+    operator-metering: "true"
+spec:
+  query: |
+    sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
+```
+
+The important part is the `spec.query` field which is the actual Prometheus query executed by the operator:
+
+```
+sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
+```
+
+[querying-prometheus]: https://prometheus.io/docs/prometheus/latest/querying/basics/

--- a/Documentation/storagelocations.md
+++ b/Documentation/storagelocations.md
@@ -1,0 +1,64 @@
+# Storage Locations
+
+A `StorageLocation` is a custom resource that configures where data will be stored.
+This includes the data collected from Prometheus, and the results produced by generating a `Report` or `ScheduledReport`.
+
+The Operator Metering default installation provides a few ways of configuring the [Default StorageLocation](#default-storagelocation), and normally it shouldn't be necessary to create these directly.
+Refer to the [Metering Configuration doc](metering-config.md#storing-data-in-s3) for details on using the `Metering` resource to set your default StorageLocation.
+
+## Fields
+
+- `s3`: If this section is present, then the `StorageLocation` will be configured to store data into an AWS S3 bucket.
+  - `bucket`: The name of the S3 bucket to store the data in.
+  - `prefix`: The path within the bucket to store the data in.
+- `local`: If this section is present, then the `StorageLocation` will be configured to store data based on what the operator defines as "local". Currently local storage is defined to be HDFS, and redefining what "local" maps to is not exposed as a configuration option, but is planned in the future. See the examples below for how to specify it.
+
+## Example StorageLocation
+
+This first example is what the built-in local storage option looks like.
+As you can see, it takes no options, so you must specify it using an empty object `{}`.
+
+```yaml
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: StorageLocation
+metadata:
+  name: local
+  labels:
+    operator-metering: "true"
+  spec:
+    local: {}
+```
+
+The example below uses an AWS S3 bucket for storage.
+The prefix is appended to the bucket name when constructing the path to use.
+
+```yaml
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: StorageLocation
+metadata:
+  name: example-s3-storage
+  labels:
+    operator-metering: "true"
+  spec:
+    s3:
+      bucket: bucket-name
+      prefix: path/within/bucket/
+```
+
+## Default StorageLocation
+
+If an annotation `storagelocation.chargeback.coreos.com/is-default` exists and is set to the string "true" on a `StorageLocation` resource, then that resource will be used if a `StorageLocation` is not specified on resources which have a `storage` configuration option.
+If more than one resource with the annotation exists, an error will be logged and the operator will consider there to be no default.
+
+```yaml
+apiVersion: chargeback.coreos.com/v1alpha1
+kind: StorageLocation
+metadata:
+  name: local
+  labels:
+    operator-metering: "true"
+  annotations:
+    storagelocation.chargeback.coreos.com/is-default: "true"
+  spec:
+    local: {}
+```


### PR DESCRIPTION
This adds a document for each custom resource the metering operator interacts with, and also another document dedicated to the metering architecture.
The architecture document contains information on what each resource maps to within the Database, and how these resources interact with each other.