### PR TITLE
Makefile: allow customization of base image url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,15 @@ CGO_ENABLED = 0
 
 CHARGEBACK_BIN_OUT = images/chargeback/bin/chargeback
 
-CHARGEBACK_HELM_OPERATOR_IMAGE := quay.io/coreos/chargeback-helm-operator
-CHARGEBACK_IMAGE := quay.io/coreos/chargeback
-HELM_OPERATOR_IMAGE := quay.io/coreos/helm-operator
-HADOOP_IMAGE := quay.io/coreos/chargeback-hadoop
-HIVE_IMAGE := quay.io/coreos/chargeback-hive
-PRESTO_IMAGE := quay.io/coreos/chargeback-presto
-CODEGEN_IMAGE := quay.io/coreosinc/chargeback-codegen
-CHARGEBACK_INTEGRATION_TESTS_IMAGE := quay.io/coreos/chargeback-integration-tests
+DOCKER_BASE_URL := quay.io/coreos
+
+CHARGEBACK_HELM_OPERATOR_IMAGE := $(DOCKER_BASE_URL)/chargeback-helm-operator
+CHARGEBACK_IMAGE := $(DOCKER_BASE_URL)/chargeback
+HELM_OPERATOR_IMAGE := $(DOCKER_BASE_URL)/helm-operator
+HADOOP_IMAGE := $(DOCKER_BASE_URL)/chargeback-hadoop
+HIVE_IMAGE := $(DOCKER_BASE_URL)/chargeback-hive
+PRESTO_IMAGE := $(DOCKER_BASE_URL)/chargeback-presto
+CHARGEBACK_INTEGRATION_TESTS_IMAGE := $(DOCKER_BASE_URL)/chargeback-integration-tests
 
 GIT_SHA    := $(shell git rev-parse HEAD)
 GIT_TAG    := $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)


### PR DESCRIPTION
As part of my testing environment for work on the containers, I've created repos under my own name on Quay so that I have a little more room to breathe. This makefile change lets me build and push these images in an easy fashion.

(My eventual goal here is a three-liner to `docker-build-all`, `docker-push-all`, and template a custom values file that contains the images by sha so I can iterate on the image install as quickly as possible.)