### PR TITLE
charts/metering-operator: Support configuring openshift auth proxy to auth metering service

### DIFF
--- a/charts/metering-operator/templates/metering-auth-proxy-authenticated-emails-secret.yaml
+++ b/charts/metering-operator/templates/metering-auth-proxy-authenticated-emails-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.authProxy.enabled .Values.authProxy.createAuthenticatedEmailsSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.authProxy.authenticatedEmailsSecretName }}
+  labels:
+    app: metering
+{{- block "extraMetadata" . }}
+{{- end }}
+type: Opaque
+data:
+  emails: {{ .Values.authProxy.authenticatedEmailsData | b64enc | quote }}
+{{- end -}}

--- a/charts/metering-operator/templates/metering-auth-proxy-cookie-secret.yaml
+++ b/charts/metering-operator/templates/metering-auth-proxy-cookie-secret.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.authProxy.enabled .Values.authProxy.createCookieSecret -}}
+{{- $_ := required "You must specify a non-empty metering-operator.authProxy.cookieSeed value! It should be a random string at least 32 characters in length." .Values.authProxy.cookieSeed -}}
+{{- if lt (len .Values.authProxy.cookieSeed) 32 -}}
+{{- fail "metering-operator.authProxy.cookieSeed should be a random string at least 32 characters in length." -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.authProxy.cookieSecretName }}
+  labels:
+    app: metering
+{{- block "extraMetadata" . }}
+{{- end }}
+type: Opaque
+data:
+  cookie-secret-seed: {{ .Values.authProxy.cookieSeed | b64enc | quote }}
+{{- end -}}

--- a/charts/metering-operator/templates/metering-auth-proxy-htpasswd-secret.yaml
+++ b/charts/metering-operator/templates/metering-auth-proxy-htpasswd-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.authProxy.enabled .Values.authProxy.createHtpasswdSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.authProxy.htpasswdSecretName }}
+  labels:
+    app: metering
+{{- block "extraMetadata" . }}
+{{- end }}
+type: Opaque
+data:
+  auth: {{ .Values.authProxy.htpasswdData | b64enc | quote }}
+{{- end -}}

--- a/charts/metering-operator/templates/metering-auth-proxy-rbac.yaml
+++ b/charts/metering-operator/templates/metering-auth-proxy-rbac.yaml
@@ -1,0 +1,43 @@
+{{- if and (or .Values.authProxy.subjectAccessReviewEnabled .Values.authProxy.delegateURLsEnabled) .Values.authProxy.createAuthProxyClusterRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metering-auth-proxy
+  labels:
+    app: metering
+{{- block "extraMetadata" . }}
+{{- end }}
+rules:
+{{- if .Values.authProxy.subjectAccessReviewEnabled }}
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}
+{{- if .Values.authProxy.delegateURLsEnabled }}
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metering-auth-proxy
+  labels:
+    app: metering
+{{- block "extraMetadata" . }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metering-auth-proxy
+subjects:
+- kind: ServiceAccount
+  name: metering
+{{- end }}

--- a/charts/metering-operator/templates/metering-config.yaml
+++ b/charts/metering-operator/templates/metering-config.yaml
@@ -18,4 +18,3 @@ data:
   leader-lease-duration: {{ .Values.config.leaderLeaseDuration | quote }}
   presto-host: {{ .Values.config.prestoHost | quote }}
   hive-host: {{ .Values.config.hiveHost | quote }}
-  use-tls: {{ .Values.config.tls.enabled | quote }}

--- a/charts/metering-operator/templates/metering-deployment.yaml
+++ b/charts/metering-operator/templates/metering-deployment.yaml
@@ -22,6 +22,18 @@ spec:
 {{- if .Values.config.createAwsCredentialsSecret }}
         metering-aws-credentials-secrets-hash: {{ include (print $.Template.BasePath "/metering-aws-credentials-secrets.yaml") . | sha256sum }}
 {{- end }}
+{{- if and .Values.config.tls.enabled .Values.config.tls.createSecret }}
+        metering-tls-secrets-hash: {{ include (print $.Template.BasePath "/metering-tls-secrets.yaml") . | sha256sum }}
+{{- end }}
+{{- if and .Values.authProxy.enabled .Values.authProxy.createCookieSecret }}
+        metering-auth-proxy-cookie-secrets-hash: {{ include (print $.Template.BasePath "/metering-auth-proxy-cookie-secret.yaml") . | sha256sum }}
+{{- end }}
+{{- if and .Values.authProxy.enabled .Values.authProxy.createHtpasswdSecret }}
+        metering-auth-proxy-htpasswd-secrets-hash: {{ include (print $.Template.BasePath "/metering-auth-proxy-htpasswd-secret.yaml") . | sha256sum }}
+{{- end }}
+{{- if and .Values.authProxy.enabled .Values.authProxy.createAuthenticatedEmailsSecret }}
+        metering-auth-proxy-authenticated-emails-secrets-hash: {{ include (print $.Template.BasePath "/metering-auth-proxy-authenticated-emails-secret.yaml") . | sha256sum }}
+{{- end }}
 {{- if .Values.annotations }}
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
@@ -104,15 +116,18 @@ spec:
             configMapKeyRef:
               name: metering-config
               key: leader-lease-duration
+{{/* If authProxy is enabled we do not enable TLS on the metering operator since the proxy will do TLS */}}
+{{- if and .Values.config.tls.enabled (not .Values.authProxy.enabled) }}
         - name: CHARGEBACK_USE_TLS
-          valueFrom:
-            configMapKeyRef:
-              name: metering-config
-              key: use-tls
+          value: "true"
         - name: CHARGEBACK_TLS_KEY
           value: "/tls/tls.key"
         - name: CHARGEBACK_TLS_CERT
           value: "/tls/tls.crt"
+{{- else }}
+        - name: CHARGEBACK_USE_TLS
+          value: "false"
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
@@ -122,7 +137,7 @@ spec:
           containerPort: 6060
         - name: "metrics"
           containerPort: 8082
-{{- if .Values.config.tls.enabled -}}
+{{- if and .Values.config.tls.enabled (not .Values.authProxy.enabled) -}}
 {{- $_ := set .Values.readinessProbe.httpGet "scheme" "HTTPS" -}}
 {{- $_ := set .Values.livenessProbe.httpGet "scheme" "HTTPS" -}}
 {{- end }}
@@ -130,16 +145,75 @@ spec:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 10 }}
-{{- if .Values.config.tls.enabled }}
+{{- if and .Values.config.tls.enabled (not .Values.authProxy.enabled) }}
         volumeMounts:
         - name: tls
           mountPath: /tls
 {{- end }}
-{{- if .Values.config.tls.enabled }}
+{{- if .Values.authProxy.enabled }}
+      - name: metering-auth-proxy
+        image: "{{ .Values.authProxy.image.repository }}:{{ .Values.authProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
+        args:
+        - -provider=openshift
+        - -https-address=:8081
+        - -http-address=
+        - -upstream=http://localhost:8080
+        - -htpasswd-file=/etc/proxy/htpasswd/auth
+        - -tls-cert=/etc/tls/tls.crt
+        - -tls-key=/etc/tls/tls.key
+        - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - -cookie-secret-file=/etc/proxy/cookie-secret/cookie-secret-seed
+        - -request-logging=true
+        - -openshift-ca=/etc/pki/tls/cert.pem
+        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -openshift-service-account=metering
+{{- if .Values.authProxy.authenticatedEmailsEnabled }}
+        - -authenticated-emails-file=/etc/proxy/authenticated-emails/emails
+{{- else }}
+        - -email-domain=*
+{{- end }}
+{{- if .Values.authProxy.subjectAccessReviewEnabled }}
+        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+{{- end }}
+{{- if .Values.authProxy.delegateURLsEnabled }}
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+{{- end }}
+        ports:
+        - name: auth-proxy
+          containerPort: 8081
+        resources:
+{{ toYaml .Values.authProxy.resources | indent 10 }}
+        volumeMounts:
+        - mountPath: /etc/tls
+          name: tls
+        - mountPath: /etc/proxy/cookie-secret
+          name: cookie-secret
+        - mountPath: /etc/proxy/htpasswd
+          name: htpasswd-secret
+{{- if .Values.authProxy.authenticatedEmailsEnabled  }}
+        - mountPath: /etc/proxy/authenticated-emails
+          name: authenticated-emails-secret
+{{- end }}
+{{- end }}
       volumes:
+{{- if .Values.config.tls.enabled }}
       - name: tls
         secret:
           secretName: {{ .Values.config.tls.secretName }}
+{{- end }}
+{{- if .Values.authProxy.enabled }}
+      - name: cookie-secret
+        secret:
+          secretName: {{ .Values.authProxy.cookieSecretName }}
+      - name: htpasswd-secret
+        secret:
+          secretName: {{ .Values.authProxy.htpasswdSecretName }}
+{{- if .Values.authProxy.authenticatedEmailsEnabled  }}
+      - name: authenticated-emails-secret
+        secret:
+          secretName: {{ .Values.authProxy.authenticatedEmailsSecretName }}
+{{- end }}
 {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 30

--- a/charts/metering-operator/templates/metering-rbac.yaml
+++ b/charts/metering-operator/templates/metering-rbac.yaml
@@ -2,7 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: metering-admin
+  name: metering-operator
+  labels:
+    app: metering
+{{- block "extraMetadata" . }}
+{{- end }}
 rules:
 - apiGroups: ["chargeback.coreos.com"]
   resources: ["*"]
@@ -43,16 +47,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: metering-admin
+  name: metering-operator
 subjects:
 - kind: ServiceAccount
   name: metering
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: metering
-  labels:
-    app: metering
-{{- block "extraMetadata" . }}
-{{- end }}

--- a/charts/metering-operator/templates/metering-service.yaml
+++ b/charts/metering-operator/templates/metering-service.yaml
@@ -15,10 +15,14 @@ spec:
   selector:
     app: metering
   ports:
-  - protocol: TCP
+  - name: http
+    protocol: TCP
     port: 8080
+{{- if .Values.authProxy.enabled }}
+    targetPort: auth-proxy
+{{- else }}
     targetPort: http
-    name: http
+{{- end }}
 {{- if and (eq (lower .Values.service.type) "nodeport" "loadbalancer") .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/charts/metering-operator/templates/metering-serviceaccount.yaml
+++ b/charts/metering-operator/templates/metering-serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metering
+  labels:
+    app: metering
+{{- if and .Values.authProxy.enabled .Values.route.enabled }}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.metering: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{ .Values.route.name }}"}}'
+{{- end }}
+{{- block "extraMetadata" . }}
+{{- end }}

--- a/charts/metering-operator/templates/route.yaml
+++ b/charts/metering-operator/templates/route.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Values.route.name }}
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  port:
+    targetPort: http
+  tls:
+    termination: Reencrypt
+  to:
+    kind: Service
+    name: metering
+{{- end }}

--- a/charts/metering-operator/values.yaml
+++ b/charts/metering-operator/values.yaml
@@ -123,3 +123,40 @@ service:
   annotations: {}
   type: ClusterIP
   nodePort: null
+
+route:
+  enabled: false
+  name: metering
+
+authProxy:
+  enabled: false
+  image:
+    repository: openshift/oauth-proxy
+    tag: v1.1.0
+    pullPolicy: Always
+
+  htpasswdSecretName: metering-auth-proxy-htpasswd
+  createHtpasswdSecret: true
+  htpasswdData: ""
+
+  cookieSecretName: metering-auth-proxy-cookie-seed
+  createCookieSecret: true
+  cookieSeed: ""
+
+  createAuthProxyClusterRole: false
+  subjectAccessReviewEnabled: false
+  delegateURLsEnabled: false
+
+  authenticatedEmailsSecretName: metering-auth-proxy-authenticated-emails
+  authenticatedEmailsEnabled: false
+  createAuthenticatedEmailsSecret: true
+  authenticatedEmailsData: ""
+
+
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "50m"
+    limits:
+      memory: "50Mi"
+      cpu: "50m"

--- a/manifests/deploy/common-helm-operator-values.yaml
+++ b/manifests/deploy/common-helm-operator-values.yaml
@@ -164,3 +164,14 @@ rbac:
     - patch
     - update
     - watch
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - delete

--- a/manifests/deploy/generic/alm/metering.0.6.1-latest.clusterserviceversion.yaml
+++ b/manifests/deploy/generic/alm/metering.0.6.1-latest.clusterserviceversion.yaml
@@ -170,6 +170,17 @@ spec:
             - patch
             - update
             - watch
+          - apiGroups:
+            - route.openshift.io
+            resources:
+            - routes
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - update
+            - delete
           serviceAccountName: metering-helm-operator
       deployments:
         - name: metering-helm-operator

--- a/manifests/deploy/generic/helm-operator/metering-helm-operator-role.yaml
+++ b/manifests/deploy/generic/helm-operator/metering-helm-operator-role.yaml
@@ -142,3 +142,14 @@ rules:
     - patch
     - update
     - watch
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - delete

--- a/manifests/deploy/openshift/alm/metering.0.6.1-latest.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/alm/metering.0.6.1-latest.clusterserviceversion.yaml
@@ -170,6 +170,17 @@ spec:
             - patch
             - update
             - watch
+          - apiGroups:
+            - route.openshift.io
+            resources:
+            - routes
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - update
+            - delete
           serviceAccountName: metering-helm-operator
       deployments:
         - name: metering-helm-operator

--- a/manifests/deploy/openshift/helm-operator/metering-helm-operator-role.yaml
+++ b/manifests/deploy/openshift/helm-operator/metering-helm-operator-role.yaml
@@ -142,3 +142,14 @@ rules:
     - patch
     - update
     - watch
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - delete

--- a/manifests/deploy/tectonic/alm/metering.0.6.1-latest.clusterserviceversion.yaml
+++ b/manifests/deploy/tectonic/alm/metering.0.6.1-latest.clusterserviceversion.yaml
@@ -170,6 +170,17 @@ spec:
             - patch
             - update
             - watch
+          - apiGroups:
+            - route.openshift.io
+            resources:
+            - routes
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - update
+            - delete
           serviceAccountName: metering-helm-operator
       deployments:
         - name: metering-helm-operator

--- a/manifests/deploy/tectonic/helm-operator/metering-helm-operator-role.yaml
+++ b/manifests/deploy/tectonic/helm-operator/metering-helm-operator-role.yaml
@@ -142,3 +142,14 @@ rules:
     - patch
     - update
     - watch
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - delete


### PR DESCRIPTION
Adds a set of configuration options for adding an extra sidecar
container to the metering pod which is responsible for authenticating
incoming requests to the metering pod and proxying them to the metering
operator container. The auth proxy uses openshift service accounts for
auth and requires that the service account has namespace access to be
allowed to access the metering API. To enable verification of
permissions metering-operator.authProxy.subjectAccessReviewEnabled must
be enabled and the metering service account must have permissions to
create SubjectAccessReview resources (requires a ClusterRole and
ClusterRoleBinding). Currently the metering-helm-operator has support
for creating these RBAC resources, but requires these permissons itself,
which is not yet supported.