### PR TITLE
Added missing column to aws-ec2-billing-data report generation query

### DIFF
--- a/charts/reporting-operator/templates/custom-resources/report-queries/aws-billing.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/aws-billing.yaml
@@ -73,6 +73,8 @@ spec:
     type: string
   - name: partition_stop
     type: string
+  - name: period_percent
+    type: double
   - name: period_start
     type: timestamp
     unit: date


### PR DESCRIPTION
The report generation query aws-ec2-billing-data is missing a column, which makes reports fail with the error:
```
  output: >-
    Failed to execute error usage report: presto: query failed (200 OK):
    "com.facebook.presto.sql.analyzer.SemanticException: Insert query has
    mismatched column types: Table: [varchar, timestamp, timestamp, double,
    varchar, varchar, timestamp, timestamp], Query: [varchar, timestamp,
    timestamp, double, varchar, varchar, double, timestamp, timestamp]"
  phase: Error
```

Just adding the missing column fixes the problem.