### PR TITLE
Refactor HTTP unit test to use helpers

### DIFF
--- a/pkg/chargeback/http_test.go
+++ b/pkg/chargeback/http_test.go
@@ -35,41 +35,82 @@ var (
 	testLogger = logrus.New()
 )
 
+func newTestReport(name, namespace, testQueryName string, reportStart, reportEnd time.Time, reportStatus v1alpha1.ReportStatus) *v1alpha1.Report {
+	return &v1alpha1.Report{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.ReportSpec{
+			GenerationQueryName: testQueryName,
+			ReportingStart:      meta.Time{reportStart},
+			ReportingEnd:        meta.Time{reportEnd},
+			RunImmediately:      true,
+		},
+		Status: reportStatus,
+	}
+}
+
+func newTestReportGenQuery(name, namespace string, columns []v1alpha1.ReportGenerationQueryColumn) *v1alpha1.ReportGenerationQuery {
+	return &v1alpha1.ReportGenerationQuery{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.ReportGenerationQuerySpec{
+			Columns: columns,
+		},
+	}
+}
+
+func newTestPrestoTable(name, namespace string, columns []hive.Column) *v1alpha1.PrestoTable {
+	return &v1alpha1.PrestoTable{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      prestoTableResourceNameFromKind("report", name),
+			Namespace: namespace,
+		},
+		State: v1alpha1.PrestoTableState{
+			Parameters: v1alpha1.TableParameters{
+				Columns: columns,
+			},
+		},
+	}
+}
+
 func TestAPIV1ReportsGet(t *testing.T) {
 	const namespace = "default"
+	const testReportName = "test-report"
+	const testQueryName = "test-query"
 	reportStart := time.Time{}
 	reportEnd := reportStart.AddDate(0, 1, 0)
 
 	tests := map[string]struct {
-		reportStatus   v1alpha1.ReportStatus
-		noCreateReport bool
+		reportName string
 
-		queryName          string
-		prestoQueryColumns []v1alpha1.ReportGenerationQueryColumn
-
-		noCreateQuery       bool
-		prestoTableColumns  []hive.Column
-		noCreatePrestoTable bool
+		report      *v1alpha1.Report
+		query       *v1alpha1.ReportGenerationQuery
+		prestoTable *v1alpha1.PrestoTable
 
 		expectedStatusCode int
-		expectAPIError     bool
+		expectedAPIError   string
 
 		queryerPrepareFunc func(*mockpresto.MockExecQueryer) []presto.Row
 	}{
 		"report-finished-no-results": {
-			reportStatus: v1alpha1.ReportStatus{Phase: v1alpha1.ReportPhaseFinished},
-			prestoQueryColumns: []v1alpha1.ReportGenerationQueryColumn{
+			reportName: testReportName,
+			report:     newTestReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{Phase: v1alpha1.ReportPhaseFinished}),
+			query: newTestReportGenQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
 				},
-			},
-			prestoTableColumns: []hive.Column{
+			}),
+			prestoTable: newTestPrestoTable(testReportName, namespace, []hive.Column{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
 				},
-			},
+			}),
 			queryerPrepareFunc: func(mock *mockpresto.MockExecQueryer) []presto.Row {
 				mock.EXPECT().Query(gomock.Any()).Return(nil, nil)
 				return nil
@@ -77,19 +118,21 @@ func TestAPIV1ReportsGet(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 		},
 		"report-finished-with-results": {
-			reportStatus: v1alpha1.ReportStatus{Phase: v1alpha1.ReportPhaseFinished},
-			prestoQueryColumns: []v1alpha1.ReportGenerationQueryColumn{
+			reportName: testReportName,
+			report:     newTestReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{Phase: v1alpha1.ReportPhaseFinished}),
+			query: newTestReportGenQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
 				},
 			},
-			prestoTableColumns: []hive.Column{
+			),
+			prestoTable: newTestPrestoTable(testReportName, namespace, []hive.Column{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
 				},
-			},
+			}),
 			queryerPrepareFunc: func(mock *mockpresto.MockExecQueryer) []presto.Row {
 				result := []presto.Row{
 					{
@@ -102,26 +145,27 @@ func TestAPIV1ReportsGet(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 		},
 		"report-finished-db-errored": {
-			reportStatus: v1alpha1.ReportStatus{Phase: v1alpha1.ReportPhaseFinished},
-			prestoQueryColumns: []v1alpha1.ReportGenerationQueryColumn{
+			reportName: testReportName,
+			report:     newTestReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{Phase: v1alpha1.ReportPhaseFinished}),
+			query: newTestReportGenQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
 				},
-			},
-			prestoTableColumns: []hive.Column{
+			}),
+			prestoTable: newTestPrestoTable(testReportName, namespace, []hive.Column{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
 				},
-			},
+			}),
 			queryerPrepareFunc: func(mock *mockpresto.MockExecQueryer) []presto.Row {
 				dbErr := errors.New("mock database had an error")
 				mock.EXPECT().Query(gomock.Any()).Return(nil, dbErr)
 				return nil
 			},
 			expectedStatusCode: http.StatusInternalServerError,
-			expectAPIError:     true,
+			expectedAPIError:   "failed to perform presto query",
 		},
 	}
 
@@ -143,50 +187,16 @@ func TestAPIV1ReportsGet(t *testing.T) {
 				prestoTables:            listers.NewPrestoTableLister(prestoTableIndexer).PrestoTables(namespace),
 			}
 
-			if !tt.noCreateReport {
-				// create a report for testing with
-				report := &v1alpha1.Report{
-					ObjectMeta: meta.ObjectMeta{
-						Name:      testName,
-						Namespace: namespace,
-					},
-					Spec: v1alpha1.ReportSpec{
-						GenerationQueryName: tt.queryName,
-						ReportingStart:      meta.Time{reportStart},
-						ReportingEnd:        meta.Time{reportEnd},
-						RunImmediately:      true,
-					},
-					Status: tt.reportStatus,
-				}
-				reportIndexer.Add(report)
+			// add our test report if one is specified
+			if tt.report != nil {
+				reportIndexer.Add(tt.report)
 			}
-			if !tt.noCreateQuery {
-				// create a reportGenerationQuery for testing with
-				reportGenerationQuery := &v1alpha1.ReportGenerationQuery{
-					ObjectMeta: meta.ObjectMeta{
-						Name:      tt.queryName,
-						Namespace: namespace,
-					},
-					Spec: v1alpha1.ReportGenerationQuerySpec{
-						Columns: tt.prestoQueryColumns,
-					},
-				}
-				reportGenerationQueryIndexer.Add(reportGenerationQuery)
+			// add our test query for the report
+			if tt.query != nil {
+				reportGenerationQueryIndexer.Add(tt.query)
 			}
-			if !tt.noCreatePrestoTable {
-				// create a prestoTable for testing with
-				prestoTable := &v1alpha1.PrestoTable{
-					ObjectMeta: meta.ObjectMeta{
-						Name:      prestoTableResourceNameFromKind("report", testName),
-						Namespace: namespace,
-					},
-					State: v1alpha1.PrestoTableState{
-						Parameters: v1alpha1.TableParameters{
-							Columns: tt.prestoTableColumns,
-						},
-					},
-				}
-				prestoTableIndexer.Add(prestoTable)
+			if tt.prestoTable != nil {
+				prestoTableIndexer.Add(tt.prestoTable)
 			}
 
 			ctrl := gomock.NewController(t)
@@ -197,8 +207,12 @@ func TestAPIV1ReportsGet(t *testing.T) {
 
 			// expectedResults is what our mock queryer will return. since the
 			// v1 results endpoint just serializes the slice of rows returned
-			// from the DB, this is also what we expect the HTTP api to return
-			expectedResults := tt.queryerPrepareFunc(queryer)
+			// from the DB, this is also what we expect the HTTP api to
+			// return when there are no errors
+			var expectedResults []presto.Row
+			if tt.queryerPrepareFunc != nil {
+				expectedResults = tt.queryerPrepareFunc(queryer)
+			}
 
 			// setup a test server suitable for making API calls against
 			router := newRouter(testLogger, queryer, testRand, noopPrometheusImporterFunc, listers)
@@ -208,10 +222,9 @@ func TestAPIV1ReportsGet(t *testing.T) {
 			// set up the query parameters for our API call.
 			// we hardcode format to JSON because validating CSV output is a
 			// bit trickier than JSON
-			// the name of the report is the same name as the sub test name
 			params := url.Values{
 				"format": []string{"json"},
-				"name":   []string{testName},
+				"name":   []string{tt.reportName},
 			}
 			endpoint := server.URL + APIV1ReportsGetEndpoint
 
@@ -235,14 +248,14 @@ func TestAPIV1ReportsGet(t *testing.T) {
 			assert.Equal(t, tt.expectedStatusCode, resp.StatusCode, "Expected http status code to match")
 			t.Logf("response body: %s", string(body))
 
-			// if tt.expectAPIError is true, then this test is testing the
+			// if tt.expectedAPIError is non-empty, then this test is testing the
 			// error response from the API, otherwise it's testing the results
 			// come back with the correct number of items
-			if tt.expectAPIError {
+			if tt.expectedAPIError != "" {
 				var errResp errorResponse
 				err = json.Unmarshal(body, &errResp)
 				assert.NoError(t, err, "expected unmarshal to not error")
-				assert.Contains(t, errResp.Error, "failed to perform presto query", "expected error to contain message about presto query failing")
+				assert.Contains(t, errResp.Error, tt.expectedAPIError, "expected error response to contain expected api error")
 			} else {
 				var results []presto.Row
 				err = json.Unmarshal(body, &results)


### PR DESCRIPTION
Simplify the http unit tests a bit by making helpers for creating test
resources instead of having a bool to control if the resource is added
to the indexer store, just use a pointer and if non-nil, add to the
indexer.

Based on #309