### PR TITLE
manifests: Add short names to long CRDs

### DIFF
--- a/manifests/custom-resource-definitions/reportdatasource.crd.yaml
+++ b/manifests/custom-resource-definitions/reportdatasource.crd.yaml
@@ -13,6 +13,9 @@ spec:
     plural: reportdatasources
     singular: reportdatasource
     kind: ReportDataSource
+    shortNames:
+    - datasource
+    - datasources
   additionalPrinterColumns:
   - name: Table Name
     type: string

--- a/manifests/custom-resource-definitions/reportgenerationquery.crd.yaml
+++ b/manifests/custom-resource-definitions/reportgenerationquery.crd.yaml
@@ -13,6 +13,8 @@ spec:
     plural: reportgenerationqueries
     singular: reportgenerationquery
     kind: ReportGenerationQuery
+    shortNames:
+    - rgq
   additionalPrinterColumns:
   - name: View Disabled
     type: string

--- a/manifests/custom-resource-definitions/reportprometheusquery.crd.yaml
+++ b/manifests/custom-resource-definitions/reportprometheusquery.crd.yaml
@@ -13,3 +13,5 @@ spec:
     plural: reportprometheusqueries
     singular: reportprometheusquery
     kind: ReportPrometheusQuery
+    shortNames:
+    - rpq


### PR DESCRIPTION
I'm not doing ScheduledReport since we plan to combine it with Report, and report is already short.

This gives us shorter names to use when using kubectl get query reportgenerationqueries and reportprometheusqueries.

Before:
```
kubectl get rgq
error: the server doesn't have a resource type "rgq"
kubectl get rpq
error: the server doesn't have a resource type "rpq"
```

Apply the CRDs:
```
kubectl apply -f manifests/custom-resource-definitions
```
After:
```
kubectl get rgq
NAME                                            VIEW DISABLED   VIEW NAME   AGE
namespace-cpu-request                           true                        48s
namespace-cpu-usage                             true                        48s
namespace-memory-request                        true                        47s
namespace-memory-usage                          true                        47s
namespace-persistentvolumeclaim-request         true                        46s
node-cpu-allocatable                                                        49s
node-cpu-capacity                                                           49s
node-cpu-utilization                            true                        49s
node-memory-allocatable                                                     48s
node-memory-capacity                                                        48s
node-memory-utilization                         true                        48s
persistentvolumeclaim-request                   true                        46s
persistentvolumeclaim-request-raw                                           46s
pod-cpu-request                                 true                        48s
pod-cpu-request-raw                                                         48s
pod-cpu-request-vs-node-cpu-allocatable         true                        48s
pod-cpu-usage                                   true                        47s
pod-cpu-usage-raw                                                           48s
pod-memory-request                              true                        47s
pod-memory-request-raw                                                      47s
pod-memory-request-vs-node-memory-allocatable   true                        47s
pod-memory-usage                                true                        47s
pod-memory-usage-raw                                                        47s

kubectl get rpq
NAME                                  AGE
node-allocatable-cpu-cores            1m
node-allocatable-memory-bytes         1m
node-capacity-cpu-cores               1m
node-capacity-memory-bytes            1m
persistentvolumeclaim-request-bytes   1m
pod-limit-cpu-cores                   1m
pod-limit-memory-bytes                1m
pod-request-cpu-cores                 1m
pod-request-memory-bytes              1m
pod-usage-cpu-cores                   1m
pod-usage-memory-bytes                1m
```