### PR TITLE
Allow passing existing secret with AWS credentials instead of creating a new one

### DIFF
--- a/charts/metering-operator/templates/metering-aws-credentials-secrets.yaml
+++ b/charts/metering-operator/templates/metering-aws-credentials-secrets.yaml
@@ -1,12 +1,18 @@
+{{- if .Values.config.createAwsCredentialsSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: metering-secrets
+  name: metering-aws-credentials-secrets
   labels:
     app: metering
 {{- block "extraMetadata" . }}
 {{- end }}
 type: Opaque
 data:
+{{- if .Values.config.awsAccessKeyID }}
   aws-access-key-id: {{ .Values.config.awsAccessKeyID | b64enc | quote}}
+{{- end}}
+{{- if .Values.config.awsSecretAccessKey }}
   aws-secret-access-key: {{ .Values.config.awsSecretAccessKey | b64enc | quote}}
+{{- end}}
+{{- end -}}

--- a/charts/metering-operator/templates/metering-deployment.yaml
+++ b/charts/metering-operator/templates/metering-deployment.yaml
@@ -19,7 +19,9 @@ spec:
 {{- end }}
       annotations:
         metering-config-hash: {{ include (print $.Template.BasePath "/metering-config.yaml") . | sha256sum }}
-        metering-secrets-hash: {{ include (print $.Template.BasePath "/metering-secrets.yaml") . | sha256sum }}
+{{- if .Values.config.createAwsCredentialsSecret }}
+        metering-aws-credentials-secrets-hash: {{ include (print $.Template.BasePath "/metering-aws-credentials-secrets.yaml") . | sha256sum }}
+{{- end }}
 {{- if .Values.annotations }}
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
@@ -38,12 +40,12 @@ spec:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              name: metering-secrets
+              name: "{{ .Values.config.awsCredentialsSecretName }}"
               key: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: metering-secrets
+              name: "{{ .Values.config.awsCredentialsSecretName }}"
               key: aws-secret-access-key
         - name: CHARGEBACK_LOG_DML_QUERIES
           valueFrom:

--- a/charts/metering-operator/values.yaml
+++ b/charts/metering-operator/values.yaml
@@ -7,6 +7,8 @@ image:
 config:
   awsAccessKeyID: ""
   awsSecretAccessKey: ""
+  awsCredentialsSecretName: metering-aws-credentials-secrets
+  createAwsCredentialsSecret: true
 
   defaultStorage:
     create: true

--- a/charts/presto/templates/_helpers.tpl
+++ b/charts/presto/templates/_helpers.tpl
@@ -2,13 +2,13 @@
 - name: HIVE_CATALOG_hive_s3_aws___access___key
   valueFrom:
     secretKeyRef:
-      name: presto-secrets
+      name: "{{ .Values.config.awsCredentialsSecretName }}"
       key: aws-access-key-id
       optional: true
 - name: HIVE_CATALOG_hive_s3_aws___secret___key
   valueFrom:
     secretKeyRef:
-      name: presto-secrets
+      name: "{{ .Values.config.awsCredentialsSecretName }}"
       key: aws-secret-access-key
       optional: true
 - name: HIVE_CATALOG_hive_metastore_uri
@@ -91,13 +91,13 @@
 - name: CORE_CONF_fs_s3a_access_key
   valueFrom:
     secretKeyRef:
-      name: presto-secrets
+      name: "{{ .Values.config.awsCredentialsSecretName }}"
       key: aws-access-key-id
       optional: true
 - name: CORE_CONF_fs_s3a_secret_key
   valueFrom:
     secretKeyRef:
-      name: presto-secrets
+      name: "{{ .Values.config.awsCredentialsSecretName }}"
       key: aws-secret-access-key
       optional: true
 - name: HIVE_SITE_CONF_hive_metastore_uris

--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -31,7 +31,9 @@ spec:
         hive-common-configmap-hash: {{ include (print $.Template.BasePath "/hive-common-config.yaml") . | sha256sum }}
         hive-common-secret-hash: {{ include (print $.Template.BasePath "/hive-common-secrets.yaml") . | sha256sum }}
         hive-metastore-configmap-hash: {{ include (print $.Template.BasePath "/hive-metastore-config.yaml") . | sha256sum }}
-        presto-secrets-hash: {{ include (print $.Template.BasePath "/presto-secrets.yaml") . | sha256sum }}
+{{- if .Values.config.createAwsCredentialsSecret }}
+        presto-aws-credentials-secrets-hash: {{ include (print $.Template.BasePath "/presto-aws-credentials-secrets.yaml") . | sha256sum }}
+{{- end }}
 {{- if .Values.hive.annotations }}
 {{ toYaml .Values.hive.annotations | indent 8 }}
 {{- end }}

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -31,7 +31,9 @@ spec:
         hive-common-configmap-hash: {{ include (print $.Template.BasePath "/hive-common-config.yaml") . | sha256sum }}
         hive-common-secret-hash: {{ include (print $.Template.BasePath "/hive-common-secrets.yaml") . | sha256sum }}
         hive-server-configmap-hash: {{ include (print $.Template.BasePath "/hive-server-config.yaml") . | sha256sum }}
-        presto-secrets-hash: {{ include (print $.Template.BasePath "/presto-secrets.yaml") . | sha256sum }}
+{{- if .Values.config.createAwsCredentialsSecret }}
+        presto-aws-credentials-secrets-hash: {{ include (print $.Template.BasePath "/presto-aws-credentials-secrets.yaml") . | sha256sum }}
+{{- end }}
 {{- if .Values.hive.annotations }}
 {{ toYaml .Values.hive.annotations | indent 8 }}
 {{- end }}

--- a/charts/presto/templates/presto-aws-credentials-secrets.yaml
+++ b/charts/presto/templates/presto-aws-credentials-secrets.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.config.createAwsCredentialsSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: presto-secrets
+  name: presto-aws-credentials-secrets
   labels:
     app: presto
 {{- block "extraMetadata" . }}
@@ -14,3 +15,4 @@ data:
 {{- if .Values.config.awsSecretAccessKey }}
   aws-secret-access-key: {{ .Values.config.awsSecretAccessKey | b64enc | quote}}
 {{- end}}
+{{- end -}}

--- a/charts/presto/templates/presto-coordinator-deployment.yaml
+++ b/charts/presto/templates/presto-coordinator-deployment.yaml
@@ -27,7 +27,9 @@ spec:
       annotations:
         presto-coordinator-config-hash: {{ include (print $.Template.BasePath "/presto-coordinator-config.yaml") . | sha256sum }}
         presto-common-config-hash: {{ include (print $.Template.BasePath "/presto-common-config.yaml") . | sha256sum }}
-        presto-secrets-hash: {{ include (print $.Template.BasePath "/presto-secrets.yaml") . | sha256sum }}
+{{- if .Values.config.createAwsCredentialsSecret }}
+        presto-aws-credentials-secrets-hash: {{ include (print $.Template.BasePath "/presto-aws-credentials-secrets.yaml") . | sha256sum }}
+{{- end }}
 {{- if .Values.presto.annotations }}
 {{ toYaml .Values.presto.annotations | indent 8 }}
 {{- end }}

--- a/charts/presto/templates/presto-worker-deployment.yaml
+++ b/charts/presto/templates/presto-worker-deployment.yaml
@@ -27,7 +27,9 @@ spec:
       annotations:
         presto-worker-config-hash: {{ include (print $.Template.BasePath "/presto-worker-config.yaml") . | sha256sum }}
         presto-common-config-hash: {{ include (print $.Template.BasePath "/presto-common-config.yaml") . | sha256sum }}
-        presto-secrets-hash: {{ include (print $.Template.BasePath "/presto-secrets.yaml") . | sha256sum }}
+{{- if .Values.config.createAwsCredentialsSecret }}
+        presto-aws-credentials-secrets-hash: {{ include (print $.Template.BasePath "/presto-aws-credentials-secrets.yaml") . | sha256sum }}
+{{- end }}
 {{- if .Values.presto.annotations }}
 {{ toYaml .Values.presto.annotations | indent 8 }}
 {{- end }}

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -127,4 +127,5 @@ config:
   awsRegion: ""
   awsAccessKeyID: ""
   awsSecretAccessKey: ""
-
+  awsCredentialsSecretName: presto-aws-credentials-secrets
+  createAwsCredentialsSecret: true


### PR DESCRIPTION
This enables us to avoid storing aws credentials in plain text in the metering CRD.
