### PR TITLE
WIP experiment with adding hostPath support for sharedVolume

### DIFF
--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -109,7 +109,13 @@ spec:
         emptyDir: {}
 {{- end }}
 {{- if .Values.spec.config.sharedVolume.enabled }}
+{{- if not .Values.spec.config.sharedVolume.useHostPath }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
           claimName: {{ .Values.spec.config.sharedVolume.persistentVolumeClaimName }}
+{{- else }}
+      - name: hive-warehouse-data
+        hostPath:
+          path: {{ .Values.spec.config.sharedVolume.hostPath }}
+{{- end}}
 {{- end}}

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -108,7 +108,13 @@ spec:
       - name: hive-metastore-db-data
         emptyDir: {}
 {{- if .Values.spec.config.sharedVolume.enabled }}
+{{- if not .Values.spec.config.sharedVolume.useHostPath }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
           claimName: {{ .Values.spec.config.sharedVolume.persistentVolumeClaimName }}
+{{- else }}
+      - name: hive-warehouse-data
+        hostPath:
+          path: {{ .Values.spec.config.sharedVolume.hostPath }}
+{{- end}}
 {{- end}}

--- a/charts/presto/templates/presto-coordinator-deployment.yaml
+++ b/charts/presto/templates/presto-coordinator-deployment.yaml
@@ -82,9 +82,15 @@ spec:
       - name: presto-data
         emptyDir: {}
 {{- if .Values.spec.config.sharedVolume.enabled }}
+{{- if not .Values.spec.config.sharedVolume.useHostPath }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
           claimName: {{ .Values.spec.config.sharedVolume.persistentVolumeClaimName }}
+{{- else }}
+      - name: hive-warehouse-data
+        hostPath:
+          path: {{ .Values.spec.config.sharedVolume.hostPath }}
+{{- end}}
 {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/presto/templates/presto-worker-deployment.yaml
+++ b/charts/presto/templates/presto-worker-deployment.yaml
@@ -77,9 +77,15 @@ spec:
       - name: presto-data
         emptyDir: {}
 {{- if .Values.spec.config.sharedVolume.enabled }}
+{{- if not .Values.spec.config.sharedVolume.useHostPath }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
           claimName: {{ .Values.spec.config.sharedVolume.persistentVolumeClaimName }}
+{{- else }}
+      - name: hive-warehouse-data
+        hostPath:
+          path: {{ .Values.spec.config.sharedVolume.hostPath }}
+{{- end}}
 {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/presto/templates/shared-volume-pvc.yaml
+++ b/charts/presto/templates/shared-volume-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.spec.config.sharedVolume.enabled .Values.spec.config.sharedVolume.createPVC }}
+{{- if and .Values.spec.config.sharedVolume.enabled .Values.spec.config.sharedVolume.createPVC (not .Values.spec.config.sharedVolume.useHostPath) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -144,6 +144,8 @@ spec:
     sharedVolume:
       enabled: false
       createPVC: true
+      useHostPath: false
+      hostPath: /hive/data
       persistentVolumeClaimName: hive-warehouse-data
       mountPath: /user/hive/warehouse
       storage:


### PR DESCRIPTION
Requires running presto and hive components as root, and they must all
have a nodeSelector that runs them on the same node.