### PR TITLE
manifests: Add additionalPrinterColumns to CRDs for display purposes

### DIFF
--- a/manifests/custom-resource-definitions/report.crd.yaml
+++ b/manifests/custom-resource-definitions/report.crd.yaml
@@ -12,3 +12,16 @@ spec:
   names:
     plural: reports
     kind: Report
+  additionalPrinterColumns:
+  - name: Query
+    type: string
+    JSONPath: .spec.generationQuery
+  - name: Table Name
+    type: string
+    JSONPath: .status.tableName
+  - name: Phase
+    type: string
+    JSONPath: .status.phase
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp

--- a/manifests/custom-resource-definitions/reportdatasource.crd.yaml
+++ b/manifests/custom-resource-definitions/reportdatasource.crd.yaml
@@ -13,3 +13,10 @@ spec:
     plural: reportdatasources
     singular: reportdatasource
     kind: ReportDataSource
+  additionalPrinterColumns:
+  - name: Table Name
+    type: string
+    JSONPath: .status.tableName
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp

--- a/manifests/custom-resource-definitions/reportgenerationquery.crd.yaml
+++ b/manifests/custom-resource-definitions/reportgenerationquery.crd.yaml
@@ -13,3 +13,13 @@ spec:
     plural: reportgenerationqueries
     singular: reportgenerationquery
     kind: ReportGenerationQuery
+  additionalPrinterColumns:
+  - name: View Disabled
+    type: string
+    JSONPath: .spec.view.disabled
+  - name: View Name
+    type: string
+    JSONPath: .status.viewName
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp

--- a/manifests/custom-resource-definitions/scheduledreport.crd.yaml
+++ b/manifests/custom-resource-definitions/scheduledreport.crd.yaml
@@ -12,3 +12,25 @@ spec:
   names:
     plural: scheduledreports
     kind: ScheduledReport
+  additionalPrinterColumns:
+  - name: Query
+    type: string
+    JSONPath: .spec.generationQuery
+  - name: Schedule
+    type: string
+    JSONPath: .spec.schedule.period
+  - name: Running
+    type: string
+    JSONPath: .status.conditions[?(@.type=="Running")].reason
+  - name: Failed
+    type: string
+    JSONPath: .status.conditions[?(@.type=="Failure")].reason
+  - name: Table Name
+    type: string
+    JSONPath: .status.tableName
+  - name: Last Report Time
+    type: string
+    JSONPath: .status.lastReportTime
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp


### PR DESCRIPTION
From Kubernetes 1.11 and onwards the API server can tell kubectl what
columns to print in get/describe output:
https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/#additional-printer-columns

```
kubectl get reportgenerationqueries,reportdatasources,scheduledreports
NAME                                                                                        VIEW DISABLED   VIEW NAME                                AGE
reportgenerationquery.metering.openshift.io/namespace-cpu-request                           true                                                     28m
reportgenerationquery.metering.openshift.io/namespace-cpu-usage                             true                                                     28m
reportgenerationquery.metering.openshift.io/namespace-memory-request                        true                                                     28m
reportgenerationquery.metering.openshift.io/namespace-memory-usage                          true                                                     28m
reportgenerationquery.metering.openshift.io/namespace-persistentvolumeclaim-request         true                                                     28m
reportgenerationquery.metering.openshift.io/node-cpu-allocatable                            false           view_node_cpu_allocatable                28m
reportgenerationquery.metering.openshift.io/node-cpu-capacity                               false           view_node_cpu_capacity                   28m
reportgenerationquery.metering.openshift.io/node-cpu-utilization                            true                                                     28m
reportgenerationquery.metering.openshift.io/node-memory-allocatable                         false           view_node_memory_allocatable             28m
reportgenerationquery.metering.openshift.io/node-memory-capacity                            false           view_node_memory_capacity                28m
reportgenerationquery.metering.openshift.io/node-memory-utilization                         true                                                     28m
reportgenerationquery.metering.openshift.io/persistentvolumeclaim-request                   true                                                     28m
reportgenerationquery.metering.openshift.io/persistentvolumeclaim-request-raw               false           view_persistentvolumeclaim_request_raw   28m
reportgenerationquery.metering.openshift.io/pod-cpu-request                                 true                                                     28m
reportgenerationquery.metering.openshift.io/pod-cpu-request-raw                             false           view_pod_cpu_request_raw                 28m
reportgenerationquery.metering.openshift.io/pod-cpu-request-vs-node-cpu-allocatable         true                                                     28m
reportgenerationquery.metering.openshift.io/pod-cpu-usage                                   true                                                     28m
reportgenerationquery.metering.openshift.io/pod-cpu-usage-raw                               false           view_pod_cpu_usage_raw                   28m
reportgenerationquery.metering.openshift.io/pod-memory-request                              true                                                     28m
reportgenerationquery.metering.openshift.io/pod-memory-request-raw                          false           view_pod_memory_request_raw              28m
reportgenerationquery.metering.openshift.io/pod-memory-request-vs-node-memory-allocatable   true                                                     28m
reportgenerationquery.metering.openshift.io/pod-memory-usage                                true                                                     28m
reportgenerationquery.metering.openshift.io/pod-memory-usage-raw                            false           view_pod_memory_usage_raw                28m

NAME                                                                         TABLE NAME                                       AGE
reportdatasource.metering.openshift.io/node-allocatable-cpu-cores            datasource_node_allocatable_cpu_cores            28m
reportdatasource.metering.openshift.io/node-allocatable-memory-bytes         datasource_node_allocatable_memory_bytes         28m
reportdatasource.metering.openshift.io/node-capacity-cpu-cores               datasource_node_capacity_cpu_cores               28m
reportdatasource.metering.openshift.io/node-capacity-memory-bytes            datasource_node_capacity_memory_bytes            28m
reportdatasource.metering.openshift.io/persistentvolumeclaim-request-bytes   datasource_persistentvolumeclaim_request_bytes   28m
reportdatasource.metering.openshift.io/pod-limit-cpu-cores                   datasource_pod_limit_cpu_cores                   28m
reportdatasource.metering.openshift.io/pod-limit-memory-bytes                datasource_pod_limit_memory_bytes                28m
reportdatasource.metering.openshift.io/pod-request-cpu-cores                 datasource_pod_request_cpu_cores                 28m
reportdatasource.metering.openshift.io/pod-request-memory-bytes              datasource_pod_request_memory_bytes              28m
reportdatasource.metering.openshift.io/pod-usage-cpu-cores                   datasource_pod_usage_cpu_cores                   28m
reportdatasource.metering.openshift.io/pod-usage-memory-bytes                datasource_pod_usage_memory_bytes                28m

NAME                                                                  QUERY                    SCHEDULE   RUNNING                   FAILED   TABLE NAME                                       LAST REPORT TIME       AGE
scheduledreport.metering.openshift.io/namespace-cpu-usage-hourly      namespace-cpu-usage      hourly     ReportPeriodNotFinished            scheduled_report_namespace_cpu_usage_hourly      2018-11-01T00:00:00Z   6m
scheduledreport.metering.openshift.io/namespace-memory-usage-hourly   namespace-memory-usage   hourly     ReportPeriodNotFinished            scheduled_report_namespace_memory_usage_hourly   2018-11-01T00:00:00Z   6m
```