### PR TITLE
pkg/operator: Set resync to 10 minutes

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -46,7 +46,7 @@ import (
 const (
 	connBackoff         = time.Second * 15
 	maxConnWaitTime     = time.Minute * 3
-	defaultResyncPeriod = time.Minute
+	defaultResyncPeriod = time.Minute * 10
 
 	serviceServingCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 


### PR DESCRIPTION
After reading
https://github.com/kubernetes/community/blob/a2998f993c6f783967be57b2393fe19a5415ea2f/contributors/devel/controllers.md
point 9, it turns out, relists aren't the same as resync, and we don't
need to re-trigger syncthetic update events as often as 1 minute.