### PR TITLE
Fix on-demand collect to correctly use non-cached ReportDataSources

### DIFF
--- a/pkg/operator/promsum.go
+++ b/pkg/operator/promsum.go
@@ -264,6 +264,7 @@ outerLoop:
 						"tableName":        dataSourceTableName(reportDataSource.Name),
 					})
 					importer = op.newPromImporter(dataSourceLogger, reportDataSource, reportPromQuery)
+					importers[reportDataSource.Name] = importer
 				}
 			}
 

--- a/test/e2e/report_test.go
+++ b/test/e2e/report_test.go
@@ -158,7 +158,7 @@ func testReportsProduceData(t *testing.T) {
 				}
 
 				if newReport.Status.TableName == "" {
-					t.Logf("ScheduledReport %s table isn't created yet", report.Name)
+					t.Logf("Report %s table isn't created yet", report.Name)
 					return false, nil
 				}
 				return true, nil


### PR DESCRIPTION
Missed a map assignment causing importers created using the non-cached list of ReportDataSources to not get used.