### PR TITLE
charts/presto: Add AWS credentials env vars back to hive env helper template

### DIFF
--- a/charts/presto/templates/_helpers.tpl
+++ b/charts/presto/templates/_helpers.tpl
@@ -51,6 +51,18 @@ connector.name=jmx
 {{- end }}
 
 {{- define "hive-env" }}
+- name: CORE_CONF_fs_s3a_access_key
+  valueFrom:
+    secretKeyRef:
+      name: hive-common-secrets
+      key: aws-access-key-id
+      optional: true
+- name: CORE_CONF_fs_s3a_secret_key
+  valueFrom:
+    secretKeyRef:
+      name: hive-common-secrets
+      key: aws-secret-access-key
+      optional: true
 - name: CORE_CONF_fs_defaultFS
   valueFrom:
     configMapKeyRef:

--- a/charts/presto/templates/hive-common-secrets.yaml
+++ b/charts/presto/templates/hive-common-secrets.yaml
@@ -11,3 +11,9 @@ data:
 {{- if .Values.spec.hive.config.dbConnectionPassword }}
   db-connection-password: {{ .Values.spec.hive.config.dbConnectionPassword | b64enc | quote }}
 {{- end }}
+{{- if .Values.spec.config.awsAccessKeyID }}
+  aws-access-key-id: {{ .Values.spec.config.awsAccessKeyID | b64enc | quote}}
+{{- end}}
+{{- if .Values.spec.config.awsSecretAccessKey }}
+  aws-secret-access-key: {{ .Values.spec.config.awsSecretAccessKey | b64enc | quote}}
+{{- end}}


### PR DESCRIPTION
This was incorrectly removed when refactoring presto configuration. This
should enable using S3 again, which previously failed due to auth errors.