### PR TITLE
jenkins: Remove deploying integration/e2e to Tectonic cluster

### DIFF
--- a/jenkins/main.groovy
+++ b/jenkins/main.groovy
@@ -7,7 +7,6 @@ def skipE2ELabel = (isPullRequest && pullRequest.labels.contains("skip-e2e"))
 def skipIntegrationLabel = (isPullRequest && pullRequest.labels.contains("skip-integration"))
 def skipNsCleanup = (isPullRequest && pullRequest.labels.contains("skip-namespace-cleanup"))
 
-def skipTectonic = (isPullRequest && pullRequest.labels.contains("skip-tectonic"))
 def skipOpenshift = (isPullRequest && pullRequest.labels.contains("skip-openshift"))
 def skipGke = (isPullRequest && pullRequest.labels.contains("skip-gke"))
 
@@ -30,7 +29,6 @@ pipeline {
 
         booleanParam(name: 'GENERIC', defaultValue: true, description: 'If true, run the configured tests against a GKE cluster using the generic config.')
         booleanParam(name: 'OPENSHIFT', defaultValue: true, description: 'If true, run the configured tests against a Openshift cluster using the Openshift config.')
-        booleanParam(name: 'TECTONIC', defaultValue: true, description: 'If true, run the configured tests against a Openshift cluster using the Openshift config.')
         booleanParam(name: 'REBUILD_HELM_OPERATOR', defaultValue: false, description: 'If true, rebuilds quay.io/coreos/helm-operator, otherwise pulls latest of the image.')
         booleanParam(name: 'SKIP_NS_CLEANUP', defaultValue: false, description: 'If true, skip cleaning up the e2e/integration namespaces after running tests.')
     }
@@ -96,7 +94,6 @@ pipeline {
                             string(name: 'DEPLOY_TAG', value: skipBuildLabel ? "master" : env.TARGET_BRANCH),
                             booleanParam(name: 'GENERIC', value: params.GENERIC && !skipGke),
                             booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT && !skipOpenshift),
-                            booleanParam(name: 'TECTONIC', value: params.TECTONIC && !skipTectonic),
                             booleanParam(name: 'SKIP_NS_CLEANUP', value: params.SKIP_NS_CLEANUP || skipNsCleanup),
                         ]
                     }
@@ -113,7 +110,6 @@ pipeline {
                             string(name: 'DEPLOY_TAG', value: skipBuildLabel ? "master" : env.TARGET_BRANCH),
                             booleanParam(name: 'GENERIC', value: params.GENERIC && !skipGke),
                             booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT && !skipOpenshift),
-                            booleanParam(name: 'TECTONIC', value: params.TECTONIC && !skipTectonic),
                             booleanParam(name: 'SKIP_NS_CLEANUP', value: params.SKIP_NS_CLEANUP || skipNsCleanup),
                         ]
                     }

--- a/jenkins/vars/testRunner.groovy
+++ b/jenkins/vars/testRunner.groovy
@@ -20,7 +20,6 @@ def call(body) {
             string(name: 'OVERRIDE_NAMESPACE', defaultValue: '', description: 'If set, sets the namespace to deploy to')
             booleanParam(name: 'GENERIC', defaultValue: false, description: 'If true, run the configured tests against a GKE cluster using the generic config.')
             booleanParam(name: 'OPENSHIFT', defaultValue: false, description: 'If true, run the configured tests against a Openshift cluster using the Openshift config.')
-            booleanParam(name: 'TECTONIC', defaultValue: false, description: 'If true, run the configured tests against a Openshift cluster using the Openshift config.')
             booleanParam(name: 'SKIP_NS_CLEANUP', defaultValue: false, description: 'If true, skip cleaning up the namespace after running tests.')
         }
         agent {
@@ -111,32 +110,6 @@ spec:
                             }
                         }
                     }
-
-                    stage('tectonic') {
-                        when {
-                            expression { return params.TECTONIC }
-                        }
-                        environment {
-                            KUBECONFIG                          = credentials('chargeback-ci-kubeconfig')
-                            TEST_OUTPUT_DIR                     = "${env.OUTPUT_DIR}/tectonic/tests"
-                            TEST_OUTPUT_PATH                    = "${env.WORKSPACE}/${env.TEST_OUTPUT_DIR}"
-                            TEST_RESULT_REPORT_OUTPUT_DIRECTORY = "${env.WORKSPACE}/${env.TEST_OUTPUT_DIR}/reports"
-                            DEPLOY_PLATFORM                     = "tectonic"
-                        }
-                        steps {
-                            runTests()
-                        }
-                        post {
-                            always {
-                                echo 'Capturing test TAP output'
-                                step([$class: "TapPublisher", testResults: "${TEST_OUTPUT_DIR}/${TEST_TAP_FILE}", failIfNoResults: false, planRequired: false])
-                            }
-                            cleanup {
-                                cleanup()
-                            }
-                        }
-                    }
-
 
                     stage('openshift') {
                         when {


### PR DESCRIPTION
We no longer target Tectonic and this isn't providing much value for us,
and the certificates are due to expire in the coming weeks, so this will
just avoid breakage when that occurs.