### PR TITLE
Test non-existing report in http unit tests

### DIFF
--- a/pkg/chargeback/http_test.go
+++ b/pkg/chargeback/http_test.go
@@ -167,6 +167,11 @@ func TestAPIV1ReportsGet(t *testing.T) {
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedAPIError:   "failed to perform presto query",
 		},
+		"non-existent-report": {
+			reportName:         "doesnt-exist",
+			expectedStatusCode: http.StatusNotFound,
+			expectedAPIError:   "not found",
+		},
 	}
 
 	for testName, tt := range tests {


### PR DESCRIPTION
Adds a sub test for the v1 API endpoint for testing trying to get report
results for a non-existant report. Updates the API to return a 404
response code instead of a 500.

Based on #310