### PR TITLE
pkg/chargeback: Always format outputs using decimals for floats

### DIFF
--- a/pkg/chargeback/http.go
+++ b/pkg/chargeback/http.go
@@ -332,12 +332,12 @@ func writeResultsAsCSV(columns []api.ReportGenerationQueryColumn, results []pres
 				vals[i] = v
 			case []byte:
 				vals[i] = string(v)
-			case uint, uint8, uint16, uint32, uint64,
-				int, int8, int16, int32, int64,
-				float32, float64,
-				complex64, complex128,
-				bool:
-				vals[i] = fmt.Sprintf("%v", v)
+			case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64:
+				vals[i] = fmt.Sprintf("%d", v)
+			case float32, float64, complex64, complex128:
+				vals[i] = fmt.Sprintf("%f", v)
+			case bool:
+				vals[i] = fmt.Sprintf("%t", v)
 			case time.Time:
 				vals[i] = v.String()
 			case nil:


### PR DESCRIPTION
%v would delegate to %g for floats meaning scientific notation is used
for the display when the number is large enough or small enough. This
forces %f for floats causing decimal representation to be used with
default precision.