### PR TITLE
Improve sync handlers to requeue dependent resources and updateFuncs now skip queuing unchanged resources

### DIFF
--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -153,7 +153,6 @@ func (op *Reporting) handleAWSBillingDataSource(logger log.FieldLogger, dataSour
 
 	if dataSource.TableName != "" {
 		logger.Infof("existing AWSBilling ReportDataSource discovered, tableName: %s", dataSource.TableName)
-		return nil
 	} else {
 		logger.Infof("new AWSBilling ReportDataSource discovered")
 	}

--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -46,7 +46,8 @@ func init() {
 func (op *Reporting) runReportDataSourceWorker() {
 	logger := op.logger.WithField("component", "reportDataSourceWorker")
 	logger.Infof("ReportDataSource worker started")
-	for op.processResource(logger, op.syncReportDataSource, "ReportDataSource", op.queues.reportDataSourceQueue) {
+	const maxRequeues = 5
+	for op.processResource(logger, op.syncReportDataSource, "ReportDataSource", op.queues.reportDataSourceQueue, maxRequeues) {
 	}
 }
 

--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -123,7 +123,6 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 
 	if dataSource.TableName != "" {
 		logger.Infof("existing Prometheus ReportDataSource discovered, tableName: %s, skipping processing", dataSource.TableName)
-		return nil
 	} else {
 		logger.Infof("new Prometheus ReportDataSource discovered")
 		storage := dataSource.Spec.Promsum.Storage

--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -92,14 +92,24 @@ func (op *Reporting) syncReportDataSource(logger log.FieldLogger, key string) er
 
 func (op *Reporting) handleReportDataSource(logger log.FieldLogger, dataSource *cbTypes.ReportDataSource) error {
 	dataSource = dataSource.DeepCopy()
+	var err error
 	switch {
 	case dataSource.Spec.Promsum != nil:
-		return op.handlePrometheusMetricsDataSource(logger, dataSource)
+		err = op.handlePrometheusMetricsDataSource(logger, dataSource)
 	case dataSource.Spec.AWSBilling != nil:
-		return op.handleAWSBillingDataSource(logger, dataSource)
+		err = op.handleAWSBillingDataSource(logger, dataSource)
 	default:
-		return fmt.Errorf("ReportDataSource %s: improperly configured missing promsum or awsBilling configuration", dataSource.Name)
+		err = fmt.Errorf("ReportDataSource %s: improperly configured missing promsum or awsBilling configuration", dataSource.Name)
 	}
+	if err != nil {
+		return err
+	}
+
+	if err := op.queueDependentReportGeneratonQueriesForDataSource(dataSource); err != nil {
+		logger.WithError(err).Errorf("error queuing ReportGenerationQuery dependents of ReportDataSource %s", dataSource.Name)
+	}
+
+	return nil
 }
 
 func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, dataSource *cbTypes.ReportDataSource) error {
@@ -396,4 +406,25 @@ func (op *Reporting) removeReportDataSourceFinalizer(ds *cbTypes.ReportDataSourc
 
 func reportDataSourceNeedsFinalizer(ds *cbTypes.ReportDataSource) bool {
 	return ds.ObjectMeta.DeletionTimestamp == nil && !slice.ContainsString(ds.ObjectMeta.Finalizers, reportDataSourceFinalizer, nil)
+}
+
+// queueDependentReportGeneratonQueriesForDataSource will queue all ReportGenerationQueries in the namespace which have a dependency on the generationQuery
+func (op *Reporting) queueDependentReportGeneratonQueriesForDataSource(dataSource *cbTypes.ReportDataSource) error {
+	queryLister := op.meteringClient.MeteringV1alpha1().ReportGenerationQueries(dataSource.Namespace)
+	queries, err := queryLister.List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, query := range queries.Items {
+		// look at the list ReportDataSource of dependencies
+		for _, dependency := range query.Spec.DataSources {
+			if dependency == dataSource.Name {
+				// this query depends on the generationQuery passed in
+				op.enqueueReportGenerationQuery(query)
+				break
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -46,7 +46,7 @@ import (
 const (
 	connBackoff         = time.Second * 15
 	maxConnWaitTime     = time.Minute * 3
-	defaultResyncPeriod = time.Minute
+	defaultResyncPeriod = time.Minute * 15
 
 	serviceServingCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 

--- a/pkg/operator/prestotables.go
+++ b/pkg/operator/prestotables.go
@@ -43,7 +43,8 @@ func (op *Reporting) processPrestoTable(logger log.FieldLogger) bool {
 	logger = logger.WithFields(newLogIdentifier(op.rand))
 	if key, ok := op.getKeyFromQueueObj(logger, "PrestoTable", obj, op.queues.prestoTableQueue); ok {
 		err := op.syncPrestoTable(logger, key)
-		op.handleErr(logger, err, "PrestoTable", key, op.queues.prestoTableQueue)
+		const maxRequeues = 10
+		op.handleErr(logger, err, "PrestoTable", key, op.queues.prestoTableQueue, maxRequeues)
 	}
 	return true
 }

--- a/pkg/operator/query.go
+++ b/pkg/operator/query.go
@@ -14,7 +14,11 @@ import (
 func (op *Reporting) runReportGenerationQueryWorker() {
 	logger := op.logger.WithField("component", "reportGenerationQueryWorker")
 	logger.Infof("ReportGenerationQuery worker started")
-	for op.processResource(logger, op.syncReportGenerationQuery, "ReportGenerationQuery", op.queues.reportGenerationQueryQueue) {
+	// 10 requeues compared to the 5 others have because
+	// ReportGenerationQueries can reference a lot of other resources, and it may
+	// take time for them to all to finish setup
+	const maxRequeues = 10
+	for op.processResource(logger, op.syncReportGenerationQuery, "ReportGenerationQuery", op.queues.reportGenerationQueryQueue, maxRequeues) {
 	}
 }
 

--- a/pkg/operator/query.go
+++ b/pkg/operator/query.go
@@ -99,8 +99,8 @@ func (op *Reporting) handleReportGenerationQuery(logger log.FieldLogger, generat
 	}
 
 	// enqueue any queries depending on this one
-	if err := op.queueDependentReportGeneratonQueries(generationQuery); err != nil {
-		logger.WithError(err).Errorf("error queuing ReportGenerationQuery dependents of %s", generationQuery.Name)
+	if err := op.queueDependentReportGeneratonQueriesForQuery(generationQuery); err != nil {
+		logger.WithError(err).Errorf("error queuing ReportGenerationQuery dependents of ReportGenerationQuery %s", generationQuery.Name)
 	}
 
 	return nil
@@ -134,8 +134,8 @@ func (op *Reporting) validateDependencyStatus(dependencyStatus *reporting.Genera
 	return deps, nil
 }
 
-// queueDependentReportGeneratonQueries will queue all ReportGenerationQueries in the namespace which have a dependency on the generationQuery
-func (op *Reporting) queueDependentReportGeneratonQueries(generationQuery *cbTypes.ReportGenerationQuery) error {
+// queueDependentReportGeneratonQueriesForQuery will queue all ReportGenerationQueries in the namespace which have a dependency on the generationQuery
+func (op *Reporting) queueDependentReportGeneratonQueriesForQuery(generationQuery *cbTypes.ReportGenerationQuery) error {
 	queryLister := op.meteringClient.MeteringV1alpha1().ReportGenerationQueries(generationQuery.Namespace)
 	queries, err := queryLister.List(metav1.ListOptions{})
 	if err != nil {
@@ -147,7 +147,7 @@ func (op *Reporting) queueDependentReportGeneratonQueries(generationQuery *cbTyp
 		if query.Name == generationQuery.Name {
 			continue
 		}
-		// look at the list of dependencies
+		// look at the list of ReportGenerationQuery dependencies
 		depenencyNames := append(query.Spec.ReportQueries, query.Spec.DynamicReportQueries...)
 		for _, dependency := range depenencyNames {
 			if dependency == generationQuery.Name {

--- a/pkg/operator/query.go
+++ b/pkg/operator/query.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
@@ -92,7 +93,17 @@ func (op *Reporting) handleReportGenerationQuery(logger log.FieldLogger, generat
 		return err
 	}
 
-	return op.updateReportQueryViewName(logger, generationQuery, viewName)
+	err = op.updateReportQueryViewName(logger, generationQuery, viewName)
+	if err != nil {
+		return err
+	}
+
+	// enqueue any queries depending on this one
+	if err := op.queueDependentReportGeneratonQueries(generationQuery); err != nil {
+		logger.WithError(err).Errorf("error queuing ReportGenerationQuery dependents of %s", generationQuery.Name)
+	}
+
+	return nil
 }
 
 func (op *Reporting) updateReportQueryViewName(logger log.FieldLogger, generationQuery *cbTypes.ReportGenerationQuery, viewName string) error {
@@ -121,4 +132,30 @@ func (op *Reporting) validateDependencyStatus(dependencyStatus *reporting.Genera
 		return nil, err
 	}
 	return deps, nil
+}
+
+// queueDependentReportGeneratonQueries will queue all ReportGenerationQueries in the namespace which have a dependency on the generationQuery
+func (op *Reporting) queueDependentReportGeneratonQueries(generationQuery *cbTypes.ReportGenerationQuery) error {
+	queryLister := op.meteringClient.MeteringV1alpha1().ReportGenerationQueries(generationQuery.Namespace)
+	queries, err := queryLister.List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, query := range queries.Items {
+		// don't queue ourself
+		if query.Name == generationQuery.Name {
+			continue
+		}
+		// look at the list of dependencies
+		depenencyNames := append(query.Spec.ReportQueries, query.Spec.DynamicReportQueries...)
+		for _, dependency := range depenencyNames {
+			if dependency == generationQuery.Name {
+				// this query depends on the generationQuery passed in
+				op.enqueueReportGenerationQuery(query)
+				break
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/operator/queues.go
+++ b/pkg/operator/queues.go
@@ -250,12 +250,24 @@ func (op *Reporting) addReportDataSource(obj interface{}) {
 	op.enqueueReportDataSource(ds)
 }
 
-func (op *Reporting) updateReportDataSource(_, cur interface{}) {
+func (op *Reporting) updateReportDataSource(prev, cur interface{}) {
+	prevReportDataSource := prev.(*cbTypes.ReportDataSource)
 	curReportDataSource := cur.(*cbTypes.ReportDataSource)
 	if curReportDataSource.DeletionTimestamp != nil {
 		op.deleteReportDataSource(curReportDataSource)
 		return
 	}
+
+	if curReportDataSource.ResourceVersion == prevReportDataSource.ResourceVersion {
+		// Periodic resyncs will send update events for all known ReportDataSources.
+		// Two different versions of the same reportDataSource will always have
+		// different ResourceVersions.
+
+		// TODO(chance): logging here is probably unnecessary and verbose
+		op.logger.Debugf("ReportDataSource %s is unchanged, skipping update", curReportDataSource.Name)
+		return
+	}
+
 	op.logger.Infof("updating ReportDataSource %s", curReportDataSource.Name)
 	op.enqueueReportDataSource(curReportDataSource)
 }

--- a/pkg/operator/queues.go
+++ b/pkg/operator/queues.go
@@ -297,8 +297,20 @@ func (op *Reporting) addReportGenerationQuery(obj interface{}) {
 	op.enqueueReportGenerationQuery(report)
 }
 
-func (op *Reporting) updateReportGenerationQuery(_, cur interface{}) {
+func (op *Reporting) updateReportGenerationQuery(prev, cur interface{}) {
 	curReportGenerationQuery := cur.(*cbTypes.ReportGenerationQuery)
+	prevReportGenerationQuery := prev.(*cbTypes.ReportGenerationQuery)
+
+	if curReportGenerationQuery.ResourceVersion == prevReportGenerationQuery.ResourceVersion {
+		// Periodic resyncs will send update events for all known ReportGenerationQuerys.
+		// Two different versions of the same reportGenerationQuery will always have
+		// different ResourceVersions.
+
+		// TODO(chance): logging here is probably unnecessary and verbose
+		op.logger.Debugf("ReportGenerationQuery %s is unchanged, skipping update", curReportGenerationQuery.Name)
+		return
+	}
+
 	op.logger.Infof("updating ReportGenerationQuery %s", curReportGenerationQuery.Name)
 	op.enqueueReportGenerationQuery(curReportGenerationQuery)
 }

--- a/pkg/operator/queues.go
+++ b/pkg/operator/queues.go
@@ -258,7 +258,10 @@ func (op *Reporting) updateReportDataSource(prev, cur interface{}) {
 		return
 	}
 
-	if curReportDataSource.ResourceVersion == prevReportDataSource.ResourceVersion {
+	// we allow periodic resyncs to trigger AWSBilling ReportDataSources even
+	// if they're not changed since we currently rely on the resyncs so our
+	// handler can periodically update the partitions on the table
+	if curReportDataSource.Spec.AWSBilling != nil && curReportDataSource.ResourceVersion == prevReportDataSource.ResourceVersion {
 		// Periodic resyncs will send update events for all known ReportDataSources.
 		// Two different versions of the same reportDataSource will always have
 		// different ResourceVersions.

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -58,7 +58,8 @@ func init() {
 func (op *Reporting) runReportWorker() {
 	logger := op.logger.WithField("component", "reportWorker")
 	logger.Infof("Report worker started")
-	for op.processResource(logger, op.syncReport, "Report", op.queues.reportQueue) {
+	const maxRequeues = 5
+	for op.processResource(logger, op.syncReport, "Report", op.queues.reportQueue, maxRequeues) {
 	}
 }
 

--- a/pkg/operator/scheduled_reports.go
+++ b/pkg/operator/scheduled_reports.go
@@ -64,7 +64,8 @@ func init() {
 func (op *Reporting) runScheduledReportWorker() {
 	logger := op.logger.WithField("component", "scheduledReportWorker")
 	logger.Infof("ScheduledReport worker started")
-	for op.processResource(logger, op.syncScheduledReport, "ScheduledReport", op.queues.scheduledReportQueue) {
+	const maxRequeues = 5
+	for op.processResource(logger, op.syncScheduledReport, "ScheduledReport", op.queues.scheduledReportQueue, maxRequeues) {
 	}
 }
 


### PR DESCRIPTION
Main improvements are handling of queueing resources when things they
depend on are "ready" (eg: table/view is created), which ensures
resources are reprocessed even without a resync when their initial sync
failed more than 5 times.

Additionally, now sync handlers for different kinds have a different
number of allowed retries before requeues are stopped.

With all of these improvements, this also allows the operator to avoid
triggering sync handlers when a resync occurs and the ResourceVersion of
a resource isn't changed.

Given the reliance on resyncs is largely reduced by the improved sync
handlers queueing their dependents the operators resync interval can be
increased from the current value of 1 minute to something much longer.
For now we'll start with 15 minutes and see how it behaves with the
changes.