### PR TITLE
Fix image volumes when deploying to Openshift

### DIFF
--- a/charts/hdfs/templates/datanode-statefulset.yaml
+++ b/charts/hdfs/templates/datanode-statefulset.yaml
@@ -87,6 +87,15 @@ spec:
           limits:
             memory: "50Mi"
             cpu: "50m"
+        volumeMounts:
+        - name: hdfs-datanode-data
+          mountPath: /hadoop/dfs/data
+          # we use a subPath to avoid the lost+found directory at the root of
+          # the volume effecting the hdfs formating
+          subPath: hadoop/dfs/data
+        # required for openshift
+        - name: namenode-empty
+          mountPath: /hadoop/dfs/name
         env:
         - name: NAMENODE_HOST
           valueFrom:
@@ -146,7 +155,12 @@ spec:
         volumeMounts:
         - name: hdfs-datanode-data
           mountPath: /hadoop/dfs/data
+          # we use a subPath to avoid the lost+found directory at the root of
+          # the volume effecting the hdfs formating
           subPath: hadoop/dfs/data
+        # required for openshift
+        - name: namenode-empty
+          mountPath: /hadoop/dfs/name
         livenessProbe:
           exec:
             command:
@@ -162,6 +176,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
 {{- end }}
+      volumes:
+      - name: namenode-empty
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: "hdfs-datanode-data"

--- a/charts/hdfs/templates/namenode-statefulset.yaml
+++ b/charts/hdfs/templates/namenode-statefulset.yaml
@@ -135,7 +135,12 @@ spec:
         volumeMounts:
         - name: hdfs-namenode-data
           mountPath: /hadoop/dfs/name
+          # we use a subPath to avoid the lost+found directory at the root of
+          # the volume effecting the hdfs formating
           subPath: hadoop/dfs/name
+        # required for openshift
+        - name: datanode-empty
+          mountPath: /hadoop/dfs/data
         resources:
 {{ toYaml .Values.namenode.resources | indent 10 }}
       serviceAccount: hdfs
@@ -143,6 +148,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
 {{- end }}
+      volumes:
+      - name: datanode-empty
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: "hdfs-namenode-data"

--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -64,20 +64,35 @@ spec:
             resourceFieldRef:
               containerName: metastore
               resource: limits.memory
-{{- if .Values.hive.metastore.storage.create }}
         volumeMounts:
         - name: hive-metastore-db-data
           mountPath: /var/lib/hive
-{{- end }}
+        # openshift requires volumeMounts for VOLUMEs in a Dockerfile
+        - name: hive-warehouse
+          mountPath: /user/hive/warehouse
+        - name: namenode-empty
+          mountPath: /hadoop/dfs/name
+        - name: datanode-empty
+          mountPath: /hadoop/dfs/data
         resources:
 {{ toYaml .Values.hive.metastore.resources | indent 10 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: {{ .Values.hive.terminationGracePeriodSeconds }}
       serviceAccount: hive
-{{- if .Values.hive.metastore.storage.create }}
       volumes:
+      # these emptyDir volumes are necessary because Openshift requires VOLUMEs
+      # in a Dockerfile have a corresponding volumeMount
+      - name: hive-warehouse
+        emptyDir: {}
+      - name: namenode-empty
+        emptyDir: {}
+      - name: datanode-empty
+        emptyDir: {}
       - name: hive-metastore-db-data
+{{- if .Values.hive.metastore.storage.create }}
         persistentVolumeClaim:
-            claimName: hive-metastore-db-data
+          claimName: hive-metastore-db-data
+{{- else }}
+        emptyDir: {}
 {{- end }}

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -68,9 +68,30 @@ spec:
             resourceFieldRef:
               containerName: hiveserver2
               resource: limits.memory
+        volumeMounts:
+        # openshift requires volumeMounts for VOLUMEs in a Dockerfile
+        - name: hive-metastore-db-data
+          mountPath: /var/lib/hive
+        - name: hive-warehouse
+          mountPath: /user/hive/warehouse
+        - name: namenode-empty
+          mountPath: /hadoop/dfs/name
+        - name: datanode-empty
+          mountPath: /hadoop/dfs/data
         resources:
 {{ toYaml .Values.hive.server.resources | indent 10 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: {{ .Values.hive.terminationGracePeriodSeconds }}
       serviceAccount: hive
+      volumes:
+      # these emptyDir volumes are necessary because Openshift requires VOLUMEs
+      # in a Dockerfile have a corresponding volumeMount
+      - name: hive-warehouse
+        emptyDir: {}
+      - name: namenode-empty
+        emptyDir: {}
+      - name: datanode-empty
+        emptyDir: {}
+      - name: hive-metastore-db-data
+        emptyDir: {}

--- a/images/hadoop/datanode-entrypoint.sh
+++ b/images/hadoop/datanode-entrypoint.sh
@@ -2,7 +2,7 @@
 
 datadir=/hadoop/dfs/data
 if [ ! -d $datadir ]; then
-  echo "Datanode data directory not found: $dataedir"
+  echo "Datanode data directory not found: $datadir"
   exit 2
 fi
 


### PR DESCRIPTION
Openshift requires volumes exposed in a image have mounts in the pod,
otherwise docker will try to create the empty dir volume and fail.
Related to https://github.com/openshift/origin/issues/16211#issuecomment-350819976