### PR TITLE
pkg,Documentation: Allow specifying a reportingEnd on ScheduledReports

### DIFF
--- a/Documentation/report.md
+++ b/Documentation/report.md
@@ -122,6 +122,31 @@ spec:
   reportingStart: "2018-01-01T00:00:00Z"
 ```
 
+
+### reportingEnd
+
+To configure a ScheduledReport to only run until a specified time, you can set the `spec.reportingEnd` field to an RFC3339 timestamp.
+The value of this field will cause the ScheduledReport to stop running on it's schedule after it has finished generating reporting data for the period covered from it's start time until `reportingEnd`.
+Because a schedule will most likely not align with reportingEnd, the last period in the schedule will be shortened to end at the specified reportingEnd time.
+If left unset, then the ScheduledReport will run forever, or until a `reportingEnd` is set on the ScheduledReport.
+
+For example, if you wanted to create a report that runs once a week for the month of July:
+
+```
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: pod-cpu-request-hourly
+spec:
+  generationQuery: "pod-cpu-request"
+  gracePeriod: "5m"
+  schedule:
+    period: "weekly"
+  reportingStart: "2018-07-01T00:00:00Z"
+  reportingEnd: "2018-07-31T00:00:00Z"
+```
+
+
 ### Scheduled Report Status
 
 The execution of a scheduled report can be tracked using its status field. Any errors occurring during the preparation of a report will be recorded here.

--- a/pkg/apis/metering/v1alpha1/scheduled_report.go
+++ b/pkg/apis/metering/v1alpha1/scheduled_report.go
@@ -38,6 +38,11 @@ type ScheduledReportSpec struct {
 	// and report on data collected before the ScheduledReport was created.
 	ReportingStart *meta.Time `json:"reportingStart,omitempty"`
 
+	// ReportingEnd specifies the time this ScheduledReport should stop
+	// running. Once a ScheduledReport has reached ReportingEnd, no new results
+	// will be generated.
+	ReportingEnd *meta.Time `json:"reportingEnd,omitempty"`
+
 	// GracePeriod controls how long after each period to wait until running
 	// the report
 	GracePeriod *meta.Duration `json:"gracePeriod,omitempty"`

--- a/pkg/apis/metering/v1alpha1/util/scheduled_report_util.go
+++ b/pkg/apis/metering/v1alpha1/util/scheduled_report_util.go
@@ -25,6 +25,9 @@ const (
 	// ReportPeriodWaitingReason is added to a ScheduledReport when the report
 	// has to wait until the next scheduled reporting time.
 	ReportPeriodWaitingReason = "ReportPeriodNotFinished"
+	// ReportPeriodFinishedReason is added to a ScheduledReport when the report
+	// has had it's report processed up until it's reportingEnd.
+	ReportPeriodFinishedReason = "ReportPeriodFinished"
 )
 
 // NewScheduledReportCondition creates a new scheduledReport condition.

--- a/pkg/apis/metering/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/metering/v1alpha1/zz_generated.deepcopy.go
@@ -923,6 +923,14 @@ func (in *ScheduledReportSpec) DeepCopyInto(out *ScheduledReportSpec) {
 			*out = (*in).DeepCopy()
 		}
 	}
+	if in.ReportingEnd != nil {
+		in, out := &in.ReportingEnd, &out.ReportingEnd
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = (*in).DeepCopy()
+		}
+	}
 	if in.GracePeriod != nil {
 		in, out := &in.GracePeriod, &out.GracePeriod
 		if *in == nil {


### PR DESCRIPTION
This allows configuring a ScheduledReport to have a fixed time range
which it will report on, while still allowing the ScheduledReport to run
forever if `spec.reportingEnd` isn't set.