### PR TITLE
charts/reporting-operator: Lower readiness probe period

### DIFF
--- a/charts/reporting-operator/values.yaml
+++ b/charts/reporting-operator/values.yaml
@@ -114,9 +114,9 @@ spec:
   readinessProbe:
    initialDelaySeconds: 60
    timeoutSeconds: 60
-   periodSeconds: 10
+   periodSeconds: 60
    successThreshold: 1
-   failureThreshold: 6
+   failureThreshold: 3
    httpGet:
      path: /ready
      port: 8080


### PR DESCRIPTION
This was basically querying presto every 10 seconds after startup which
is a bit excessive.