### PR TITLE
pkg/operator: Update resource DeepCopies to happen earlier

### DIFF
--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -79,11 +79,12 @@ func (op *Reporting) syncReportDataSource(logger log.FieldLogger, key string) er
 		return err
 	}
 
-	return op.handleReportDataSource(logger, reportDataSource)
+	// Deep-copy otherwise we are mutating our cache
+	ds := reportDataSource.DeepCopy()
+	return op.handleReportDataSource(logger, ds)
 }
 
 func (op *Reporting) handleReportDataSource(logger log.FieldLogger, dataSource *cbTypes.ReportDataSource) error {
-	dataSource = dataSource.DeepCopy()
 	var err error
 	switch {
 	case dataSource.Spec.Promsum != nil:

--- a/pkg/operator/prestotables.go
+++ b/pkg/operator/prestotables.go
@@ -68,30 +68,29 @@ func (op *Reporting) syncPrestoTable(logger log.FieldLogger, key string) error {
 		}
 		return err
 	}
+	pt := prestoTable.DeepCopy()
 
-	if prestoTable.DeletionTimestamp != nil {
+	if pt.DeletionTimestamp != nil {
 		logger.Infof("PrestoTable is marked for deletion, performing cleanup")
-		err := op.dropPrestoTable(prestoTable)
+		err := op.dropPrestoTable(pt)
 		if err != nil {
 			return err
 		}
-		_, err = op.removePrestoTableFinalizer(prestoTable)
+		_, err = op.removePrestoTableFinalizer(pt)
 		return err
 	}
 
-	logger.Infof("syncing PrestoTable %s", prestoTable.GetName())
-	err = op.handlePrestoTable(logger, prestoTable)
+	logger.Infof("syncing PrestoTable %s", pt.GetName())
+	err = op.handlePrestoTable(logger, pt)
 	if err != nil {
-		logger.WithError(err).Errorf("error syncing PrestoTable %s", prestoTable.GetName())
+		logger.WithError(err).Errorf("error syncing PrestoTable %s", pt.GetName())
 		return err
 	}
-	logger.Infof("successfully synced PrestoTable %s", prestoTable.GetName())
+	logger.Infof("successfully synced PrestoTable %s", pt.GetName())
 	return nil
 }
 
 func (op *Reporting) handlePrestoTable(logger log.FieldLogger, prestoTable *cbTypes.PrestoTable) error {
-	prestoTable = prestoTable.DeepCopy()
-
 	if op.cfg.EnableFinalizers && prestoTableNeedsFinalizer(prestoTable) {
 		var err error
 		prestoTable, err = op.addPrestoTableFinalizer(prestoTable)

--- a/pkg/operator/query.go
+++ b/pkg/operator/query.go
@@ -44,13 +44,11 @@ func (op *Reporting) syncReportGenerationQuery(logger log.FieldLogger, key strin
 		}
 		return err
 	}
-
-	return op.handleReportGenerationQuery(logger, reportGenerationQuery)
+	q := reportGenerationQuery.DeepCopy()
+	return op.handleReportGenerationQuery(logger, q)
 }
 
 func (op *Reporting) handleReportGenerationQuery(logger log.FieldLogger, generationQuery *cbTypes.ReportGenerationQuery) error {
-	generationQuery = generationQuery.DeepCopy()
-
 	var viewName string
 	if generationQuery.Spec.View.Disabled {
 		logger.Infof("ReportGenerationQuery has spec.view.disabled=true, skipping processing")

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -85,12 +85,11 @@ func (op *Reporting) syncReport(logger log.FieldLogger, key string) error {
 		return err
 	}
 
-	return op.handleReport(logger, report)
+	r := report.DeepCopy()
+	return op.handleReport(logger, r)
 }
 
 func (op *Reporting) handleReport(logger log.FieldLogger, report *cbTypes.Report) error {
-	report = report.DeepCopy()
-
 	tableName := reportingutil.ReportTableName(report.Name)
 	metricLabels := prometheus.Labels{
 		"report":                report.Name,

--- a/pkg/operator/scheduled_reports.go
+++ b/pkg/operator/scheduled_reports.go
@@ -86,13 +86,14 @@ func (op *Reporting) syncScheduledReport(logger log.FieldLogger, key string) err
 		}
 		return err
 	}
+	sr := scheduledReport.DeepCopy()
 
 	if scheduledReport.DeletionTimestamp != nil {
-		_, err = op.removeScheduledReportFinalizer(scheduledReport)
+		_, err = op.removeScheduledReportFinalizer(sr)
 		return err
 	}
 
-	return op.handleScheduledReport(logger, scheduledReport)
+	return op.handleScheduledReport(logger, sr)
 }
 
 type reportSchedule interface {
@@ -185,8 +186,6 @@ func getSchedule(reportSched cbTypes.ScheduledReportSchedule) (reportSchedule, e
 }
 
 func (op *Reporting) handleScheduledReport(logger log.FieldLogger, scheduledReport *cbTypes.ScheduledReport) error {
-	scheduledReport = scheduledReport.DeepCopy()
-
 	if op.cfg.EnableFinalizers && scheduledReportNeedsFinalizer(scheduledReport) {
 		var err error
 		scheduledReport, err = op.addScheduledReportFinalizer(scheduledReport)


### PR DESCRIPTION
To ensure we are never mutating the objects returned from the cache,
create the copy immediately after it's retrieved.