### PR TITLE
charts/metering-operator: Fix CPU/memory usage prom query

### DIFF
--- a/charts/metering-operator/templates/custom-resources/prom-queries/pod-cpu-usage.yaml
+++ b/charts/metering-operator/templates/custom-resources/prom-queries/pod-cpu-usage.yaml
@@ -36,4 +36,4 @@ metadata:
 {{- end }}
 spec:
   query: |
-    label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") * on (pod, namespace) group_left(node) kube_pod_info{pod_ip!="",node!="",host_ip!=""}
+    label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)

--- a/charts/metering-operator/templates/custom-resources/prom-queries/pod-memory-usage.yaml
+++ b/charts/metering-operator/templates/custom-resources/prom-queries/pod-memory-usage.yaml
@@ -36,4 +36,4 @@ metadata:
 {{- end }}
 spec:
   query: |
-    sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) * on (pod, namespace) group_left(node) kube_pod_info{pod_ip!="",node!="",host_ip!=""}
+    sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)


### PR DESCRIPTION
Was getting a many to many matching when multiple instances of
kube-state-metrics were running, resulting in the `instance` label
varying, causing there two be multiple metrics for the same aggregation
query.