### PR TITLE
test: Set scheduled reportStart/end to a range which definitely was collected

### DIFF
--- a/test/e2e/scheduled_report_test.go
+++ b/test/e2e/scheduled_report_test.go
@@ -46,13 +46,13 @@ func testScheduledReportsProduceData(t *testing.T, testFramework *framework.Fram
 			// (1 hour) + the default gracePeriod (5 minutes).
 			// to do this, we set reportStart to 1.5 hours back if it isn't
 			// already
-			now := time.Now().UTC()
-			hourAndAHalf := time.Hour + 30*time.Minute
 			reportStart := periodStart
-			if now.Sub(reportStart) < hourAndAHalf {
-				reportStart = now.Add(-hourAndAHalf)
+			reportEnd := periodEnd
+			if reportEnd.Sub(reportStart) < time.Hour {
+				reportStart = reportEnd.Add(-time.Hour)
 			}
-			report := testFramework.NewSimpleScheduledReport(name, test.queryName, &reportStart)
+			t.Logf("scheduledReport reportingStart: %s, reportingEnd: %s", reportStart, reportEnd)
+			report := testFramework.NewSimpleScheduledReport(name, test.queryName, &reportStart, &reportEnd)
 
 			err := testFramework.MeteringClient.ScheduledReports(testFramework.Namespace).Delete(report.Name, nil)
 			assert.Condition(t, func() bool {

--- a/test/framework/report.go
+++ b/test/framework/report.go
@@ -41,10 +41,13 @@ func (f *Framework) NewSimpleReport(name, queryName string, start, end time.Time
 	}
 }
 
-func (f *Framework) NewSimpleScheduledReport(name, queryName string, reportingStart *time.Time) *meteringv1alpha1.ScheduledReport {
-	var start *meta.Time
+func (f *Framework) NewSimpleScheduledReport(name, queryName string, reportingStart, reportingEnd *time.Time) *meteringv1alpha1.ScheduledReport {
+	var start, end *meta.Time
 	if reportingStart != nil {
 		start = &meta.Time{*reportingStart}
+	}
+	if reportingEnd != nil {
+		end = &meta.Time{*reportingEnd}
 	}
 	return &meteringv1alpha1.ScheduledReport{
 		ObjectMeta: meta.ObjectMeta{
@@ -57,6 +60,7 @@ func (f *Framework) NewSimpleScheduledReport(name, queryName string, reportingSt
 				Period: meteringv1alpha1.ScheduledReportPeriodHourly,
 			},
 			ReportingStart: start,
+			ReportingEnd:   end,
 		},
 	}
 }


### PR DESCRIPTION
Using the current time was a mistake, given that if these run after
other tests, it can drift away from the collected period.