### PR TITLE
Set ScheduledReport condition failure if validation fails

### DIFF
--- a/pkg/apis/metering/v1alpha1/util/scheduled_report_util.go
+++ b/pkg/apis/metering/v1alpha1/util/scheduled_report_util.go
@@ -19,6 +19,10 @@ const (
 	// spec.reportingStart.
 	InvalidReportingEndReason = "InvalidReportingEnd"
 
+	// FailedValidationReason is added to a ScheduledReport when the it's
+	// ReportGenerationQuery or it's dependencies aren't ready
+	FailedValidationReason = "FailedValidation"
+
 	// Running scheduledReport conditions:
 
 	// ScheduledReason is added to a ScheduledReport when it's reached the next

--- a/pkg/operator/query.go
+++ b/pkg/operator/query.go
@@ -51,8 +51,7 @@ func (op *Reporting) syncReportGenerationQuery(logger log.FieldLogger, key strin
 func (op *Reporting) handleReportGenerationQuery(logger log.FieldLogger, generationQuery *cbTypes.ReportGenerationQuery) error {
 	var viewName string
 	if generationQuery.Spec.View.Disabled {
-		logger.Infof("ReportGenerationQuery has spec.view.disabled=true, skipping processing")
-		return nil
+		logger.Infof("ReportGenerationQuery has spec.view.disabled=true, skipping view creation")
 	} else if generationQuery.Status.ViewName == "" {
 		logger.Infof("new ReportGenerationQuery discovered")
 		viewName = reportingutil.GenerationQueryViewName(generationQuery.Name)
@@ -70,27 +69,28 @@ func (op *Reporting) handleReportGenerationQuery(logger log.FieldLogger, generat
 		op.uninitialiedDependendenciesHandler(),
 	)
 	if err != nil {
-		return fmt.Errorf("unable to create view for ReportGenerationQuery %s, failed to validate dependencies %v", generationQuery.Name, err)
+		return fmt.Errorf("unable to validate ReportGenerationQuery %s, failed to validate dependencies %v", generationQuery.Name, err)
 	}
 
-	tmplCtx := &reporting.ReportQueryTemplateContext{
-		DynamicDependentQueries: queryDependencies.DynamicReportGenerationQueries,
-		Report:                  nil,
-	}
+	if viewName != "" {
+		tmplCtx := &reporting.ReportQueryTemplateContext{
+			DynamicDependentQueries: queryDependencies.DynamicReportGenerationQueries,
+			Report:                  nil,
+		}
+		renderedQuery, err := reporting.RenderQuery(generationQuery.Spec.Query, tmplCtx)
+		if err != nil {
+			return err
+		}
 
-	renderedQuery, err := reporting.RenderQuery(generationQuery.Spec.Query, tmplCtx)
-	if err != nil {
-		return err
-	}
+		err = op.prestoViewCreator.CreateView(viewName, renderedQuery)
+		if err != nil {
+			return fmt.Errorf("error creating view %s for ReportGenerationQuery %s: %v", viewName, generationQuery.Name, err)
+		}
 
-	err = op.prestoViewCreator.CreateView(viewName, renderedQuery)
-	if err != nil {
-		return err
-	}
-
-	err = op.updateReportQueryViewName(logger, generationQuery, viewName)
-	if err != nil {
-		return err
+		err = op.updateReportQueryViewName(logger, generationQuery, viewName)
+		if err != nil {
+			return err
+		}
 	}
 
 	// enqueue any queries depending on this one

--- a/pkg/operator/scheduled_reports.go
+++ b/pkg/operator/scheduled_reports.go
@@ -355,7 +355,31 @@ func (op *Reporting) runScheduledReport(logger log.FieldLogger, report *cbTypes.
 		op.uninitialiedDependendenciesHandler(),
 	)
 	if err != nil {
-		return fmt.Errorf("unable to run ScheduledReport %s, ReportGenerationQuery %s, failed to validate dependencies: %v", report.Name, genQuery.Name, err)
+		// wrapped the error with more information
+		err = fmt.Errorf("unable to run ScheduledReport %s, ReportGenerationQuery %s, failed to validate dependencies: %v", report.Name, genQuery.Name, err)
+
+		// avoid continously triggering an update cycle if we're already failed
+		// validation
+		if isFailureCond := cbutil.GetScheduledReportCondition(report.Status, cbTypes.ScheduledReportFailure); isFailureCond != nil && isFailureCond.Status == v1.ConditionTrue && isFailureCond.Reason == cbutil.FailedValidationReason {
+			logger.Warnf("ScheduledReport %s failed validation last reconcile, skipping updating status", report.Name)
+		} else {
+			// update the status to indicate the query failed validation
+			failureCondition := cbutil.NewScheduledReportCondition(cbTypes.ScheduledReportFailure, v1.ConditionTrue, cbutil.FailedValidationReason, err.Error())
+			cbutil.RemoveScheduledReportCondition(&report.Status, cbTypes.ScheduledReportRunning)
+			cbutil.SetScheduledReportCondition(&report.Status, *failureCondition)
+
+			// store updateErr so we can log it and return the wrapped error
+			_, updateErr := op.meteringClient.MeteringV1alpha1().ScheduledReports(report.Namespace).Update(report)
+			if err != nil {
+				logger.WithError(updateErr).Errorf("unable to update ScheduledReport status")
+				return err
+			}
+		}
+		return err
+	}
+	// if it was previously failed validation, remove the status
+	if isFailureCond := cbutil.GetScheduledReportCondition(report.Status, cbTypes.ScheduledReportFailure); isFailureCond != nil && isFailureCond.Status == v1.ConditionTrue && isFailureCond.Reason == cbutil.FailedValidationReason {
+		cbutil.RemoveScheduledReportCondition(&report.Status, cbTypes.ScheduledReportFailure)
 	}
 
 	if reportGracePeriodUnmet {


### PR DESCRIPTION
The idea here is to surface dependency validation errors to users when a scheduledReport has a reportGenerationQuery which is uninitialized, or has uninitialized ReportDataSource/ReportGenerationQuery dependencies itself.

To test this:
- Modify a reportGenerationQuery and add a non-existent ReportDataSource and/or ReportGenerationQuery to it's spec.reportDataSources or spec.reportQueries field.
   - `kubectl edit reportgenerationquery namespace-cpu-usage` then edit the `spec.reportQueries` list to include an item that doesn't exist.
- Create a scheduledReport that uses the above reportGenerationQuery

Query the scheduledReport and check it's status:
```
kubectl get scheduledreport
NAME                            QUERY                    SCHEDULE   RUNNING                     FAILED             TABLE NAME                                       LAST REPORT TIME       AGE
namespace-cpu-usage-hourly      namespace-cpu-usage      hourly     ValidatingScheduledReport   FailedValidation                                                    2018-11-01T12:00:00Z   14s
```