### PR TITLE
Documentation: roll-up report guide & explanation

### DIFF
--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -15,6 +15,7 @@
 Custom Resources:
 
 - [Reports](report.md)
+  - [Roll-up Reports](rollup-reports.md)
 - [ReportGenerationQueries](reportgenerationqueries.md)
 - [ReportDataSources](reportdatasources.md)
 - [ReportPrometheusQueries](reportprometheusqueries.md)

--- a/Documentation/report.md
+++ b/Documentation/report.md
@@ -297,3 +297,29 @@ A report can have the following states:
 
 
 [rfc3339]: https://tools.ietf.org/html/rfc3339#section-5.8
+
+## Roll-up Reports
+
+Report data is stored in the database much like metrics themselves, and can thus be used in aggregated or roll-up reports. A simple use case for a roll-up report is to spread the time required to produce a report over a longer period of time: instead of requiring a monthly report to query and add all data over an entire month, the task can be split into daily reports that each run over a thirtieth of the data.
+
+A custom roll-up report requires a custom generation query. The ReportGenerationQuery processor provides a macro that can get the necessary table name [from a report name](rollup-reports.md#2-create-the-aggregation-query):
+
+```
+# namespace-cpu-usage-aggregated-query.yaml
+inputs:
+- name: AggregatedReportName
+  required: true
+...
+ WHERE {| .Report.Inputs.AggregatedReportName | scheduledReportTableName |}.period_start >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+```
+
+```
+# aggregated-report.yaml
+spec:
+  generationQuery: "namespace-cpu-usage-aggregated"
+  inputs:
+  - name: "AggregatedReportName"
+    value: "namespace-cpu-usage-hourly"
+```
+
+For more information on setting up a roll-up report, see the [roll-up report guide](rollup-reports.md).

--- a/Documentation/rollup-reports.md
+++ b/Documentation/rollup-reports.md
@@ -1,0 +1,82 @@
+# Guide: Roll-Up Reports
+
+Often, it makes sense to report on data collected in other reports, called roll-up reports. Roll-up reports can combine datatypes (memory *and* CPU usage per namespace) and can combine smaller periods of time into larger ones — for instance, in an environment where a large amount of data is collected, splitting up processing over a month instead of waiting for the end of the month can be an effective way to spread out compute time and get a quicker final report.
+
+Currently, there are no built-in roll-up reports. Therefore, a custom roll-up report requires a custom generation query. In the following guide, we will create a daily report that aggregates hourly reports:
+
+## 1. Create the sub-report
+
+```
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: namespace-cpu-usage-hourly
+spec:
+  generationQuery: "namespace-cpu-usage"
+  reportingStart: '2018-10-09T00:00:00Z'
+  schedule:
+    period: "hourly"
+```
+
+## 2. Create the aggregation query
+
+To aggregate the reports together, we need a query that will retrieve the data from the report we wish to aggregate. This report is essentially a duplicate of the original `namespace-cpu-usage` query with the `data_end` and `data_start` timestamps stripped out, and a custom input `AggregatedReportName` that we use to pass the name of our sub-report in:
+
+```
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: namespace-cpu-usage-aggregated
+spec:
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: namespace
+    type: string
+    unit: kubernetes_namespace
+  - name: pod_usage_cpu_core_seconds
+    type: double
+    unit: cpu_core_seconds
+  inputs:
+  - name: ReportingStart
+  - name: ReportingEnd
+  - name: AggregatedReportName
+    required: true
+  query: |
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      namespace,
+      sum(pod_usage_cpu_core_seconds) as pod_usage_cpu_core_seconds
+    FROM {| .Report.Inputs.AggregatedReportName | scheduledReportTableName |}
+    WHERE {| .Report.Inputs.AggregatedReportName | scheduledReportTableName |}.period_start >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+    AND {| .Report.Inputs.AggregatedReportName | scheduledReportTableName |}.period_end < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+    GROUP BY namespace
+    ORDER BY pod_usage_cpu_core_seconds DESC
+```
+
+Note the use of the macro `scheduledReportTableName`, which will automatically get the proper table name from the given scheduled report name.
+
+## 3. Create the aggregator report
+
+We now have a sub-report and a query that can read data from other reports. We can create a `ScheduledReport` that uses that custom generation query with the sub-report:
+
+```
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: namespace-cpu-usage-daily-aggregate
+spec:
+  generationQuery: "namespace-cpu-usage-aggregated"
+  inputs:
+  - name: "AggregatedReportName"
+    value: "namespace-cpu-usage-hourly"
+  reportingStart: '2018-10-09T00:00:00Z'
+  gracePeriod: "10m" # wait for sub-query to finish
+  schedule:
+    period: "daily"
+```


### PR DESCRIPTION
The reports generated with the examples in the docs produce the same output.

I'd like to rendez-vous with you about why we're doing both `<=` and `>=` in general in ReportGenerationQueries by default. I think that's probably a mistake in general, and will lead to things getting miscounted no matter what. After all, even without automated roll-up, there's at least someone somewhere who deals with these reports in chunks, and as it stands we're double-counting every start/end point.

Also, thoughts on what to do about the `data_start`/`data_end` on the aggregated reports? It seems to me that we either have to accept internal gaps that we can't expose on larger scales (how do we propagate the fact that on the 3rd we were missing twenty minutes of data?), fail out, or add a data_period that isn't just a pair of dates.