### PR TITLE
charts: Support exposing metering service via LoadBalancer or NodePort

### DIFF
--- a/charts/metering-operator/templates/metering-service.yaml
+++ b/charts/metering-operator/templates/metering-service.yaml
@@ -22,6 +22,20 @@ spec:
 {{- if and (eq (lower .Values.service.type) "nodeport" "loadbalancer") .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: metering-metrics
+  labels:
+    app: metering
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  selector:
+    app: metering
+  ports:
   - protocol: TCP
     port: 8082
     targetPort: metrics

--- a/charts/metering-operator/templates/metering-service.yaml
+++ b/charts/metering-operator/templates/metering-service.yaml
@@ -4,13 +4,14 @@ metadata:
   name: metering
   labels:
     app: metering
-{{- if .Values.serviceAnnotations }}
+{{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.serviceAnnotations | indent 4 }}
+{{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
 {{- block "extraMetadata" . }}
 {{- end }}
 spec:
+  type: "{{ .Values.service.type }}"
   selector:
     app: metering
   ports:
@@ -18,6 +19,9 @@ spec:
     port: 8080
     targetPort: http
     name: http
+{{- if and (eq (lower .Values.service.type) "nodeport" "loadbalancer") .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
   - protocol: TCP
     port: 8082
     targetPort: metrics

--- a/charts/metering-operator/values.yaml
+++ b/charts/metering-operator/values.yaml
@@ -119,5 +119,7 @@ livenessProbe:
    port: 8080
    scheme: HTTP
 
-annotations: null
-serviceAnnotations: null
+service:
+  annotations: {}
+  type: ClusterIP
+  nodePort: null

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -5,9 +5,9 @@ metering-operator:
       enabled: true
       createSecret: false
       secretName: "metering-tls-secrets"
-  serviceAnnotations:
-    "service.alpha.openshift.io/serving-cert-secret-name": "metering-tls-secrets"
-
+  service:
+    annotations:
+      "service.alpha.openshift.io/serving-cert-secret-name": "metering-tls-secrets"
   image:
     tag: latest
 
@@ -25,4 +25,3 @@ hdfs:
 
   securityContext:
     fsGroup: null
-


### PR DESCRIPTION
Allows specifying the metering service should be created as either a
ClusterIP, NodePort, or LoadBalancer type service. Additionally, if the
type is NodePort or LoadBalancer the NodePort can optionally be specified.