### PR TITLE
*: Set imagePullSecret for pods in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,6 +128,7 @@ podTemplate(
                     "DEPLOY_TAG=${deployTag}",
                     "BRANCH_TAG_CACHE=${isMasterBranch}",
                     "DOCKER_BUILD_ARGS=${dockerBuildArgs}",
+                    "METERING_CREATE_PULL_SECRET=true",
                     "METERING_E2E_NAMESPACE=${meteringE2ENamespace}",
                     "METERING_INTEGRATION_NAMESPACE=${meteringIntegrationNamespace}",
                     "METERING_SHORT_TESTS=${shortTests}",
@@ -430,7 +431,7 @@ def e2eRunner(meteringSourceDir, envVars, skipNamespaceCleanup) {
                             tail -f ${TEST_OUTPUT_DIR}/${TEST_LOG_FILE} &
                             docker run \
                             -i --rm \
-                            --env-file <(env | grep -E 'INSTALL_METHOD|TEST|LOG|DEPLOY|KUBECONFIG|AWS|CHARGEBACK|METERING|PULL_SECRET') \
+                            --env-file <(env | grep -E 'INSTALL_METHOD|DOCKER|TEST|LOG|DEPLOY|KUBECONFIG|AWS|CHARGEBACK|METERING|PULL_SECRET') \
                             -v "${JENKINS_WORKSPACE}:${JENKINS_WORKSPACE}" \
                             -v "${KUBECONFIG}:${KUBECONFIG}" \
                             -v "${TEST_OUTPUT_DIR}:/out" \

--- a/charts/hdfs/templates/datanode-statefulset.yaml
+++ b/charts/hdfs/templates/datanode-statefulset.yaml
@@ -158,6 +158,10 @@ spec:
         resources:
 {{ toYaml .Values.datanode.resources | indent 10 }}
       serviceAccount: hdfs
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: "hdfs-datanode-data"

--- a/charts/hdfs/templates/namenode-statefulset.yaml
+++ b/charts/hdfs/templates/namenode-statefulset.yaml
@@ -139,6 +139,10 @@ spec:
         resources:
 {{ toYaml .Values.namenode.resources | indent 10 }}
       serviceAccount: hdfs
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: "hdfs-namenode-data"

--- a/charts/metering-operator/templates/metering-deployment.yaml
+++ b/charts/metering-operator/templates/metering-deployment.yaml
@@ -114,3 +114,7 @@ spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       serviceAccount: metering
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}

--- a/charts/presto/templates/presto-coordinator-deployment.yaml
+++ b/charts/presto/templates/presto-coordinator-deployment.yaml
@@ -142,4 +142,8 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccount: presto
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.presto.coordinator.terminationGracePeriodSeconds }}

--- a/charts/presto/templates/presto-worker-deployment.yaml
+++ b/charts/presto/templates/presto-worker-deployment.yaml
@@ -138,4 +138,8 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccount: presto
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.presto.worker.terminationGracePeriodSeconds }}

--- a/hack/deploy-ci.sh
+++ b/hack/deploy-ci.sh
@@ -13,6 +13,7 @@ export CUSTOM_HELM_OPERATOR_OVERRIDE_VALUES=${CUSTOM_HELM_OPERATOR_OVERRIDE_VALU
 export CUSTOM_ALM_OVERRIDE_VALUES=${CUSTOM_ALM_OVERRIDE_VALUES:-"$TMP_DIR/custom-alm-values-${DEPLOY_TAG}.yaml"}
 export DELETE_PVCS=${DELETE_PVCS:-true}
 
+
 ROOT_DIR=$(dirname "${BASH_SOURCE}")/..
 source "${ROOT_DIR}/hack/common.sh"
 
@@ -21,6 +22,14 @@ source "${ROOT_DIR}/hack/common.sh"
 : "${AWS_SECRET_ACCESS_KEY:=}"
 : "${AWS_BILLING_BUCKET:=}"
 : "${AWS_BILLING_BUCKET_PREFIX:=}"
+: "${METERING_CREATE_PULL_SECRET:=false}"
+
+METERING_PULL_SECRET_NAME=""
+if [ "$METERING_CREATE_PULL_SECRET" == "true" ]; then
+    : "${DOCKER_USERNAME:?}"
+    : "${DOCKER_PASSWORD:?}"
+    METERING_PULL_SECRET_NAME="metering-pull-secret"
+fi
 
 cat <<EOF > "$METERING_CR_FILE"
 apiVersion: chargeback.coreos.com/v1alpha1
@@ -63,6 +72,28 @@ spec:
       terminationGracePeriodSeconds: 0
 EOF
 
+
+
+if [ "$METERING_CREATE_PULL_SECRET" == "true" ]; then
+
+    cat <<EOF >> "$METERING_CR_FILE"
+  metering-operator:
+    imagePullSecrets: [ { name: "$METERING_PULL_SECRET_NAME" } ]
+
+  presto:
+    presto:
+      imagePullSecrets: [ { name: "$METERING_PULL_SECRET_NAME" } ]
+    hive:
+      imagePullSecrets: [ { name: "$METERING_PULL_SECRET_NAME" } ]
+  hdfs:
+    datanode:
+      imagePullSecrets: [ { name: "$METERING_PULL_SECRET_NAME" } ]
+    namenode:
+      imagePullSecrets: [ { name: "$METERING_PULL_SECRET_NAME" } ]
+EOF
+
+fi
+
 cat <<EOF > "$CUSTOM_HELM_OPERATOR_OVERRIDE_VALUES"
 image:
   tag: ${DEPLOY_TAG}
@@ -84,7 +115,19 @@ echo "Creating metering manifests"
 export MANIFEST_OUTPUT_DIR="$CUSTOM_DEPLOY_MANIFESTS_DIR"
 "$ROOT_DIR/hack/create-metering-manifests.sh"
 
-echo "Deploying"
 
+if [ "$METERING_CREATE_PULL_SECRET" == "true" ]; then
+    # We need to create the namespace in this situation because it isn't created normally until deploy is run
+    kubectl create ns "$METERING_NAMESPACE" || true
+    echo "\$METERING_CREATE_PULL_SECRET is true, creating pull-secret $METERING_PULL_SECRET_NAME"
+    kubectl -n "$METERING_NAMESPACE" \
+        create secret docker-registry "$METERING_PULL_SECRET_NAME" \
+        --docker-server=quay.io \
+        --docker-username="$DOCKER_USERNAME" \
+        --docker-password="$DOCKER_PASSWORD" \
+        --docker-email=example@example.com
+fi
+
+echo "Deploying"
 export DEPLOY_MANIFESTS_DIR="$CUSTOM_DEPLOY_MANIFESTS_DIR"
 "${ROOT_DIR}/hack/deploy.sh"


### PR DESCRIPTION
This should help with our imagePull errors in integration/e2e deployments, which might be caused due to concurrent anonymous image pulls