### PR TITLE
Improve memory usage

### DIFF
--- a/pkg/chargeback/prestostore/prometheusmetric.go
+++ b/pkg/chargeback/prestostore/prometheusmetric.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/operator-framework/operator-metering/pkg/presto"
@@ -15,6 +16,13 @@ const (
 	// before Presto will error due to the payload being too large.
 	prestoQueryCap = 1000000
 )
+
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		// capacity prestoQueryCap, length 0
+		return bytes.NewBuffer(make([]byte, 0, prestoQueryCap))
+	},
+}
 
 // PrometheusMetric is a receipt of a usage determined by a query within a specific time range.
 type PrometheusMetric struct {
@@ -27,8 +35,9 @@ type PrometheusMetric struct {
 // StorePrometheusMetrics handles storing Prometheus metrics into the specified
 // Presto table.
 func StorePrometheusMetrics(ctx context.Context, execer presto.Execer, tableName string, metrics []*PrometheusMetric) error {
-	// capacity prestoQueryCap, length 0
-	queryBuf := bytes.NewBuffer(make([]byte, 0, prestoQueryCap))
+	queryBuf := bufPool.Get().(*bytes.Buffer)
+	queryBuf.Reset()
+	defer bufPool.Put(queryBuf)
 
 	insertStatementLength := len(presto.FormatInsertQuery(tableName, ""))
 	// calculate the queryCap with the "INSERT INTO $table_name" portion


### PR DESCRIPTION
I noticed after the weekend my metering instance was being OOM killed periodically. I ran a quick pprof profile and found a lot of the allocations happening in StorePrometheusMetrics. The biggest culprit is keeping a slice of strings containing SQL values before writing to our byte.Buffer, so instead remove the slice, and just write to the buffer instead. 

Additionally, since we usually have a few ReportDataSources and worker go routines are running in small batches, re-using the buffers using a sync.Pool should yield some smaller improvements on general allocation, but total in-use memory would probably remain about the same with sync.Pool improvements. 

Finally, reducing the amount of keys returned by the S3 ListObjects API to 200 should reduce allocations and peek usage when an AWS datasource is being updated.