### PR TITLE
Improve jenkins flexibility

### DIFF
--- a/jenkins/main.groovy
+++ b/jenkins/main.groovy
@@ -40,7 +40,16 @@ pipeline {
     }
 
     stages {
+        stage('Setup') {
+            steps {
+                script {
+                    if (isPullRequest) {
+                        echo "Github PR labels: ${pullRequest.labels.join(',')}"
+                    }
+                }
+            }
 
+        }
         stage('Build') {
             when {
                 expression {

--- a/jenkins/main.groovy
+++ b/jenkins/main.groovy
@@ -5,6 +5,10 @@ def skipBuildLabel = (isPullRequest && pullRequest.labels.contains("skip-build")
 def skipE2ELabel = (isPullRequest && pullRequest.labels.contains("skip-e2e"))
 def skipIntegrationLabel = (isPullRequest && pullRequest.labels.contains("skip-integration"))
 
+def skipTectonic = (isPullRequest && pullRequest.labels.contains("skip-tectonic"))
+def skipOpenshift = (isPullRequest && pullRequest.labels.contains("skip-openshift"))
+def skipGke = (isPullRequest && pullRequest.labels.contains("skip-gke"))
+
 pipeline {
     agent none
     parameters {
@@ -55,23 +59,23 @@ pipeline {
                 stage("integration") {
                     when {
                         expression {
-                            return params.INTEGRATION && !(skipBuildLabel || skipIntegrationLabel)
+                            return params.INTEGRATION && !skipIntegrationLabel
                         }
                     }
                     steps {
                         echo "Running metering integration tests"
                         build job: "metering/operator-metering-integration/${env.TARGET_BRANCH}", parameters: [
                             string(name: 'DEPLOY_TAG', value: env.TARGET_BRANCH),
-                            booleanParam(name: 'GENERIC', value: params.GENERIC),
-                            booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT),
-                            booleanParam(name: 'TECTONIC', value: params.TECTONIC),
+                            booleanParam(name: 'GENERIC', value: params.GENERIC && !skipGke),
+                            booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT && !skipOpenshift),
+                            booleanParam(name: 'TECTONIC', value: params.TECTONIC && !skipTectonic),
                         ]
                     }
                 }
                 stage("e2e") {
                     when {
                         expression {
-                            return params.E2E && !(skipBuildLabel || skipE2ELabel)
+                            return params.E2E && !skipE2ELabel
 
                         }
                     }
@@ -79,9 +83,9 @@ pipeline {
                         echo "Running metering e2e tests"
                         build job: "metering/operator-metering-e2e/${env.TARGET_BRANCH}", parameters: [
                             string(name: 'DEPLOY_TAG', value: env.TARGET_BRANCH),
-                            booleanParam(name: 'GENERIC', value: params.GENERIC),
-                            booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT),
-                            booleanParam(name: 'TECTONIC', value: params.TECTONIC),
+                            booleanParam(name: 'GENERIC', value: params.GENERIC && !skipGke),
+                            booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT && !skipOpenshift),
+                            booleanParam(name: 'TECTONIC', value: params.TECTONIC && !skipTectonic),
                         ]
                     }
                 }

--- a/jenkins/main.groovy
+++ b/jenkins/main.groovy
@@ -48,7 +48,6 @@ pipeline {
                     }
                 }
             }
-
         }
         stage('Build') {
             when {
@@ -74,7 +73,7 @@ pipeline {
                     steps {
                         echo "Running metering integration tests"
                         build job: "metering/operator-metering-integration/${env.TARGET_BRANCH}", parameters: [
-                            string(name: 'DEPLOY_TAG', value: env.TARGET_BRANCH),
+                            string(name: 'DEPLOY_TAG', value: skipBuildLabel ? "master" : env.TARGET_BRANCH),
                             booleanParam(name: 'GENERIC', value: params.GENERIC && !skipGke),
                             booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT && !skipOpenshift),
                             booleanParam(name: 'TECTONIC', value: params.TECTONIC && !skipTectonic),
@@ -85,13 +84,12 @@ pipeline {
                     when {
                         expression {
                             return params.E2E && !skipE2ELabel
-
                         }
                     }
                     steps {
                         echo "Running metering e2e tests"
                         build job: "metering/operator-metering-e2e/${env.TARGET_BRANCH}", parameters: [
-                            string(name: 'DEPLOY_TAG', value: env.TARGET_BRANCH),
+                            string(name: 'DEPLOY_TAG', value: skipBuildLabel ? "master" : env.TARGET_BRANCH),
                             booleanParam(name: 'GENERIC', value: params.GENERIC && !skipGke),
                             booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT && !skipOpenshift),
                             booleanParam(name: 'TECTONIC', value: params.TECTONIC && !skipTectonic),

--- a/jenkins/main.groovy
+++ b/jenkins/main.groovy
@@ -3,6 +3,7 @@ def isMasterBranch = env.BRANCH_NAME == "master"
 
 def skipBuildLabel = (isPullRequest && pullRequest.labels.contains("skip-build"))
 def skipE2ELabel = (isPullRequest && pullRequest.labels.contains("skip-e2e"))
+def skipIntegrationLabel = (isPullRequest && pullRequest.labels.contains("skip-integration"))
 
 pipeline {
     agent none
@@ -54,7 +55,7 @@ pipeline {
                 stage("integration") {
                     when {
                         expression {
-                            return params.INTEGRATION && !(skipBuildLabel || skipE2ELabel)
+                            return params.INTEGRATION && !(skipBuildLabel || skipIntegrationLabel)
                         }
                     }
                     steps {

--- a/jenkins/vars/testRunner.groovy
+++ b/jenkins/vars/testRunner.groovy
@@ -59,8 +59,8 @@ spec:
             OUTPUT_TEST_LOG_STDOUT      = "true"
             OUTPUT_DIR                  = "test_output"
             METERING_CREATE_PULL_SECRET = "true"
-            // use the OVERRIDE_NAMESPACE if specified, otherwise set namespace to prefix + DEPLOY_TAG
-            METERING_NAMESPACE          = "${params.OVERRIDE_NAMESPACE ?: "metering-ci2-${pipelineParams.testType}-${env.DEPLOY_TAG}"}"
+            // use the OVERRIDE_NAMESPACE if specified, otherwise set namespace to prefix + BRANCH_NAME
+            METERING_NAMESPACE          = "${params.OVERRIDE_NAMESPACE ?: "metering-ci2-${pipelineParams.testType}-${env.BRANCH_NAME}"}"
             SCRIPT                      = "${pipelineParams.testScript}"
             TEST_LOG_FILE               = "${pipelineParams.testType}-tests.log"
             TEST_TAP_FILE               = "${pipelineParams.testType}-tests.tap"


### PR DESCRIPTION
Allow skipping specific platforms for e2e/integration tests, and print the PR labels at the beginning of the main job.