### PR TITLE
CentOS based Docker images

### DIFF
--- a/images/chargeback/Dockerfile
+++ b/images/chargeback/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine
+FROM centos:7
 
-RUN apk update
-RUN apk add ca-certificates bash
+RUN yum install ca-certificates bash
 # add pod data collector binary
 ADD ./bin/chargeback /usr/local/bin/chargeback
 

--- a/images/hadoop/Dockerfile
+++ b/images/hadoop/Dockerfile
@@ -1,21 +1,21 @@
-FROM openjdk:8-slim
-
-ENV DEBIAN_FRONTEND noninteractive
+FROM centos:7
 
 RUN \
-    apt-get update \
-    && apt-get install -y --no-install-recommends \
+    yum install epel-release -y \
+    && yum install -y \
+        java-1.8.0-openjdk \
         curl \
         less  \
         perl \
         procps \
         net-tools \
-        dnsutils \
+        bind-utils \
+        which \
         jq \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && yum clean all \
+    && rm -rf /tmp/* /var/tmp/*
 
-# ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+ENV JAVA_HOME=/etc/alternatives/jre/
 
 ENV HADOOP_VERSION 2.9.1
 ENV HADOOP_URL http://apache.osuosl.org/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz

--- a/images/hadoop/Dockerfile
+++ b/images/hadoop/Dockerfile
@@ -18,7 +18,7 @@ RUN \
 ENV JAVA_HOME=/etc/alternatives/jre/
 
 ENV HADOOP_VERSION 2.9.1
-ENV HADOOP_URL http://apache.osuosl.org/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz
+ENV HADOOP_URL https://apache.osuosl.org/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz
 # The upstream .mds checksum files aren't supported by sha256sum or shasum so
 # this checksum is taken from that file and put here manually.
 ENV HADOOP_SHA256_CHECKSUM eed6015a123644d3b4247bac58770e4a8b31340fa62721987430e15a0dd942fc

--- a/images/helm-operator/Dockerfile
+++ b/images/helm-operator/Dockerfile
@@ -1,9 +1,37 @@
-FROM gcr.io/kubernetes-helm/tiller:v2.6.2
+FROM centos:7 as build
+# CentOS golang build environment based on
+# https://github.com/CentOS/CentOS-Dockerfiles/blob/master/golang/centos7/Dockerfile
+
+RUN yum -y update && yum clean all
+
+RUN mkdir -p /go && chmod -R 777 /go && \
+    yum -y install epel-release && yum -y install hg git golang glide && yum group install -y "Development Tools"
+RUN yum clean all && rm -rf /var/cache/yum
+
+ENV HELM_VERSION 2.6.2
+ENV GOPATH /go
+
+WORKDIR /go/src/k8s.io/helm
+RUN git clone https://github.com/helm/helm.git . && git checkout v${HELM_VERSION}
+
+RUN go get github.com/golang/protobuf/proto
+RUN make bootstrap build
+RUN make docker-binary
+
+FROM centos:7
+
+COPY --from=build /go/src/k8s.io/helm/rootfs/tiller .
 
 ENV KUBERNETES_VERSION 1.8.3
 ENV HELM_VERSION 2.6.2
 
-RUN apk add --no-cache curl bash jq
+USER root
+
+RUN yum install -y epel-release \
+    && yum install -y curl bash jq ca-certificates socat
+
+EXPOSE 44134
+
 RUN curl \
     --silent \
     --show-error \
@@ -27,6 +55,8 @@ COPY run-operator.sh /usr/local/bin/run-operator.sh
 COPY get_owner.sh /usr/local/bin/get_owner.sh
 
 ENV HELM_HOST 127.0.0.1:44134
+
+ENV HOME /tmp
 
 CMD ["run-operator.sh"]
 

--- a/images/hive/Dockerfile
+++ b/images/hive/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /opt
 USER root
 # Install Hive
 RUN set -x \
-    && curl -fSLs http://apache.osuosl.org/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz | tar -xz && mv apache-hive-$HIVE_VERSION-bin hive
+    && curl -fSLs https://apache.osuosl.org/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz | tar -xz && mv apache-hive-$HIVE_VERSION-bin hive
 
 ENV HADOOP_CLASSPATH /opt/hive/hcatalog/share/hcatalog/*:${HADOOP_CLASSPATH}
 ENV HIVE_AUX_JARS_PATH /usr/hdp/current/hive-server2/auxlib

--- a/images/presto/Dockerfile
+++ b/images/presto/Dockerfile
@@ -27,7 +27,7 @@ RUN useradd presto -u 1003 -d /opt/presto
 
 # install presto server
 RUN set -x \
-    && curl -fSLs -o /tmp/presto.tar.gz http://repo1.maven.org/maven2/com/facebook/presto/presto-server/$PRESTO_VERSION/presto-server-$PRESTO_VERSION.tar.gz \
+    && curl -fSLs -o /tmp/presto.tar.gz https://repo1.maven.org/maven2/com/facebook/presto/presto-server/$PRESTO_VERSION/presto-server-$PRESTO_VERSION.tar.gz \
     && mkdir -p /opt/presto \
     && tar -zxf /tmp/presto.tar.gz -C /opt/presto \
     && rm /tmp/presto.tar.gz

--- a/images/presto/Dockerfile
+++ b/images/presto/Dockerfile
@@ -1,18 +1,17 @@
-FROM openjdk:8-slim
-
-ENV DEBIAN_FRONTEND noninteractive
+FROM centos:7
 
 RUN \
-    apt-get update \
-    && apt-get install -y --no-install-recommends \
+    yum install -y \
+        java-1.8.0-openjdk \
         curl \
         less  \
         gpg \
         python \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+        perl \
+    && yum clean all \
+    && rm -rf /tmp/* /var/tmp/*
 
-# ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+ENV JAVA_HOME=/etc/alternatives/jre/
 
 ENV PRESTO_VERSION 0.202
 ENV PRESTO_HOME /opt/presto/presto-server-$PRESTO_VERSION


### PR DESCRIPTION
As part of preparing metering for use in Openshift Origin, we need to use a CentOS base for our images. For now, this is a pretty simple transform of deps, but in the future we'll need to rely less on `curl`ing binaries and `git clone`ing inside the build step.

Also, I swapped `http` mirror urls to `https` while I was in there.

https://jira.coreos.com/browse/MC-197 