### PR TITLE
Use presto.ExecQueryer instead of db.Queryer in chargeback package

### DIFF
--- a/pkg/chargeback/health.go
+++ b/pkg/chargeback/health.go
@@ -95,7 +95,7 @@ func (c *Chargeback) testWriteToPresto(logger logrus.FieldLogger) bool {
 	}
 	// Hive does not support timezones, and now() returns a
 	// TIMESTAMP WITH TIMEZONE so we cast the return of now() to a TIMESTAMP.
-	err = presto.ExecuteInsertQuery(c.prestoConn, tableName, "VALUES (cast(now() AS TIMESTAMP))")
+	err = presto.InsertInto(c.prestoQueryer, tableName, "VALUES (cast(now() AS TIMESTAMP))")
 	if err != nil {
 		logger.WithError(err).Debugf("cannot insert into Presto table %s", tableName)
 		return false

--- a/pkg/chargeback/http.go
+++ b/pkg/chargeback/http.go
@@ -21,7 +21,6 @@ import (
 	api "github.com/operator-framework/operator-metering/pkg/apis/chargeback/v1alpha1"
 	cbutil "github.com/operator-framework/operator-metering/pkg/apis/chargeback/v1alpha1/util"
 	"github.com/operator-framework/operator-metering/pkg/chargeback/prestostore"
-	"github.com/operator-framework/operator-metering/pkg/db"
 	listers "github.com/operator-framework/operator-metering/pkg/generated/listers/chargeback/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/presto"
 	"github.com/operator-framework/operator-metering/pkg/util/orderedmap"
@@ -40,7 +39,7 @@ type server struct {
 	logger log.FieldLogger
 
 	rand          *rand.Rand
-	queryer       db.Queryer
+	queryer       presto.ExecQueryer
 	collectorFunc prometheusImporterFunc
 	listers       meteringListers
 }
@@ -53,7 +52,7 @@ func (l *requestLogger) Print(v ...interface{}) {
 	l.FieldLogger.Info(v...)
 }
 
-func newRouter(logger log.FieldLogger, queryer db.Queryer, rand *rand.Rand, collectorFunc prometheusImporterFunc, listers meteringListers) chi.Router {
+func newRouter(logger log.FieldLogger, queryer presto.ExecQueryer, rand *rand.Rand, collectorFunc prometheusImporterFunc, listers meteringListers) chi.Router {
 	router := chi.NewRouter()
 
 	logger = logger.WithField("component", "api")

--- a/pkg/chargeback/operator.go
+++ b/pkg/chargeback/operator.go
@@ -39,6 +39,7 @@ import (
 	cbClientset "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned"
 	cbInformers "github.com/operator-framework/operator-metering/pkg/generated/informers/externalversions"
 	"github.com/operator-framework/operator-metering/pkg/hive"
+	"github.com/operator-framework/operator-metering/pkg/presto"
 )
 
 const (
@@ -79,10 +80,10 @@ type Chargeback struct {
 	chargebackClient cbClientset.Interface
 	kubeClient       corev1.CoreV1Interface
 
-	prestoConn  db.Queryer
-	prestoDB    *sql.DB
-	hiveQueryer *hiveQueryer
-	promConn    prom.API
+	prestoConn    *sql.DB
+	prestoQueryer presto.ExecQueryer
+	hiveQueryer   *hiveQueryer
+	promConn      prom.API
 
 	scheduledReportRunner *scheduledReportRunner
 
@@ -281,11 +282,12 @@ func (c *Chargeback) Run(stopCh <-chan struct{}) error {
 	var g errgroup.Group
 	g.Go(func() error {
 		var err error
-		c.prestoDB, err = c.newPrestoConn(stopCh)
+		c.prestoConn, err = c.newPrestoConn(stopCh)
 		if err != nil {
 			return err
 		}
-		c.prestoConn = db.New(c.prestoDB, c.logger, c.cfg.LogDMLQueries)
+		prestoDB := db.New(c.prestoConn, c.logger, c.cfg.LogDMLQueries)
+		c.prestoQueryer = presto.NewDB(prestoDB)
 		return nil
 	})
 	g.Go(func() error {
@@ -298,7 +300,7 @@ func (c *Chargeback) Run(stopCh <-chan struct{}) error {
 		return err
 	}
 
-	defer c.prestoDB.Close()
+	defer c.prestoConn.Close()
 	defer c.hiveQueryer.closeHiveConnection()
 
 	transportConfig, err := c.kubeConfig.TransportConfig()
@@ -340,7 +342,7 @@ func (c *Chargeback) Run(stopCh <-chan struct{}) error {
 		prestoTables:            c.informers.Chargeback().V1alpha1().PrestoTables().Lister().PrestoTables(c.cfg.Namespace),
 	}
 
-	apiRouter := newRouter(c.logger, c.prestoConn, c.rand, c.triggerPrometheusImporterForTimeRange, listers)
+	apiRouter := newRouter(c.logger, c.prestoQueryer, c.rand, c.triggerPrometheusImporterForTimeRange, listers)
 	apiRouter.HandleFunc("/ready", c.readinessHandler)
 	apiRouter.HandleFunc("/healthy", c.healthinessHandler)
 

--- a/pkg/chargeback/prestostore/importer.go
+++ b/pkg/chargeback/prestostore/importer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/clock"
 
-	"github.com/operator-framework/operator-metering/pkg/db"
+	"github.com/operator-framework/operator-metering/pkg/presto"
 	"github.com/operator-framework/operator-metering/pkg/promquery"
 )
 
@@ -24,7 +24,7 @@ const (
 type PrometheusImporter struct {
 	logger          logrus.FieldLogger
 	promConn        prom.API
-	prestoQueryer   db.Queryer
+	prestoQueryer   presto.ExecQueryer
 	collectHandlers promquery.ResultHandler
 	clock           clock.Clock
 	cfg             Config
@@ -46,7 +46,7 @@ type Config struct {
 	AllowIncompleteChunks bool
 }
 
-func NewPrometheusImporter(logger logrus.FieldLogger, promConn prom.API, prestoQueryer db.Queryer, clock clock.Clock, cfg Config) *PrometheusImporter {
+func NewPrometheusImporter(logger logrus.FieldLogger, promConn prom.API, prestoQueryer presto.ExecQueryer, clock clock.Clock, cfg Config) *PrometheusImporter {
 	logger = logger.WithFields(logrus.Fields{
 		"component": "PrometheusImporter",
 		"tableName": cfg.PrestoTableName,

--- a/pkg/chargeback/prestostore/prometheusmetric.go
+++ b/pkg/chargeback/prestostore/prometheusmetric.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/operator-framework/operator-metering/pkg/db"
 	"github.com/operator-framework/operator-metering/pkg/presto"
 )
 
@@ -27,9 +26,7 @@ type PrometheusMetric struct {
 
 // StorePrometheusMetrics handles storing Prometheus metrics into the specified
 // Presto table.
-//
-// Any Queryer is accepted, but this function expects a Presto connection.
-func StorePrometheusMetrics(ctx context.Context, queryer db.Queryer, tableName string, metrics []*PrometheusMetric) error {
+func StorePrometheusMetrics(ctx context.Context, execer presto.Execer, tableName string, metrics []*PrometheusMetric) error {
 	var queryValues []string
 
 	for _, metric := range metrics {
@@ -70,7 +67,7 @@ func StorePrometheusMetrics(ctx context.Context, queryer db.Queryer, tableName s
 		// if writing the current value to the buffer would exceed the
 		// prestoQueryCap, preform the insert query, and reset the buffer
 		if newBufferSize > queryCap {
-			err := presto.ExecuteInsertQuery(queryer, tableName, queryBuf.String())
+			err := presto.InsertInto(execer, tableName, queryBuf.String())
 			if err != nil {
 				return fmt.Errorf("failed to store metrics into presto: %v", err)
 			}
@@ -81,7 +78,7 @@ func StorePrometheusMetrics(ctx context.Context, queryer db.Queryer, tableName s
 	}
 	// if the buffer has unwritten values, perform the final insert
 	if queryBuf.Len() != 0 {
-		err := presto.ExecuteInsertQuery(queryer, tableName, queryBuf.String())
+		err := presto.InsertInto(execer, tableName, queryBuf.String())
 		if err != nil {
 			return fmt.Errorf("failed to store metrics into presto: %v", err)
 		}
@@ -111,7 +108,7 @@ func generatePrometheusMetricSQLValues(metric *PrometheusMetric) string {
 		metric.Amount, presto.Timestamp(metric.Timestamp), metric.StepSize.Seconds(), keyString, valString)
 }
 
-func getLastTimestampForTable(queryer db.Queryer, tableName string) (*time.Time, error) {
+func getLastTimestampForTable(queryer presto.Queryer, tableName string) (*time.Time, error) {
 	// Get the most recent timestamp in the table for this query
 	getLastTimestampQuery := fmt.Sprintf(`
 				SELECT "timestamp"
@@ -119,7 +116,7 @@ func getLastTimestampForTable(queryer db.Queryer, tableName string) (*time.Time,
 				ORDER BY "timestamp" DESC
 				LIMIT 1`, tableName)
 
-	results, err := presto.ExecuteSelect(queryer, getLastTimestampQuery)
+	results, err := queryer.Query(getLastTimestampQuery)
 	if err != nil {
 		return nil, fmt.Errorf("error getting last timestamp for table %s, maybe table doesn't exist yet? %v", tableName, err)
 	}
@@ -131,7 +128,7 @@ func getLastTimestampForTable(queryer db.Queryer, tableName string) (*time.Time,
 	return nil, nil
 }
 
-func GetPrometheusMetrics(queryer db.Queryer, tableName string, start, end time.Time) ([]*PrometheusMetric, error) {
+func GetPrometheusMetrics(queryer presto.Queryer, tableName string, start, end time.Time) ([]*PrometheusMetric, error) {
 	whereClause := ""
 	if !start.IsZero() {
 		whereClause += fmt.Sprintf(`WHERE "timestamp" >= timestamp '%s' `, presto.Timestamp(start))
@@ -153,36 +150,28 @@ func GetPrometheusMetrics(queryer db.Queryer, tableName string, start, end time.
 		return nil, err
 	}
 
-	var results []*PrometheusMetric
-	for rows.Next() {
-		var dbMetric dbPrometheusMetric
-		if err := rows.Scan(&dbMetric.Labels, &dbMetric.Amount, &dbMetric.TimePrecision, &dbMetric.Timestamp); err != nil {
-			return nil, err
-		}
+	results := make([]*PrometheusMetric, len(rows))
+	for i, row := range rows {
+		rowLabels := row["labels"].(map[string]interface{})
+		rowAmount := row["amount"].(float64)
+		rowTimePrecision := row["timeprecision"].(float64)
+		rowTimestamp := row["timestamp"].(time.Time)
+
 		labels := make(map[string]string)
-		for key, value := range dbMetric.Labels {
+		for key, value := range rowLabels {
 			var ok bool
 			labels[key], ok = value.(string)
 			if !ok {
 				return nil, fmt.Errorf("invalid label %s, valueType: %T, value: %+v", key, value, value)
 			}
 		}
-		metric := PrometheusMetric{
+		metric := &PrometheusMetric{
 			Labels:    labels,
-			Amount:    dbMetric.Amount,
-			StepSize:  time.Duration(dbMetric.TimePrecision) * time.Second,
-			Timestamp: dbMetric.Timestamp,
+			Amount:    rowAmount,
+			StepSize:  time.Duration(rowTimePrecision) * time.Second,
+			Timestamp: rowTimestamp,
 		}
-		results = append(results, &metric)
+		results[i] = metric
 	}
 	return results, nil
-}
-
-// dbPrometheusMetric is used for scanning results from the database
-// before being turned into a PrometheusMetric
-type dbPrometheusMetric struct {
-	Labels        map[string]interface{}
-	Amount        float64
-	TimePrecision float64
-	Timestamp     time.Time
 }

--- a/pkg/chargeback/promsum.go
+++ b/pkg/chargeback/promsum.go
@@ -151,7 +151,7 @@ func (c *Chargeback) startPrometheusImporter(ctx context.Context) {
 				dataSourceLogger.Debugf("ReportDataSource %s already has an importer, updating configuration", dataSourceName)
 				importer.UpdateConfig(cfg)
 			} else {
-				importer := prestostore.NewPrometheusImporter(dataSourceLogger, c.promConn, c.prestoConn, c.clock, cfg)
+				importer := prestostore.NewPrometheusImporter(dataSourceLogger, c.promConn, c.prestoQueryer, c.clock, cfg)
 				prometheusImporters[dataSourceName] = importer
 			}
 		}

--- a/pkg/presto/db.go
+++ b/pkg/presto/db.go
@@ -1,0 +1,32 @@
+package presto
+
+import "github.com/operator-framework/operator-metering/pkg/db"
+
+type Queryer interface {
+	Query(query string) ([]Row, error)
+}
+
+type Execer interface {
+	Exec(query string) error
+}
+
+type ExecQueryer interface {
+	Queryer
+	Execer
+}
+
+type DB struct {
+	queryer db.Queryer
+}
+
+func NewDB(queryer db.Queryer) *DB {
+	return &DB{queryer}
+}
+
+func (db *DB) Query(query string) ([]Row, error) {
+	return ExecuteSelect(db.queryer, query)
+}
+
+func (db *DB) Exec(query string) error {
+	return ExecuteQuery(db.queryer, query)
+}

--- a/pkg/presto/presto.go
+++ b/pkg/presto/presto.go
@@ -2,18 +2,13 @@ package presto
 
 import (
 	"fmt"
-	"strings"
-	"time"
 
 	_ "github.com/prestodb/presto-go-client/presto"
 
 	"github.com/operator-framework/operator-metering/pkg/db"
 )
 
-const (
-	// TimestampFormat is the time format string used to produce Presto timestamps.
-	TimestampFormat = "2006-01-02 15:04:05.000"
-)
+type Row map[string]interface{}
 
 type Column struct {
 	Name string `json:"name"`
@@ -25,16 +20,6 @@ type PartitionSpec map[string]string
 type TablePartition struct {
 	Location      string        `json:"location"`
 	PartitionSpec PartitionSpec `json:"partitionSpec"`
-}
-
-func FormatInsertQuery(target, query string) string {
-	return fmt.Sprintf("INSERT INTO %s %s", target, query)
-}
-
-// ExecuteInsertQuery performs the query an INSERT into the table target. It's expected target has the correct schema.
-func ExecuteInsertQuery(queryer db.Queryer, target, query string) error {
-	insertQuery := FormatInsertQuery(target, query)
-	return ExecuteQuery(queryer, insertQuery)
 }
 
 func ExecuteQuery(queryer db.Queryer, query string) error {
@@ -54,8 +39,6 @@ func ExecuteQuery(queryer db.Queryer, query string) error {
 	}
 	return nil
 }
-
-type Row map[string]interface{}
 
 // ExecuteSelectQuery performs the query on the table target. It's expected
 // target has the correct schema.
@@ -99,49 +82,4 @@ func ExecuteSelect(queryer db.Queryer, query string) ([]Row, error) {
 	}
 
 	return results, nil
-}
-
-func DeleteFrom(prestoConn db.Queryer, tableName string) error {
-	return ExecuteQuery(prestoConn, fmt.Sprintf("DELETE FROM %s", tableName))
-}
-
-func GetRows(prestoConn db.Queryer, tableName string, columns []Column) ([]Row, error) {
-	columnsSQL := GenerateQuotedColumnsListSQL(columns)
-	orderBySQL := GenerateOrderBySQL(columns)
-	query := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", columnsSQL, tableName, orderBySQL)
-	return ExecuteSelect(prestoConn, query)
-}
-
-func GenerateQuotedColumnsListSQL(columns []Column) string {
-	var columnNames []string
-	for _, col := range columns {
-		columnNames = append(columnNames, quoteColumn(col))
-	}
-	columnsSQL := strings.Join(columnNames, ",")
-	return columnsSQL
-}
-
-func GenerateOrderBySQL(columns []Column) string {
-	var quotedColumns []string
-	for _, col := range columns {
-		colName := col.Name
-		// if we detect a map(...) in the column, use map_entries to do
-		// ordering. we detect a map column using a best effort approach by
-		// checking if the column type contains the string "map(" , and is
-		// followed by a ")" after that string.
-		if mapIndex := strings.Index(col.Type, "map("); mapIndex != -1 && strings.Index(col.Type, ")") > mapIndex {
-			quotedColumns = append(quotedColumns, fmt.Sprintf(`map_entries("%s")`, colName))
-		} else {
-			quotedColumns = append(quotedColumns, quoteColumn(col))
-		}
-	}
-	return fmt.Sprintf("%s ASC", strings.Join(quotedColumns, ", "))
-}
-
-func Timestamp(date time.Time) string {
-	return date.Format(TimestampFormat)
-}
-
-func quoteColumn(col Column) string {
-	return `"` + col.Name + `"`
 }

--- a/pkg/presto/util.go
+++ b/pkg/presto/util.go
@@ -1,0 +1,65 @@
+package presto
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	// TimestampFormat is the time format string used to produce Presto timestamps.
+	TimestampFormat = "2006-01-02 15:04:05.000"
+)
+
+func DeleteFrom(execer Execer, tableName string) error {
+	return execer.Exec(fmt.Sprintf("DELETE FROM %s", tableName))
+}
+
+func InsertInto(execer Execer, tableName, query string) error {
+	return execer.Exec(FormatInsertQuery(tableName, query))
+}
+
+func GetRows(queryer Queryer, tableName string, columns []Column) ([]Row, error) {
+	columnsSQL := GenerateQuotedColumnsListSQL(columns)
+	orderBySQL := GenerateOrderBySQL(columns)
+	query := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", columnsSQL, tableName, orderBySQL)
+	return queryer.Query(query)
+}
+
+func GenerateQuotedColumnsListSQL(columns []Column) string {
+	var columnNames []string
+	for _, col := range columns {
+		columnNames = append(columnNames, quoteColumn(col))
+	}
+	columnsSQL := strings.Join(columnNames, ",")
+	return columnsSQL
+}
+
+func GenerateOrderBySQL(columns []Column) string {
+	var quotedColumns []string
+	for _, col := range columns {
+		colName := col.Name
+		// if we detect a map(...) in the column, use map_entries to do
+		// ordering. we detect a map column using a best effort approach by
+		// checking if the column type contains the string "map(" , and is
+		// followed by a ")" after that string.
+		if mapIndex := strings.Index(col.Type, "map("); mapIndex != -1 && strings.Index(col.Type, ")") > mapIndex {
+			quotedColumns = append(quotedColumns, fmt.Sprintf(`map_entries("%s")`, colName))
+		} else {
+			quotedColumns = append(quotedColumns, quoteColumn(col))
+		}
+	}
+	return fmt.Sprintf("%s ASC", strings.Join(quotedColumns, ", "))
+}
+
+func FormatInsertQuery(target, query string) string {
+	return fmt.Sprintf("INSERT INTO %s %s", target, query)
+}
+
+func Timestamp(date time.Time) string {
+	return date.Format(TimestampFormat)
+}
+
+func quoteColumn(col Column) string {
+	return `"` + col.Name + `"`
+}


### PR DESCRIPTION
Updates querying logic to rely on presto.ExecQueryer instead of
db.Queryer.  The presto.ExecQueryer is a higher level abstraction over
the db.Queryer interface which has an implementation in presto.(*DB).
This higher level abstraction will be easier to fake/mock in tests since
we can avoid having to make the sql.Rows and instead just mock creating
presto.Row objects which are easier to construct.