### PR TITLE
pkg/chargeback: Refactor http.go to rely on *Chargeback less

### DIFF
--- a/pkg/chargeback/datasources.go
+++ b/pkg/chargeback/datasources.go
@@ -40,7 +40,7 @@ func (c *Chargeback) processReportDataSource(logger log.FieldLogger) bool {
 	}
 	defer c.queues.reportDataSourceQueue.Done(obj)
 
-	logger = logger.WithFields(c.newLogIdentifier())
+	logger = logger.WithFields(newLogIdentifier(c.rand))
 	if key, ok := c.getKeyFromQueueObj(logger, "ReportDataSource", obj, c.queues.reportDataSourceQueue); ok {
 		err := c.syncReportDataSource(logger, key)
 		c.handleErr(logger, err, "ReportDataSource", key, c.queues.reportDataSourceQueue)

--- a/pkg/chargeback/http.go
+++ b/pkg/chargeback/http.go
@@ -7,14 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/http"
-	"net/http/pprof"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
-
-	"golang.org/x/sync/singleflight"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -24,22 +21,28 @@ import (
 	api "github.com/operator-framework/operator-metering/pkg/apis/chargeback/v1alpha1"
 	cbutil "github.com/operator-framework/operator-metering/pkg/apis/chargeback/v1alpha1/util"
 	"github.com/operator-framework/operator-metering/pkg/chargeback/prestostore"
+	"github.com/operator-framework/operator-metering/pkg/db"
+	listers "github.com/operator-framework/operator-metering/pkg/generated/listers/chargeback/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/presto"
 	"github.com/operator-framework/operator-metering/pkg/util/orderedmap"
 )
 
 var ErrReportIsRunning = errors.New("the report is still running")
 
+type meteringListers struct {
+	reports                 listers.ReportNamespaceLister
+	scheduledReports        listers.ScheduledReportNamespaceLister
+	reportGenerationQueries listers.ReportGenerationQueryNamespaceLister
+	prestoTables            listers.PrestoTableNamespaceLister
+}
+
 type server struct {
-	chargeback *Chargeback
-	logger     log.FieldLogger
+	logger log.FieldLogger
 
-	// wg is used to wait on httpServer and pprofServer stopping
-	wg          sync.WaitGroup
-	httpServer  *http.Server
-	pprofServer *http.Server
-
-	healthCheckSingleFlight singleflight.Group
+	rand          *rand.Rand
+	queryer       db.Queryer
+	collectorFunc prometheusImporterFunc
+	listers       meteringListers
 }
 
 type requestLogger struct {
@@ -50,28 +53,19 @@ func (l *requestLogger) Print(v ...interface{}) {
 	l.FieldLogger.Info(v...)
 }
 
-func newServer(c *Chargeback, logger log.FieldLogger) *server {
+func newRouter(logger log.FieldLogger, queryer db.Queryer, rand *rand.Rand, collectorFunc prometheusImporterFunc, listers meteringListers) chi.Router {
 	router := chi.NewRouter()
-	pprofMux := http.NewServeMux()
 
 	logger = logger.WithField("component", "api")
 	requestLogger := middleware.RequestLogger(&middleware.DefaultLogFormatter{Logger: &requestLogger{logger}})
 	router.Use(requestLogger)
 
-	httpServer := &http.Server{
-		Addr:    ":8080",
-		Handler: router,
-	}
-	pprofServer := &http.Server{
-		Addr:    "127.0.0.1:6060",
-		Handler: pprofMux,
-	}
-
 	srv := &server{
-		chargeback:  c,
-		logger:      logger,
-		httpServer:  httpServer,
-		pprofServer: pprofServer,
+		logger:        logger,
+		rand:          rand,
+		queryer:       queryer,
+		collectorFunc: collectorFunc,
+		listers:       listers,
 	}
 
 	router.HandleFunc("/api/v1/reports/get", srv.getReportHandler)
@@ -82,109 +76,35 @@ func newServer(c *Chargeback, logger log.FieldLogger) *server {
 	router.HandleFunc("/api/v1/datasources/prometheus/collect", srv.collectPromsumDataHandler)
 	router.HandleFunc("/api/v1/datasources/prometheus/store/{datasourceName}", srv.storePromsumDataHandler)
 	router.HandleFunc("/api/v1/datasources/prometheus/fetch/{datasourceName}", srv.fetchPromsumDataHandler)
-	router.HandleFunc("/ready", srv.readinessHandler)
-	router.HandleFunc("/healthy", srv.healthinessHandler)
 
-	pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
-	pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	return srv
-}
-
-func (srv *server) start() {
-	srv.wg.Add(2)
-	go func() {
-		srv.logger.Infof("HTTP API server started")
-		srv.logger.WithError(srv.httpServer.ListenAndServe()).Info("HTTP API server exited")
-		srv.wg.Done()
-	}()
-	go func() {
-		srv.logger.Infof("pprof server started")
-		srv.logger.WithError(srv.pprofServer.ListenAndServe()).Info("pprof server exited")
-		srv.wg.Done()
-	}()
-}
-
-func (srv *server) stop() {
-	srv.wg.Add(2)
-	go func() {
-		srv.logger.Infof("stopping HTTP API server")
-		err := srv.httpServer.Shutdown(context.TODO())
-		if err != nil {
-			srv.logger.WithError(err).Warnf("got an error shutting down HTTP API server")
-		}
-		srv.wg.Done()
-	}()
-	go func() {
-		srv.logger.Infof("stopping pprof server")
-		err := srv.pprofServer.Shutdown(context.TODO())
-		if err != nil {
-			srv.logger.WithError(err).Warnf("got an error shutting down pprof server")
-		}
-		srv.wg.Done()
-	}()
-	srv.wg.Wait()
-}
-
-func (srv *server) newLogger(r *http.Request) log.FieldLogger {
-	return srv.logger.WithFields(log.Fields{
-		"method": r.Method,
-		"url":    r.URL.String(),
-	}).WithFields(srv.chargeback.newLogIdentifier())
-}
-
-type errorResponse struct {
-	Error string `json:"error"`
-}
-
-func (srv *server) writeErrorResponse(logger log.FieldLogger, w http.ResponseWriter, r *http.Request, status int, message string, args ...interface{}) {
-	msg := fmt.Sprintf(message, args...)
-	srv.writeResponseWithBody(logger, w, status, errorResponse{Error: msg})
-}
-
-// writeResponseWithBody attempts to marshal an arbitrary thing to JSON then write
-// it to the http.ResponseWriter
-func (srv *server) writeResponseWithBody(logger log.FieldLogger, w http.ResponseWriter, code int, resp interface{}) {
-	enc, err := json.Marshal(resp)
-	if err != nil {
-		logger.WithError(err).Error("failed JSON-encoding HTTP response")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	if _, err = w.Write(enc); err != nil {
-		logger.WithError(err).Error("failed writing HTTP response")
-	}
+	return router
 }
 
 func (srv *server) validateGetReportReq(logger log.FieldLogger, requiredQueryParams []string, w http.ResponseWriter, r *http.Request) bool {
 	if r.Method != "GET" {
-		srv.writeErrorResponse(logger, w, r, http.StatusNotFound, "Not found")
+		writeErrorResponse(logger, w, r, http.StatusNotFound, "Not found")
 		return false
 	}
 	err := r.ParseForm()
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusBadRequest, "couldn't parse URL query params: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusBadRequest, "couldn't parse URL query params: %v", err)
 		return false
 	}
 	err = checkForFields(requiredQueryParams, r.Form)
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusBadRequest, "%v", err)
+		writeErrorResponse(logger, w, r, http.StatusBadRequest, "%v", err)
 		return false
 	}
 	format := r.Form["format"][0]
 	if format == "json" || format == "csv" {
 		return true
 	}
-	srv.writeErrorResponse(logger, w, r, http.StatusBadRequest, "format must be one of: csv, json")
+	writeErrorResponse(logger, w, r, http.StatusBadRequest, "format must be one of: csv, json")
 	return false
 }
 
 func (srv *server) getReportHandler(w http.ResponseWriter, r *http.Request) {
-	logger := srv.newLogger(r)
+	logger := newRequestLogger(srv.logger, r, srv.rand)
 	if !srv.validateGetReportReq(logger, []string{"name", "format"}, w, r) {
 		return
 	}
@@ -192,7 +112,7 @@ func (srv *server) getReportHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (srv *server) getReportV2FullHandler(w http.ResponseWriter, r *http.Request) {
-	logger := srv.newLogger(r)
+	logger := newRequestLogger(srv.logger, r, srv.rand)
 	name := chi.URLParam(r, "name")
 	if !srv.validateGetReportReq(logger, []string{"format"}, w, r) {
 		return
@@ -201,7 +121,7 @@ func (srv *server) getReportV2FullHandler(w http.ResponseWriter, r *http.Request
 }
 
 func (srv *server) getReportV2TableHandler(w http.ResponseWriter, r *http.Request) {
-	logger := srv.newLogger(r)
+	logger := newRequestLogger(srv.logger, r, srv.rand)
 	name := chi.URLParam(r, "name")
 	if !srv.validateGetReportReq(logger, []string{"format"}, w, r) {
 		return
@@ -210,7 +130,7 @@ func (srv *server) getReportV2TableHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (srv *server) getScheduledReportHandler(w http.ResponseWriter, r *http.Request) {
-	logger := srv.newLogger(r)
+	logger := newRequestLogger(srv.logger, r, srv.rand)
 	if !srv.validateGetReportReq(logger, []string{"name", "format"}, w, r) {
 		return
 	}
@@ -218,20 +138,20 @@ func (srv *server) getScheduledReportHandler(w http.ResponseWriter, r *http.Requ
 }
 
 func (srv *server) runReportHandler(w http.ResponseWriter, r *http.Request) {
-	logger := srv.newLogger(r)
+	logger := newRequestLogger(srv.logger, r, srv.rand)
 	if r.Method != "GET" {
-		srv.writeErrorResponse(logger, w, r, http.StatusNotFound, "Not found")
+		writeErrorResponse(logger, w, r, http.StatusNotFound, "Not found")
 		return
 	}
 	err := r.ParseForm()
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusBadRequest, "couldn't parse URL query params: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusBadRequest, "couldn't parse URL query params: %v", err)
 		return
 	}
 	vals := r.Form
 	err = checkForFields([]string{"query", "start", "end"}, vals)
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusBadRequest, "%v", err)
+		writeErrorResponse(logger, w, r, http.StatusBadRequest, "%v", err)
 		return
 	}
 	srv.runReport(logger, vals["query"][0], vals["start"][0], vals["end"][0], w)
@@ -252,48 +172,48 @@ func checkForFields(fields []string, vals url.Values) error {
 
 func (srv *server) getScheduledReport(logger log.FieldLogger, name, format string, w http.ResponseWriter, r *http.Request) {
 	// Get the scheduledReport to make sure it's isn't failed
-	report, err := srv.chargeback.informers.Chargeback().V1alpha1().ScheduledReports().Lister().ScheduledReports(srv.chargeback.cfg.Namespace).Get(name)
+	report, err := srv.listers.scheduledReports.Get(name)
 	if err != nil {
 		logger.WithError(err).Errorf("error getting scheduledReport: %v", err)
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting scheduledReport: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting scheduledReport: %v", err)
 		return
 	}
 
 	if r.FormValue("ignore_failed") != "true" {
 		if cond := cbutil.GetScheduledReportCondition(report.Status, api.ScheduledReportFailure); cond != nil && cond.Status == v1.ConditionTrue {
 			logger.Errorf("scheduledReport is is failed state, reason: %s, message: %s", cond.Reason, cond.Message)
-			srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "scheduledReport is is failed state, reason: %s, message: %s", cond.Reason, cond.Message)
+			writeErrorResponse(logger, w, r, http.StatusInternalServerError, "scheduledReport is is failed state, reason: %s, message: %s", cond.Reason, cond.Message)
 			return
 		}
 	}
 
-	reportQuery, err := srv.chargeback.informers.Chargeback().V1alpha1().ReportGenerationQueries().Lister().ReportGenerationQueries(srv.chargeback.cfg.Namespace).Get(report.Spec.GenerationQueryName)
+	reportQuery, err := srv.listers.reportGenerationQueries.Get(report.Spec.GenerationQueryName)
 	if err != nil {
 		logger.WithError(err).Errorf("error getting report: %v", err)
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting report: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting report: %v", err)
 		return
 	}
 
 	prestoColumns := generatePrestoColumns(reportQuery)
 	tableName := scheduledReportTableName(name)
-	results, err := presto.GetRows(srv.chargeback.prestoConn, tableName, prestoColumns)
+	results, err := presto.GetRows(srv.queryer, tableName, prestoColumns)
 	if err != nil {
 		logger.WithError(err).Errorf("failed to perform presto query")
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "failed to perform presto query (see chargeback logs for more details): %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "failed to perform presto query (see chargeback logs for more details): %v", err)
 		return
 	}
 
 	// Get the presto table to get actual columns in table
-	prestoTable, err := srv.chargeback.informers.Chargeback().V1alpha1().PrestoTables().Lister().PrestoTables(report.Namespace).Get(prestoTableResourceNameFromKind("scheduledreport", report.Name))
+	prestoTable, err := srv.listers.prestoTables.Get(prestoTableResourceNameFromKind("scheduledreport", report.Name))
 	if err != nil {
 		logger.WithError(err).Errorf("error getting presto table: %v", err)
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting presto table: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting presto table: %v", err)
 		return
 	}
 
 	if len(results) > 0 && len(prestoTable.State.Parameters.Columns) != len(results[0]) {
 		logger.Errorf("report results schema doesn't match expected schema, got %d columns, expected %d", len(results[0]), len(prestoTable.State.Parameters.Columns))
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "report results schema doesn't match expected schema")
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "report results schema doesn't match expected schema")
 		return
 	}
 
@@ -301,17 +221,17 @@ func (srv *server) getScheduledReport(logger log.FieldLogger, name, format strin
 }
 func (srv *server) getReport(logger log.FieldLogger, name, format string, useNewFormat bool, full bool, w http.ResponseWriter, r *http.Request) {
 	// Get the current report to make sure it's in a finished state
-	report, err := srv.chargeback.informers.Chargeback().V1alpha1().Reports().Lister().Reports(srv.chargeback.cfg.Namespace).Get(name)
+	report, err := srv.listers.reports.Get(name)
 	if err != nil {
 		logger.WithError(err).Errorf("error getting report: %v", err)
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting report: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting report: %v", err)
 		return
 	}
 	switch report.Status.Phase {
 	case api.ReportPhaseError:
 		err := fmt.Errorf(report.Status.Output)
 		logger.WithError(err).Errorf("the report encountered an error")
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "the report encountered an error: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "the report encountered an error: %v", err)
 		return
 	case api.ReportPhaseFinished:
 		// continue with returning the report if the report is finished
@@ -319,38 +239,38 @@ func (srv *server) getReport(logger log.FieldLogger, name, format string, useNew
 		fallthrough
 	default:
 		logger.Errorf(ErrReportIsRunning.Error())
-		srv.writeErrorResponse(logger, w, r, http.StatusAccepted, ErrReportIsRunning.Error())
+		writeErrorResponse(logger, w, r, http.StatusAccepted, ErrReportIsRunning.Error())
 		return
 	}
 
-	reportQuery, err := srv.chargeback.informers.Chargeback().V1alpha1().ReportGenerationQueries().Lister().ReportGenerationQueries(srv.chargeback.cfg.Namespace).Get(report.Spec.GenerationQueryName)
+	reportQuery, err := srv.listers.reportGenerationQueries.Get(report.Spec.GenerationQueryName)
 	if err != nil {
 		logger.WithError(err).Errorf("error getting report: %v", err)
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting report: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting report: %v", err)
 		return
 	}
 
 	prestoColumns := generatePrestoColumns(reportQuery)
 	tableName := reportTableName(name)
-	results, err := presto.GetRows(srv.chargeback.prestoConn, tableName, prestoColumns)
+	results, err := presto.GetRows(srv.queryer, tableName, prestoColumns)
 	if err != nil {
 		logger.WithError(err).Errorf("failed to perform presto query")
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "failed to perform presto query (see chargeback logs for more details): %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "failed to perform presto query (see chargeback logs for more details): %v", err)
 		return
 	}
 
 	// Get the presto table to get actual columns in table
-	prestoTable, err := srv.chargeback.informers.Chargeback().V1alpha1().PrestoTables().Lister().PrestoTables(report.Namespace).Get(prestoTableResourceNameFromKind("report", report.Name))
+	prestoTable, err := srv.listers.prestoTables.Get(prestoTableResourceNameFromKind("report", report.Name))
 	if err != nil {
 		logger.WithError(err).Errorf("error getting presto table: %v", err)
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting presto table: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting presto table: %v", err)
 		return
 	}
 
 	columns := prestoTable.State.Parameters.Columns
 	if len(results) > 0 && len(columns) != len(results[0]) {
 		logger.Errorf("report results schema doesn't match expected schema, got %d columns, expected %d", len(results[0]), len(prestoTable.State.Parameters.Columns))
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "report results schema doesn't match expected schema")
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "report results schema doesn't match expected schema")
 		return
 	}
 
@@ -384,7 +304,7 @@ func (srv *server) writeResultsAsCSV(logger log.FieldLogger, columns []api.Repor
 			val, ok := row[key]
 			if !ok {
 				logger.Errorf("report results schema doesn't match expected schema, unexpected key: %q", key)
-				srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "report results schema doesn't match expected schema, unexpected key: %q", key)
+				writeErrorResponse(logger, w, r, http.StatusInternalServerError, "report results schema doesn't match expected schema, unexpected key: %q", key)
 				return
 			}
 			switch v := val.(type) {
@@ -404,7 +324,7 @@ func (srv *server) writeResultsAsCSV(logger log.FieldLogger, columns []api.Repor
 				vals[i] = ""
 			default:
 				logger.Errorf("error marshalling csv: unknown type %t for value %v", val, val)
-				srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error marshalling csv (see chargeback logs for more details)")
+				writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error marshalling csv (see chargeback logs for more details)")
 				return
 			}
 		}
@@ -428,11 +348,11 @@ func (srv *server) writeResults(logger log.FieldLogger, format string, columns [
 			var err error
 			newResults[i], err = orderedmap.NewFromMap(item)
 			if err != nil {
-				srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error converting results: %v", err)
+				writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error converting results: %v", err)
 				return
 			}
 		}
-		srv.writeResponseWithBody(logger, w, http.StatusOK, newResults)
+		writeResponseWithBody(logger, w, http.StatusOK, newResults)
 		return
 	case "csv":
 		srv.writeResultsAsCSV(logger, columns, results, w, r)
@@ -499,7 +419,7 @@ func (srv *server) writeResultsV2(logger log.FieldLogger, full bool, format stri
 
 	switch format {
 	case "json":
-		srv.writeResponseWithBody(logger, w, http.StatusOK, convertsToGetReportResults(results, filteredColumns))
+		writeResponseWithBody(logger, w, http.StatusOK, convertsToGetReportResults(results, filteredColumns))
 		return
 
 	case "csv":
@@ -518,13 +438,13 @@ type CollectPromsumDataRequest struct {
 }
 
 func (srv *server) collectPromsumDataHandler(w http.ResponseWriter, r *http.Request) {
-	logger := srv.newLogger(r)
+	logger := newRequestLogger(srv.logger, r, srv.rand)
 
 	decoder := json.NewDecoder(r.Body)
 	var req CollectPromsumDataRequest
 	err := decoder.Decode(&req)
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
 		return
 	}
 
@@ -533,19 +453,19 @@ func (srv *server) collectPromsumDataHandler(w http.ResponseWriter, r *http.Requ
 
 	logger.Debugf("collecting promsum data between %s and %s", start.Format(time.RFC3339), end.Format(time.RFC3339))
 
-	err = srv.chargeback.triggerPrometheusImporterForTimeRange(context.Background(), start, end)
+	err = srv.collectorFunc(context.Background(), start, end)
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to collect prometheus data: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to collect prometheus data: %v", err)
 		return
 	}
 
-	srv.writeResponseWithBody(logger, w, http.StatusOK, struct{}{})
+	writeResponseWithBody(logger, w, http.StatusOK, struct{}{})
 }
 
 type StorePromsumDataRequest []*prestostore.PrometheusMetric
 
 func (srv *server) storePromsumDataHandler(w http.ResponseWriter, r *http.Request) {
-	logger := srv.newLogger(r)
+	logger := newRequestLogger(srv.logger, r, srv.rand)
 
 	name := chi.URLParam(r, "datasourceName")
 
@@ -553,26 +473,26 @@ func (srv *server) storePromsumDataHandler(w http.ResponseWriter, r *http.Reques
 	var req StorePromsumDataRequest
 	err := decoder.Decode(&req)
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
 		return
 	}
 
-	err = prestostore.StorePrometheusMetrics(context.Background(), srv.chargeback.prestoConn, dataSourceTableName(name), []*prestostore.PrometheusMetric(req))
+	err = prestostore.StorePrometheusMetrics(context.Background(), srv.queryer, dataSourceTableName(name), []*prestostore.PrometheusMetric(req))
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to store promsum metrics: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to store promsum metrics: %v", err)
 		return
 	}
 
-	srv.writeResponseWithBody(logger, w, http.StatusOK, struct{}{})
+	writeResponseWithBody(logger, w, http.StatusOK, struct{}{})
 }
 
 func (srv *server) fetchPromsumDataHandler(w http.ResponseWriter, r *http.Request) {
-	logger := srv.newLogger(r)
+	logger := newRequestLogger(srv.logger, r, srv.rand)
 
 	name := chi.URLParam(r, "datasourceName")
 	err := r.ParseForm()
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode body: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode body: %v", err)
 		return
 	}
 
@@ -583,22 +503,22 @@ func (srv *server) fetchPromsumDataHandler(w http.ResponseWriter, r *http.Reques
 	if start != "" {
 		startTime, err = time.Parse(time.RFC3339, start)
 		if err != nil {
-			srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "invalid start time parameter: %v", err)
+			writeErrorResponse(logger, w, r, http.StatusInternalServerError, "invalid start time parameter: %v", err)
 			return
 		}
 	}
 	if end != "" {
 		endTime, err = time.Parse(time.RFC3339, end)
 		if err != nil {
-			srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "invalid end time parameter: %v", err)
+			writeErrorResponse(logger, w, r, http.StatusInternalServerError, "invalid end time parameter: %v", err)
 			return
 		}
 	}
-	results, err := prestostore.GetPrometheusMetrics(srv.chargeback.prestoConn, datasourceTable, startTime, endTime)
+	results, err := prestostore.GetPrometheusMetrics(srv.queryer, datasourceTable, startTime, endTime)
 	if err != nil {
-		srv.writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error querying for datasource: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error querying for datasource: %v", err)
 		return
 	}
 
-	srv.writeResponseWithBody(logger, w, http.StatusOK, results)
+	writeResponseWithBody(logger, w, http.StatusOK, results)
 }

--- a/pkg/chargeback/pprof.go
+++ b/pkg/chargeback/pprof.go
@@ -1,0 +1,21 @@
+package chargeback
+
+import (
+	"net/http"
+	"net/http/pprof"
+)
+
+func newPprofServer() *http.Server {
+	pprofMux := http.NewServeMux()
+
+	pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
+	pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	return &http.Server{
+		Addr:    "127.0.0.1:6060",
+		Handler: pprofMux,
+	}
+}

--- a/pkg/chargeback/promsum.go
+++ b/pkg/chargeback/promsum.go
@@ -44,6 +44,8 @@ func (c *Chargeback) triggerPrometheusImporterFromLastTimestamp(ctx context.Cont
 	}
 }
 
+type prometheusImporterFunc func(ctx context.Context, start, end time.Time) error
+
 type prometheusImporterTimeRangeTrigger struct {
 	start, end time.Time
 	errCh      chan error

--- a/pkg/chargeback/query.go
+++ b/pkg/chargeback/query.go
@@ -29,7 +29,7 @@ func (c *Chargeback) processReportGenerationQuery(logger log.FieldLogger) bool {
 	}
 	defer c.queues.reportGenerationQueryQueue.Done(obj)
 
-	logger = logger.WithFields(c.newLogIdentifier())
+	logger = logger.WithFields(newLogIdentifier(c.rand))
 	if key, ok := c.getKeyFromQueueObj(logger, "ReportGenerationQuery", obj, c.queues.reportGenerationQueryQueue); ok {
 		err := c.syncReportGenerationQuery(logger, key)
 		c.handleErr(logger, err, "ReportGenerationQuery", key, c.queues.reportGenerationQueryQueue)

--- a/pkg/chargeback/reports.go
+++ b/pkg/chargeback/reports.go
@@ -36,7 +36,7 @@ func (c *Chargeback) processReport(logger log.FieldLogger) bool {
 	}
 	defer c.queues.reportQueue.Done(obj)
 
-	logger = logger.WithFields(c.newLogIdentifier())
+	logger = logger.WithFields(newLogIdentifier(c.rand))
 	if key, ok := c.getKeyFromQueueObj(logger, "report", obj, c.queues.reportQueue); ok {
 		err := c.syncReport(logger, key)
 		c.handleErr(logger, err, "report", obj, c.queues.reportQueue)

--- a/pkg/chargeback/scheduled_reports.go
+++ b/pkg/chargeback/scheduled_reports.go
@@ -37,7 +37,7 @@ func (c *Chargeback) processScheduledReport(logger log.FieldLogger) bool {
 	}
 	defer c.queues.scheduledReportQueue.Done(obj)
 
-	logger = logger.WithFields(c.newLogIdentifier())
+	logger = logger.WithFields(newLogIdentifier(c.rand))
 	if key, ok := c.getKeyFromQueueObj(logger, "ScheduledReport", obj, c.queues.scheduledReportQueue); ok {
 		err := c.syncScheduledReport(logger, key)
 		c.handleErr(logger, err, "ScheduledReport", obj, c.queues.scheduledReportQueue)


### PR DESCRIPTION
Beginnings of refactoring that reduce the overall interface required for
the HTTP API to work. This will be necessary in the tests that we are
adding for the HTTP API so that can control the behavior as needed.