### PR TITLE
hack,Makefile: Add a script to run metering-operator locally

### DIFF
--- a/Documentation/manual-install.md
+++ b/Documentation/manual-install.md
@@ -70,7 +70,7 @@ Then run the installation script for your platform:
 
 For more details on configuration options, most are documented in the [configuring metering document][configuring-metering].
 
-## Run metering operator locally
+## Run reporting operator locally
 
 It's also possible to run the operator locally.
 To simplify this, we've got a few `Makefile` targets to handle the building and running of the operator.
@@ -107,5 +107,35 @@ make run-reporting-operator-local
 The above command builds the operator for your local OS (by default it only builds for Linux), uses kubectl port-forward to make Prometheus, Presto, and Hive available locally for your operator to communicate with, and then starts the operator with configuration set to use these local port-forwards.
 Lastly, the operator automatically uses your `$KUBECONFIG` to connect and authenticate to your cluster and perform Kubernetes API calls.
 
+## Run metering operator locally
+
+The metering operator is the top-level operator which deploys other components using helm charts.
+It's possible to also run this locally so you can iterate on charts and test them with the metering-operator before they're built and pushed to Quay for CI.
+
+To run it locally you need to have the following:
+
+- A connection to a docker daemon.
+- Your `$KUBECONFIG` environment variable must be set and accessible to your Docker daemon.
+- Your `$METERING_NAMESPACE` environment variable must be set, and unless `$LOCAL_METERING_OPERATOR_RUN_INSTALL` to `true`, the namespace must already exist.
+
+This will just build and run the metering-operator docker image, which will watch for `Metering` resources in the namespace specified by `$METERING_NAMESPACE`, using your `$KUBECONFIG` to communicate with the API server.
+
+```
+make run-metering-operator-local
+```
+
+If you want to also create the namespace using the install scripts you can do that manually and set `$SKIP_METERING_OPERATOR_DEPLOYMENT` to `true`:
+
+```
+export SKIP_METERING_OPERATOR_DEPLOYMENT=true
+./hack/openshift-install.sh
+```
+
+Or you can set `$LOCAL_METERING_OPERATOR_RUN_INSTALL` to `true` and run the same make command as above:
+
+```
+export LOCAL_METERING_OPERATOR_RUN_INSTALL=true
+make run-metering-operator-local
+```
 
 [configuring-metering]: metering-config.md

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,11 @@ ci-validate: verify-codegen all-charts metering-manifests fmt
 ci-validate-docker:
 	docker run -i $(METERING_E2E_IMAGE):$(IMAGE_TAG) bash -c 'make ci-validate'
 
+
+.PHONY: run-metering-operator-local
+run-metering-operator-local: metering-operator-docker-build
+	./hack/run-metering-operator-local.sh
+
 reporting-operator-bin: $(REPORTING_OPERATOR_BIN_OUT)
 
 reporting-operator-local: $(REPORTING_OPERATOR_GO_FILES)

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -15,15 +15,19 @@ msg "Installing Custom Resource Definitions"
 kube-install \
     "$MANIFESTS_DIR/custom-resource-definitions"
 
-msg "Installing metering-operator service account and RBAC resources"
-kube-install \
-    "$INSTALLER_MANIFESTS_DIR/metering-operator-service-account.yaml" \
-    "$INSTALLER_MANIFESTS_DIR/metering-operator-role.yaml" \
-    "$INSTALLER_MANIFESTS_DIR/metering-operator-rolebinding.yaml"
+if [ "$SKIP_METERING_OPERATOR_DEPLOYMENT" == "true" ]; then
+    echo "\$SKIP_METERING_OPERATOR_DEPLOYMENT=true, not creating metering-operator"
+else
+    msg "Installing metering-operator service account and RBAC resources"
+    kube-install \
+        "$INSTALLER_MANIFESTS_DIR/metering-operator-service-account.yaml" \
+        "$INSTALLER_MANIFESTS_DIR/metering-operator-role.yaml" \
+        "$INSTALLER_MANIFESTS_DIR/metering-operator-rolebinding.yaml"
 
-msg "Installing metering-operator"
-kube-install \
-    "$INSTALLER_MANIFESTS_DIR/metering-operator-deployment.yaml"
+    msg "Installing metering-operator"
+    kube-install \
+        "$INSTALLER_MANIFESTS_DIR/metering-operator-deployment.yaml"
+fi
 
 msg "Installing Metering Resource"
 kube-install \

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -17,6 +17,7 @@ source "${ROOT_DIR}/hack/lib/version.sh"
 
 : "${CREATE_NAMESPACE:=true}"
 : "${SKIP_DELETE_CRDS:=true}"
+: "${SKIP_METERING_OPERATOR_DEPLOYMENT:=false}"
 : "${DELETE_PVCS:=false}"
 
 : "${DEPLOY_PLATFORM:=generic}"

--- a/hack/run-metering-operator-local.sh
+++ b/hack/run-metering-operator-local.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+ROOT_DIR=$(dirname "${BASH_SOURCE}")/..
+source "${ROOT_DIR}/hack/common.sh"
+
+load_version_vars
+
+: "${METERING_OPERATOR_IMAGE_REPO:=quay.io/coreos/metering-helm-operator}"
+: "${METERING_OPERATOR_IMAGE_TAG:=$METERING_VERSION}"
+: "${METERING_OPERATOR_IMAGE:=${METERING_OPERATOR_IMAGE_REPO}:${METERING_OPERATOR_IMAGE_TAG}}"
+: "${METERING_CHART:=/openshift-metering-0.1.0.tgz}"
+: "${LOCAL_METERING_OPERATOR_RUN_INSTALL:=true}"
+: "${METERING_INSTALL_SCRIPT:=./hack/openshift-install.sh}"
+
+set -ex
+
+if [ "$LOCAL_METERING_OPERATOR_RUN_INSTALL" == "true" ]; then
+    export SKIP_METERING_OPERATOR_DEPLOYMENT=true
+    "$METERING_INSTALL_SCRIPT"
+fi
+
+docker run \
+    -it \
+    -v "$KUBECONFIG:/kubeconfig" \
+    -e KUBECONFIG=/kubeconfig \
+    -e HELM_RELEASE_CRD_NAME="Metering" \
+    -e HELM_RELEASE_CRD_API_GROUP="metering.openshift.io" \
+    -e HELM_CHART_PATH="$METERING_CHART" \
+    -e MY_POD_NAME="local-pod" \
+    -e MY_POD_NAMESPACE="$METERING_NAMESPACE" \
+    -e HELM_HOST="127.0.0.1:44134" \
+    -e HELM_WAIT="false" \
+    -e HELM_RECONCILE_INTERVAL_SECONDS="5" \
+    -e RELEASE_HISTORY_LIMIT="3" \
+    -e TILLER_NAMESPACE="$METERING_NAMESPACE" \
+    -e TILLER_HISTORY_MAX="3" \
+    "${METERING_OPERATOR_IMAGE}" \
+    bash -c 'tiller & sleep 2 && run-operator.sh'


### PR DESCRIPTION
Adds a script which allows running tiller and metering-helm-operator
via docker. Updates install script to support skipping creation
of the metering-operator for use with run-metering-operator-local.sh.

export LOCAL_METERING_OPERATOR_RUN_INSTALL to enable it to automatically
run the script specified by $METERING_INSTALL_SCRIPT, or
hack/openshift-install.sh by default, prior to running the operator.