### PR TITLE
Optimize helm-operator build process

### DIFF
--- a/images/helm-operator/Dockerfile
+++ b/images/helm-operator/Dockerfile
@@ -5,7 +5,7 @@ FROM centos:7 as build
 RUN yum -y update && yum clean all
 
 RUN mkdir -p /go && chmod -R 777 /go && \
-    yum -y install epel-release && yum -y install hg git golang glide && yum group install -y "Development Tools"
+    yum -y install epel-release && yum -y install protobuf hg git golang glide make
 RUN yum clean all && rm -rf /var/cache/yum
 
 ENV HELM_VERSION 2.6.2
@@ -14,13 +14,18 @@ ENV GOPATH /go
 WORKDIR /go/src/k8s.io/helm
 RUN git clone https://github.com/helm/helm.git . && git checkout v${HELM_VERSION}
 
-RUN go get github.com/golang/protobuf/proto
-RUN make bootstrap build
+RUN glide install --strip-vendor \
+    && go build -o bin/protoc-gen-go ./vendor/github.com/golang/protobuf/protoc-gen-go \
+    && scripts/setup-apimachinery.sh
+# build tiller (in later Helm versions, this will build both binaries)
 RUN make docker-binary
+# build helm
+RUN make build
 
 FROM centos:7
 
 COPY --from=build /go/src/k8s.io/helm/rootfs/tiller .
+COPY --from=build /go/src/k8s.io/helm/bin/helm /usr/local/bin
 
 ENV KUBERNETES_VERSION 1.8.3
 ENV HELM_VERSION 2.6.2
@@ -39,17 +44,6 @@ RUN curl \
     "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl" \
     -o /usr/local/bin/kubectl \
      && chmod +x /usr/local/bin/kubectl
-
-RUN mkdir /tmp/helm \
-    && curl \
-    --silent \
-    --show-error \
-    --location \
-    "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
-    | tar xz -C /tmp/helm \
-    && mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm \
-    && rm -rf /tmp/helm \
-    && chmod +x /usr/local/bin/helm
 
 COPY run-operator.sh /usr/local/bin/run-operator.sh
 COPY get_owner.sh /usr/local/bin/get_owner.sh


### PR DESCRIPTION
Download fewer unnecessary packages for building helm and tiller, and build helm instead of downloading a precompiled version.