### PR TITLE
Fix test flakes when ReportDataSources aren't seen by reporting-operator

### DIFF
--- a/pkg/apis/metering/v1alpha1/report.go
+++ b/pkg/apis/metering/v1alpha1/report.go
@@ -47,8 +47,9 @@ type ReportSpec struct {
 }
 
 type ReportStatus struct {
-	Phase  ReportPhase `json:"phase,omitempty"`
-	Output string      `json:"output,omitempty"`
+	Phase     ReportPhase `json:"phase,omitempty"`
+	Output    string      `json:"output,omitempty"`
+	TableName string      `json:"table_name"`
 }
 
 type ReportPhase string

--- a/pkg/apis/metering/v1alpha1/scheduled_report.go
+++ b/pkg/apis/metering/v1alpha1/scheduled_report.go
@@ -95,6 +95,7 @@ type ScheduledReportScheduleMonthly struct {
 type ScheduledReportStatus struct {
 	Conditions     []ScheduledReportCondition `json:"conditions,omitempty"`
 	LastReportTime *meta.Time                 `json:"lastReportTime,omitempty"`
+	TableName      string                     `json:"table_name"`
 }
 
 type ScheduledReportCondition struct {

--- a/pkg/operator/http.go
+++ b/pkg/operator/http.go
@@ -217,6 +217,10 @@ func (srv *server) getScheduledReport(logger log.FieldLogger, name, format strin
 	// Get the presto table to get actual columns in table
 	prestoTable, err := srv.listers.prestoTables.Get(prestoTableResourceNameFromKind("scheduledreport", report.Name))
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			writeErrorResponse(logger, w, r, http.StatusAccepted, "ScheduledReport is not processed yet")
+			return
+		}
 		logger.WithError(err).Errorf("error getting presto table: %v", err)
 		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting presto table: %v", err)
 		return
@@ -297,6 +301,10 @@ func (srv *server) getReport(logger log.FieldLogger, name, format string, useNew
 	// Get the presto table to get actual columns in table
 	prestoTable, err := srv.listers.prestoTables.Get(prestoTableResourceNameFromKind("report", report.Name))
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			writeErrorResponse(logger, w, r, http.StatusAccepted, "Report is not processed yet")
+			return
+		}
 		logger.WithError(err).Errorf("error getting presto table: %v", err)
 		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting presto table: %v", err)
 		return

--- a/pkg/operator/http.go
+++ b/pkg/operator/http.go
@@ -528,6 +528,10 @@ type CollectPromsumDataRequest struct {
 	EndTime   time.Time `json:"endTime"`
 }
 
+type CollectPromsumDataResponse struct {
+	Results []*prometheusImportResults `json:"results"`
+}
+
 func (srv *server) collectPromsumDataHandler(w http.ResponseWriter, r *http.Request) {
 	logger := newRequestLogger(srv.logger, r, srv.rand)
 
@@ -544,13 +548,15 @@ func (srv *server) collectPromsumDataHandler(w http.ResponseWriter, r *http.Requ
 
 	logger.Debugf("collecting promsum data between %s and %s", start.Format(time.RFC3339), end.Format(time.RFC3339))
 
-	err = srv.collectorFunc(context.Background(), start, end)
+	results, err := srv.collectorFunc(context.Background(), start, end)
 	if err != nil {
 		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to collect prometheus data: %v", err)
 		return
 	}
 
-	writeResponseAsJSON(logger, w, http.StatusOK, struct{}{})
+	writeResponseAsJSON(logger, w, http.StatusOK, CollectPromsumDataResponse{
+		Results: results,
+	})
 }
 
 type StorePromsumDataRequest []*prestostore.PrometheusMetric

--- a/pkg/operator/http_test.go
+++ b/pkg/operator/http_test.go
@@ -30,8 +30,8 @@ import (
 var (
 	testRandSeed               = rand.NewSource(0)
 	testRand                   = rand.New(testRandSeed)
-	noopPrometheusImporterFunc = func(ctx context.Context, start, end time.Time) error {
-		return nil
+	noopPrometheusImporterFunc = func(ctx context.Context, start, end time.Time) ([]*prometheusImportResults, error) {
+		return nil, nil
 	}
 	testLogger = logrus.New()
 )

--- a/pkg/operator/scheduled_reports.go
+++ b/pkg/operator/scheduled_reports.go
@@ -289,6 +289,13 @@ func (job *scheduledReportJob) start(logger log.FieldLogger) {
 			return
 		}
 
+		report.Status.TableName = tableName
+		report, err = job.operator.meteringClient.MeteringV1alpha1().ScheduledReports(job.report.Namespace).Update(report)
+		if err != nil {
+			logger.WithError(err).Errorf("unable to update scheduledReport status with tableName")
+			return
+		}
+
 		now := job.operator.clock.Now().UTC()
 		var lastScheduled time.Time
 		lastReportTime := report.Status.LastReportTime
@@ -359,9 +366,7 @@ func (job *scheduledReportJob) start(logger log.FieldLogger) {
 				tableName,
 				reportPeriod.periodStart,
 				reportPeriod.periodEnd,
-				job.report.Spec.Output,
 				genQuery,
-				false,
 				job.report.Spec.OverwriteExistingData,
 			)
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -2,16 +2,48 @@ package e2e
 
 import (
 	"flag"
+	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"github.com/operator-framework/operator-metering/test/framework"
 )
 
-var testFramework *framework.Framework
+var (
+	testFramework *framework.Framework
+
+	reportTestTimeout         = 5 * time.Minute
+	reportTestOutputDirectory string
+	runAWSBillingTests        bool
+
+	periodStart, periodEnd time.Time
+)
+
+func init() {
+	if reportTestTimeoutStr := os.Getenv("REPORT_TEST_TIMEOUT"); reportTestTimeoutStr != "" {
+		var err error
+		reportTestTimeout, err = time.ParseDuration(reportTestTimeoutStr)
+		if err != nil {
+			log.Fatalf("Invalid REPORT_TEST_TIMEOUT: %v", err)
+		}
+	}
+	reportTestOutputDirectory = os.Getenv("TEST_RESULT_REPORT_OUTPUT_DIRECTORY")
+	if reportTestOutputDirectory == "" {
+		log.Fatalf("$TEST_RESULT_REPORT_OUTPUT_DIRECTORY must be set")
+	}
+
+	err := os.MkdirAll(reportTestOutputDirectory, 0777)
+	if err != nil {
+		log.Fatalf("error making directory %s, err: %s", reportTestOutputDirectory, err)
+	}
+
+	runAWSBillingTests = os.Getenv("ENABLE_AWS_BILLING_TESTS") == "true"
+}
 
 func TestMain(m *testing.M) {
 	kubeconfig := flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
@@ -25,4 +57,38 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
+}
+
+func TestReportingE2E(t *testing.T) {
+	t.Run("TestReportingProducesResults", func(t *testing.T) {
+		// validate all the ReportDataSources for our tests exist before running
+		// collect
+		for _, test := range reportsProduceDataTestCases {
+			if test.skip {
+				continue
+			}
+			reportGenQuery, err := testFramework.WaitForMeteringReportGenerationQuery(t, test.queryName, time.Second*5, test.timeout)
+			require.NoError(t, err, "ReportGenerationQuery should exist before creating report using it")
+
+			for _, datasourceName := range reportGenQuery.Spec.DataSources {
+				_, err := testFramework.WaitForMeteringReportDataSourceTable(t, datasourceName, time.Second*5, test.timeout)
+				require.NoError(t, err, "ReportDataSource %s table for ReportGenerationQuery %s should exist before running reports against it", datasourceName, test.queryName)
+			}
+		}
+
+		for _, test := range scheduledReportsProduceDataTestCases {
+			reportGenQuery, err := testFramework.WaitForMeteringReportGenerationQuery(t, test.queryName, time.Second*5, test.timeout)
+			require.NoError(t, err, "ReportGenerationQuery should exist before creating report using it")
+
+			for _, datasourceName := range reportGenQuery.Spec.DataSources {
+				_, err := testFramework.WaitForMeteringReportDataSourceTable(t, datasourceName, time.Second*5, test.timeout)
+				require.NoError(t, err, "ReportDataSource %s table for ReportGenerationQuery %s should exist before running reports against it", datasourceName, test.queryName)
+			}
+		}
+
+		periodStart, periodEnd = testFramework.CollectMetricsOnce(t)
+
+		t.Run("TestReportsProduceData", testReportsProduceData)
+		t.Run("TestScheduledReportsProduceData", testScheduledReportsProduceData)
+	})
 }

--- a/test/e2e/report_test.go
+++ b/test/e2e/report_test.go
@@ -148,7 +148,7 @@ func testReportsProduceData(t *testing.T) {
 
 			var reportResults []map[string]interface{}
 			var reportData []byte
-			err = wait.Poll(time.Second*5, test.timeout, func() (bool, error) {
+			err = wait.PollImmediate(time.Second*5, test.timeout, func() (bool, error) {
 				req := testFramework.NewReportingOperatorSVCRequest("/api/v1/reports/get", query)
 				result := req.Do()
 				resp, err := result.Raw()

--- a/test/e2e/report_test.go
+++ b/test/e2e/report_test.go
@@ -174,7 +174,7 @@ func testReportsProduceData(t *testing.T) {
 			require.NoError(t, err, "expected getting report result to not timeout")
 			assert.NotEmpty(t, reportResults, "reports should return at least 1 row")
 
-			fileName := path.Join(reportTestOutputDirectory, fmt.Sprintf("%s.json", test.name))
+			fileName := path.Join(reportTestOutputDirectory, fmt.Sprintf("%s-report.json", test.name))
 			err = ioutil.WriteFile(fileName, reportData, os.ModePerm)
 			require.NoError(t, err, "expected writing report results to disk not to error")
 		})

--- a/test/e2e/scheduled_report_test.go
+++ b/test/e2e/scheduled_report_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestScheduledReportsProduceData(t *testing.T) {
-	tests := map[string]struct {
+var (
+	scheduledReportsProduceDataTestCases = map[string]struct {
 		queryName string
 		timeout   time.Duration
 	}{
@@ -27,12 +27,11 @@ func TestScheduledReportsProduceData(t *testing.T) {
 			timeout:   reportTestTimeout,
 		},
 	}
+)
 
-	periodStart, periodEnd := testFramework.CollectMetricsOnce(t)
-
+func testScheduledReportsProduceData(t *testing.T) {
 	t.Logf("periodStart: %s, periodEnd: %s", periodStart, periodEnd)
-
-	for name, test := range tests {
+	for name, test := range scheduledReportsProduceDataTestCases {
 		// Fix closure captures
 		test := test
 		t.Run(name, func(t *testing.T) {

--- a/test/e2e/scheduled_report_test.go
+++ b/test/e2e/scheduled_report_test.go
@@ -3,7 +3,10 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -63,7 +66,6 @@ func testScheduledReportsProduceData(t *testing.T) {
 				"format": "json",
 			}
 
-			var reportResults []map[string]interface{}
 			err = wait.PollImmediate(time.Second*5, test.timeout, func() (bool, error) {
 				// poll the status
 				newReport, err := testFramework.GetMeteringScheduledReport(name)
@@ -88,19 +90,33 @@ func testScheduledReportsProduceData(t *testing.T) {
 			})
 			require.NoError(t, err, "expected getting report result to not timeout")
 
-			req := testFramework.NewReportingOperatorSVCRequest("/api/v1/scheduledreports/get", query)
-			result := req.Do()
-			resp, err := result.Raw()
-			require.NoError(t, err, "fetching report results should be successful")
+			var reportResults []map[string]interface{}
+			var reportData []byte
+			err = wait.PollImmediate(time.Second*5, test.timeout, func() (bool, error) {
+				req := testFramework.NewReportingOperatorSVCRequest("/api/v1/scheduledreports/get", query)
+				result := req.Do()
+				resp, err := result.Raw()
+				require.NoError(t, err, "fetching ScheduledReport results should be successful")
 
-			var statusCode int
-			result.StatusCode(&statusCode)
+				var statusCode int
+				result.StatusCode(&statusCode)
+				if statusCode == http.StatusAccepted {
+					t.Logf("report is still running")
+					return false, nil
+				}
 
-			require.Equal(t, http.StatusOK, statusCode, "http response status code should be ok")
-
-			err = json.Unmarshal(resp, &reportResults)
-			require.NoError(t, err, "expected to unmarshal response")
+				require.Equal(t, http.StatusOK, statusCode, "http response status code should be ok")
+				err = json.Unmarshal(resp, &reportResults)
+				require.NoError(t, err, "expected to unmarshal response")
+				reportData = resp
+				return true, nil
+			})
+			require.NoError(t, err, "expected getting ScheduledReport result to not timeout")
 			assert.NotEmpty(t, reportResults, "reports should return at least 1 row")
+
+			fileName := path.Join(reportTestOutputDirectory, fmt.Sprintf("%s-scheduled-report.json", name))
+			err = ioutil.WriteFile(fileName, reportData, os.ModePerm)
+			require.NoError(t, err, "expected writing report results to disk not to error")
 		})
 	}
 }

--- a/test/e2e/scheduled_report_test.go
+++ b/test/e2e/scheduled_report_test.go
@@ -68,13 +68,18 @@ func testScheduledReportsProduceData(t *testing.T) {
 
 			err = wait.PollImmediate(time.Second*5, test.timeout, func() (bool, error) {
 				// poll the status
-				newReport, err := testFramework.GetMeteringScheduledReport(name)
+				newReport, err := testFramework.GetMeteringScheduledReport(report.Name)
 				if err != nil {
 					return false, err
 				}
 				cond := cbutil.GetScheduledReportCondition(newReport.Status, meteringv1alpha1.ScheduledReportFailure)
 				if cond != nil && cond.Status == v1.ConditionTrue {
 					return false, fmt.Errorf("report is failed, reason: %s, message: %s", cond.Reason, cond.Message)
+				}
+
+				if newReport.Status.TableName == "" {
+					t.Logf("ScheduledReport %s table isn't created yet", report.Name)
+					return false, nil
 				}
 
 				// If the last reportTime is updated, that means this report
@@ -88,7 +93,7 @@ func testScheduledReportsProduceData(t *testing.T) {
 				}
 				return true, nil
 			})
-			require.NoError(t, err, "expected getting report result to not timeout")
+			require.NoError(t, err, "expected getting ScheduledReport to not timeout")
 
 			var reportResults []map[string]interface{}
 			var reportData []byte

--- a/test/e2e/scheduled_report_test.go
+++ b/test/e2e/scheduled_report_test.go
@@ -64,7 +64,7 @@ func testScheduledReportsProduceData(t *testing.T) {
 			}
 
 			var reportResults []map[string]interface{}
-			err = wait.Poll(time.Second*5, test.timeout, func() (bool, error) {
+			err = wait.PollImmediate(time.Second*5, test.timeout, func() (bool, error) {
 				// poll the status
 				newReport, err := testFramework.GetMeteringScheduledReport(name)
 				if err != nil {

--- a/test/framework/collect.go
+++ b/test/framework/collect.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 
 	"github.com/operator-framework/operator-metering/pkg/operator"
@@ -43,6 +44,10 @@ func (f *Framework) CollectMetricsOnce(t *testing.T) (time.Time, time.Time) {
 		resp, err := result.Raw()
 		t.Logf("Finishing querying %s, took: %s to finish", collectEndpoint, time.Now().UTC().Sub(currentTime))
 		require.NoErrorf(t, err, "expected no errors triggering data collection, body: %v", string(resp))
+		var collectResp operator.CollectPromsumDataResponse
+		err = json.Unmarshal(resp, &collectResp)
+		require.NoError(t, err, "expected to unmarshal CollectPrometheusData response as JSON")
+		t.Logf("CollectPromsumDataResponse: %s", spew.Sdump(collectResp))
 	})
 	return f.reportStart, f.reportEnd
 }

--- a/test/framework/datasource.go
+++ b/test/framework/datasource.go
@@ -17,7 +17,7 @@ func (f *Framework) GetMeteringReportDataSource(name string) (*meteringv1alpha1.
 
 func (f *Framework) WaitForMeteringReportDataSourceTable(t *testing.T, name string, pollInterval, timeout time.Duration) (*meteringv1alpha1.ReportDataSource, error) {
 	var ds *meteringv1alpha1.ReportDataSource
-	return ds, wait.Poll(pollInterval, timeout, func() (bool, error) {
+	return ds, wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
 		var err error
 		ds, err = f.GetMeteringReportDataSource(name)
 		if err != nil {

--- a/test/framework/report.go
+++ b/test/framework/report.go
@@ -18,6 +18,10 @@ func (f *Framework) CreateMeteringScheduledReport(report *meteringv1alpha1.Sched
 	return err
 }
 
+func (f *Framework) GetMeteringReport(name string) (*meteringv1alpha1.Report, error) {
+	return f.MeteringClient.Reports(f.Namespace).Get(name, meta.GetOptions{})
+}
+
 func (f *Framework) GetMeteringScheduledReport(name string) (*meteringv1alpha1.ScheduledReport, error) {
 	return f.MeteringClient.ScheduledReports(f.Namespace).Get(name, meta.GetOptions{})
 }

--- a/test/framework/reportgenerationquery.go
+++ b/test/framework/reportgenerationquery.go
@@ -17,7 +17,7 @@ func (f *Framework) GetMeteringReportGenerationQuery(name string) (*meteringv1al
 
 func (f *Framework) WaitForMeteringReportGenerationQuery(t *testing.T, name string, pollInterval, timeout time.Duration) (*meteringv1alpha1.ReportGenerationQuery, error) {
 	var reportQuery *meteringv1alpha1.ReportGenerationQuery
-	return reportQuery, wait.Poll(pollInterval, timeout, func() (bool, error) {
+	return reportQuery, wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
 		var err error
 		reportQuery, err = f.GetMeteringReportGenerationQuery(name)
 		if err != nil {


### PR DESCRIPTION
If /api/v1/datasources/prometheus/collect is called before the reporting-operator's informer cache contains ReportDataSources then the collection call will result in no metrics being imported.
In e2e this is happening fairly often due to the ReportDataSources being created at the same time as the reporting-operator, meaning the reporting-operator will only see them after it issues it's first resync list on ReportDataSources.
To deal with this, avoid using the cache for the prometheus collect endpoint, and update tests to correctly wait for ReportDataSources to exist.