### PR TITLE
pkg/{chargeback,apis}: Support overwriteExistingData in scheduledReports

### DIFF
--- a/pkg/apis/chargeback/v1alpha1/scheduled_report.go
+++ b/pkg/apis/chargeback/v1alpha1/scheduled_report.go
@@ -33,6 +33,12 @@ type ScheduledReportSpec struct {
 	// the report
 	GracePeriod *meta.Duration `json:"gracePeriod,omitempty"`
 
+	// OverwriteExistingData controls whether or not to delete any existing
+	// data in the report table before the scheduled report runs. Useful for
+	// having a report that is just a snapshot of the most recent data rather
+	// than a log of all runs before it.
+	OverwriteExistingData bool `json:"overwriteExistingData",omitempty`
+
 	// Output is the storage location where results are sent.
 	Output *StorageLocationRef `json:"output,omitempty"`
 }

--- a/pkg/chargeback/aws_usage_hive.go
+++ b/pkg/chargeback/aws_usage_hive.go
@@ -74,7 +74,7 @@ func (c *Chargeback) createAWSUsageTable(logger logrus.FieldLogger, dataSource *
 		SerdeRowProperties: awsUsageHiveSerdeProps,
 		External:           true,
 	}
-	return c.createTableWith(logger, dataSource, "ReportDataSource", dataSource.Name, params, properties, false)
+	return c.createTableWith(logger, dataSource, "ReportDataSource", dataSource.Name, params, properties)
 }
 
 // addAWSHivePartition will add a new partition to the given tableName for the time

--- a/pkg/chargeback/datasources.go
+++ b/pkg/chargeback/datasources.go
@@ -120,7 +120,7 @@ func (c *Chargeback) handleReportDataSource(logger log.FieldLogger, dataSource *
 func (c *Chargeback) handlePrometheusMetricsDataSource(logger log.FieldLogger, dataSource *cbTypes.ReportDataSource) error {
 	storage := dataSource.Spec.Promsum.Storage
 	tableName := dataSourceTableName(dataSource.Name)
-	err := c.createTableForStorage(logger, dataSource, "ReportDataSource", dataSource.Name, storage, tableName, promsumHiveColumns, false)
+	err := c.createTableForStorage(logger, dataSource, "ReportDataSource", dataSource.Name, storage, tableName, promsumHiveColumns)
 	if err != nil {
 		return err
 	}

--- a/pkg/chargeback/health.go
+++ b/pkg/chargeback/health.go
@@ -90,14 +90,14 @@ func (c *Chargeback) testWriteToPresto(logger logrus.FieldLogger) bool {
 	const tableName = "chargeback_health_check"
 	err := c.createTableForStorageNoCR(logger, nil, tableName, []hive.Column{{Name: "check_time", Type: "TIMESTAMP"}})
 	if err != nil {
-		logger.WithError(err).Debugf("cannot create Presto table %s", tableName)
+		logger.WithError(err).Errorf("cannot create Presto table %s", tableName)
 		return false
 	}
 	// Hive does not support timezones, and now() returns a
 	// TIMESTAMP WITH TIMEZONE so we cast the return of now() to a TIMESTAMP.
 	err = presto.InsertInto(c.prestoQueryer, tableName, "VALUES (cast(now() AS TIMESTAMP))")
 	if err != nil {
-		logger.WithError(err).Debugf("cannot insert into Presto table %s", tableName)
+		logger.WithError(err).Errorf("cannot insert into Presto table %s", tableName)
 		return false
 	}
 	return true

--- a/pkg/chargeback/health.go
+++ b/pkg/chargeback/health.go
@@ -88,7 +88,7 @@ func (c *Chargeback) testReadFromPresto(logger logrus.FieldLogger) bool {
 func (c *Chargeback) testWriteToPresto(logger logrus.FieldLogger) bool {
 	logger = logger.WithField("component", "testWriteToPresto")
 	const tableName = "chargeback_health_check"
-	err := c.createTableForStorageNoCR(logger, nil, tableName, []hive.Column{{Name: "check_time", Type: "TIMESTAMP"}}, false)
+	err := c.createTableForStorageNoCR(logger, nil, tableName, []hive.Column{{Name: "check_time", Type: "TIMESTAMP"}})
 	if err != nil {
 		logger.WithError(err).Debugf("cannot create Presto table %s", tableName)
 		return false

--- a/pkg/chargeback/reports.go
+++ b/pkg/chargeback/reports.go
@@ -179,6 +179,7 @@ func (c *Chargeback) handleReport(logger log.FieldLogger, report *cbTypes.Report
 		report.Spec.Output,
 		genQuery,
 		true,
+		false,
 	)
 	if err != nil {
 		c.setReportError(logger, report, err, "report execution failed")

--- a/pkg/chargeback/scheduled_reports.go
+++ b/pkg/chargeback/scheduled_reports.go
@@ -286,7 +286,7 @@ func (job *scheduledReportJob) start(logger log.FieldLogger) {
 
 		tableName := scheduledReportTableName(job.report.Name)
 		columns := generateHiveColumns(genQuery)
-		err = job.chargeback.createTableForStorage(logger, job.report, "scheduledreport", job.report.Name, job.report.Spec.Output, tableName, columns, false)
+		err = job.chargeback.createTableForStorage(logger, job.report, "scheduledreport", job.report.Name, job.report.Spec.Output, tableName, columns)
 		if err != nil {
 			logger.WithError(err).Error("error creating report table for scheduledReport")
 			return
@@ -306,9 +306,10 @@ func (job *scheduledReportJob) start(logger log.FieldLogger) {
 		reportPeriod := getNextReportPeriod(job.schedule, job.report.Spec.Schedule.Period, lastScheduled)
 
 		loggerWithFields := logger.WithFields(log.Fields{
-			"periodStart": reportPeriod.periodStart,
-			"periodEnd":   reportPeriod.periodEnd,
-			"period":      job.report.Spec.Schedule.Period,
+			"periodStart":       reportPeriod.periodStart,
+			"periodEnd":         reportPeriod.periodEnd,
+			"period":            job.report.Spec.Schedule.Period,
+			"overwriteExisting": job.report.Spec.OverwriteExistingData,
 		})
 
 		var gracePeriod time.Duration
@@ -364,6 +365,7 @@ func (job *scheduledReportJob) start(logger log.FieldLogger) {
 				job.report.Spec.Output,
 				genQuery,
 				false,
+				job.report.Spec.OverwriteExistingData,
 			)
 
 			if err != nil {

--- a/pkg/chargeback/storage.go
+++ b/pkg/chargeback/storage.go
@@ -42,7 +42,7 @@ func (c *Chargeback) getStorageSpec(logger log.FieldLogger, storage *cbTypes.Sto
 	var storageSpec cbTypes.StorageLocationSpec
 	// Nothing specified, try to use default storage location
 	if storage == nil || (storage.StorageSpec == nil && storage.StorageLocationName == "") {
-		logger.Infof("%s storage does not have a spec or storageLocationName set, getting default storage location", kind)
+		logger.Debugf("%s storage does not have a spec or storageLocationName set, getting default storage location", kind)
 		storageLocation, err := c.getDefaultStorageLocation(storageLister)
 		if err != nil {
 			return storageSpec, err
@@ -53,7 +53,7 @@ func (c *Chargeback) getStorageSpec(logger log.FieldLogger, storage *cbTypes.Sto
 
 		storageSpec = storageLocation.Spec
 	} else if storage.StorageLocationName != "" { // Specific storage location specified
-		logger.Infof("%s configured to use StorageLocation %s", kind, storage.StorageLocationName)
+		logger.Debugf("%s configured to use StorageLocation %s", kind, storage.StorageLocationName)
 		storageLocation, err := storageLister.StorageLocations(c.cfg.Namespace).Get(storage.StorageLocationName)
 		if err != nil {
 			return storageSpec, err

--- a/pkg/hive/table.go
+++ b/pkg/hive/table.go
@@ -27,14 +27,7 @@ type TableProperties struct {
 	External           bool              `json:"external,omitempty"`
 }
 
-func ExecuteCreateTable(queryer db.Queryer, params TableParameters, properties TableProperties, dropTable bool) error {
-	if dropTable {
-		err := ExecuteDropTable(queryer, params.Name, true)
-		if err != nil {
-			return err
-		}
-	}
-
+func ExecuteCreateTable(queryer db.Queryer, params TableParameters, properties TableProperties) error {
 	query := generateCreateTableSQL(params, properties)
 	_, err := queryer.Query(query)
 	return err


### PR DESCRIPTION
Refactors create table logic and removes the dropTable portion since
it's possible to do separately and many createTable calls don't want to
drop the table. Since most commonly dropping a table happens for
reports, the generateReport method has options for both dropTable and
deleting existing data.