### PR TITLE
Run a single e2e/integration test per jenkins job

### DIFF
--- a/hack/e2e-test-runner.sh
+++ b/hack/e2e-test-runner.sh
@@ -6,12 +6,11 @@ set -e
 
 : "${TEST_SCRIPT:?}"
 
-: "${TEST_LOG_FILE:?}"
-: "${DEPLOY_LOG_FILE:?}"
-: "${TEST_TAP_FILE:?}"
-
-: "${DEPLOY_POD_LOGS_LOG_FILE:=""}"
-: "${FINAL_POD_LOGS_LOG_FILE:=""}"
+: "${TEST_TAP_FILE:=tests.tap}"
+: "${TEST_LOG_FILE:=tests.txt}"
+: "${DEPLOY_LOG_FILE:=deploy.log}"
+: "${DEPLOY_POD_LOGS_LOG_FILE:=pod-logs.log}"
+: "${FINAL_POD_LOGS_LOG_FILE:=final-pod-descriptions-logs.log}"
 
 : "${DEPLOY_METERING:=true}"
 : "${TEST_METERING:=true}"
@@ -37,33 +36,44 @@ echo "\$KUBECONFIG=$KUBECONFIG"
 echo "\$METERING_NAMESPACE=$METERING_NAMESPACE"
 echo "\$INSTALL_METHOD=$INSTALL_METHOD"
 
-mkdir -p $TEST_OUTPUT_PATH
-touch "$TEST_OUTPUT_PATH/$TEST_LOG_FILE"
-touch "$TEST_OUTPUT_PATH/$DEPLOY_LOG_FILE"
-touch "$TEST_OUTPUT_PATH/$TEST_TAP_FILE"
-touch "$TEST_OUTPUT_PATH/$DEPLOY_POD_LOGS_LOG_FILE"
-touch "$TEST_OUTPUT_PATH/$FINAL_POD_LOGS_LOG_FILE"
+REPORTS_DIR=$TEST_OUTPUT_PATH/reports
+LOG_DIR=$TEST_OUTPUT_PATH/logs
+TEST_OUT_DIR=$TEST_OUTPUT_PATH/tests
+
+TEST_LOG_FILE_PATH="${TEST_LOG_FILE_PATH:-$TEST_OUT_DIR/$TEST_LOG_FILE}"
+TEST_TAP_FILE_PATH="${TEST_TAP_FILE_PATH:-$TEST_OUT_DIR/$TEST_TAP_FILE}"
+DEPLOY_LOG_FILE_PATH="${DEPLOY_LOG_FILE_PATH:-$LOG_DIR/$DEPLOY_LOG_FILE}"
+DEPLOY_POD_LOGS_LOG_FILE_PATH="${DEPLOY_POD_LOGS_LOG_FILE_PATH:-$LOG_DIR/$DEPLOY_POD_LOGS_LOG_FILE}"
+FINAL_POD_LOGS_LOG_FILE_PATH="${FINAL_POD_LOGS_LOG_FILE_PATH:-$LOG_DIR/$FINAL_POD_LOGS_LOG_FILE}"
+
+mkdir -p $TEST_OUT_DIR $LOG_DIR $REPORTS_DIR
+touch "$TEST_LOG_FILE_PATH"
+touch "$TEST_TAP_FILE_PATH"
+touch "$DEPLOY_LOG_FILE_PATH"
+touch "$DEPLOY_POD_LOGS_LOG_FILE_PATH"
+touch "$FINAL_POD_LOGS_LOG_FILE_PATH"
 
 # fail with the last non-zero exit code (preserves test fail exit code)
 set -o pipefail
 
 export SKIP_DELETE_CRDS=true
 export DELETE_PVCS=true
+export TEST_RESULT_REPORT_OUTPUT_DIRECTORY="$REPORTS_DIR"
 
 function cleanup() {
     echo "Performing cleanup"
 
     if [ -n "$FINAL_POD_LOGS_LOG_FILE" ]; then
         echo "Capturing final pod logs"
-        capture_pod_logs "$METERING_NAMESPACE" >> "$TEST_OUTPUT_PATH/$FINAL_POD_LOGS_LOG_FILE"
+        capture_pod_logs "$METERING_NAMESPACE" >> "$FINAL_POD_LOGS_LOG_FILE_PATH"
         echo "Finished capturing final pod logs"
     fi
 
     echo "Running uninstall"
     if [ "$OUTPUT_DEPLOY_LOG_STDOUT" == "true" ]; then
-        uninstall_metering "$INSTALL_METHOD" | tee -a "$TEST_OUTPUT_PATH/$DEPLOY_LOG_FILE"
+        uninstall_metering "$INSTALL_METHOD" | tee -a "$DEPLOY_LOG_FILE_PATH"
     else
-        uninstall_metering "$INSTALL_METHOD" >> "$TEST_OUTPUT_PATH/$DEPLOY_LOG_FILE"
+        uninstall_metering "$INSTALL_METHOD" >> "$DEPLOY_LOG_FILE_PATH"
     fi
 
     # kill any background jobs, such as stern
@@ -76,9 +86,9 @@ if [ "$DEPLOY_METERING" == "true" ]; then
     if [ -n "$DEPLOY_POD_LOGS_LOG_FILE" ]; then
         echo "Capturing pod logs"
         if [ "$OUTPUT_POD_LOG_STDOUT" == "true" ]; then
-            stern --timestamps -n "$METERING_NAMESPACE" '.*' | tee -a "$TEST_OUTPUT_PATH/$DEPLOY_POD_LOGS_LOG_FILE" &
+            stern --timestamps -n "$METERING_NAMESPACE" '.*' | tee -a "$DEPLOY_POD_LOGS_LOG_FILE_PATH" &
         else
-            stern --timestamps -n "$METERING_NAMESPACE" '.*' >> "$TEST_OUTPUT_PATH/$DEPLOY_POD_LOGS_LOG_FILE" &
+            stern --timestamps -n "$METERING_NAMESPACE" '.*' >> "$DEPLOY_POD_LOGS_LOG_FILE_PATH" &
         fi
     fi
 
@@ -88,9 +98,9 @@ if [ "$DEPLOY_METERING" == "true" ]; then
 
     echo "Deploying Metering"
     if [ "$OUTPUT_DEPLOY_LOG_STDOUT" == "true" ]; then
-        "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" | tee -a "$TEST_OUTPUT_PATH/$DEPLOY_LOG_FILE" 2>&1
+        "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" | tee -a "$DEPLOY_LOG_FILE_PATH" 2>&1
     else
-        "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" >> "$TEST_OUTPUT_PATH/$DEPLOY_LOG_FILE" 2>&1
+        "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" >> "$DEPLOY_LOG_FILE_PATH" 2>&1
     fi
 fi
 
@@ -99,17 +109,17 @@ if [ "$TEST_METERING" == "true" ]; then
 
 
     if [ "$OUTPUT_TEST_LOG_STDOUT" == "true" ]; then
-        tail -f "$TEST_OUTPUT_PATH/$TEST_LOG_FILE" &
+        tail -f "$TEST_LOG_FILE_PATH" &
     fi
 
     "$TEST_SCRIPT" 2>&1 \
-        | tee -a "$TEST_OUTPUT_PATH/$TEST_LOG_FILE" \
+        | tee -a "$TEST_LOG_FILE_PATH" \
         | "$ROOT_DIR/bin/test2json" \
-        | tee -a "$TEST_OUTPUT_PATH/${TEST_LOG_FILE}.json" \
+        | tee -a "${TEST_LOG_FILE}.json_PATH" \
         | jq -r -s -f "$ROOT_DIR/hack/tap-output.jq" \
-        | tee -a "$TEST_OUTPUT_PATH/$TEST_TAP_FILE"
+        | tee -a "$TEST_TAP_FILE_PATH"
 
-    if grep -q '^not' < "$TEST_OUTPUT_PATH/$TEST_LOG_FILE"; then
+    if grep -q '^not' < "$TEST_LOG_FILE_PATH"; then
       exit 1
     else
       exit 0

--- a/jenkins/gke-e2e.groovy
+++ b/jenkins/gke-e2e.groovy
@@ -3,4 +3,6 @@ def testRunner = evaluate(readTrusted('jenkins/vars/testRunner.groovy'))
 testRunner {
     testScript = "hack/e2e-ci.sh"
     testType   = "e2e"
+    kubeconfigCredentialsID = 'gke-metering-ci-kubeconfig'
+    deployPlatform = "generic"
 }

--- a/jenkins/gke-integration.groovy
+++ b/jenkins/gke-integration.groovy
@@ -3,4 +3,6 @@ def testRunner = evaluate(readTrusted('jenkins/vars/testRunner.groovy'))
 testRunner {
     testScript = "hack/integration-ci.sh"
     testType   = "integration"
+    kubeconfigCredentialsID = 'gke-metering-ci-kubeconfig'
+    deployPlatform = "generic"
 }

--- a/jenkins/main.groovy
+++ b/jenkins/main.groovy
@@ -92,34 +92,58 @@ pipeline {
 
         stage('Test') {
             parallel {
-                stage("integration") {
+                stage("openshift-integration") {
                     when {
                         expression {
-                            return params.INTEGRATION && !skipIntegrationLabel
+                            return params.INTEGRATION && !skipIntegrationLabel && !skipOpenshift
                         }
                     }
                     steps {
                         echo "Running metering integration tests"
-                        build job: "metering/operator-metering-integration/${env.TARGET_BRANCH}", parameters: [
+                        build job: "metering/operator-metering-openshift-integration/${env.TARGET_BRANCH}", parameters: [
                             string(name: 'DEPLOY_TAG', value: skipBuildLabel ? "master" : env.TARGET_BRANCH),
-                            booleanParam(name: 'GENERIC', value: params.GENERIC && !skipGke),
-                            booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT && !skipOpenshift),
                             booleanParam(name: 'SKIP_NS_CLEANUP', value: params.SKIP_NS_CLEANUP || skipNsCleanup),
                         ]
                     }
                 }
-                stage("e2e") {
+                stage("openshift-e2e") {
                     when {
                         expression {
-                            return params.E2E && !skipE2ELabel
+                            return params.E2E && !skipE2ELabel && !skipOpenshift
                         }
                     }
                     steps {
-                        echo "Running metering e2e tests"
-                        build job: "metering/operator-metering-e2e/${env.TARGET_BRANCH}", parameters: [
+                        echo "Running metering openshift e2e tests"
+                        build job: "metering/operator-metering-openshift-e2e/${env.TARGET_BRANCH}", parameters: [
                             string(name: 'DEPLOY_TAG', value: skipBuildLabel ? "master" : env.TARGET_BRANCH),
-                            booleanParam(name: 'GENERIC', value: params.GENERIC && !skipGke),
-                            booleanParam(name: 'OPENSHIFT', value: params.OPENSHIFT && !skipOpenshift),
+                            booleanParam(name: 'SKIP_NS_CLEANUP', value: params.SKIP_NS_CLEANUP || skipNsCleanup),
+                        ]
+                    }
+                }
+                stage("gke-integration") {
+                    when {
+                        expression {
+                            return params.INTEGRATION && !skipIntegrationLabel && !skipGke
+                        }
+                    }
+                    steps {
+                        echo "Running metering gke integration tests"
+                        build job: "metering/operator-metering-gke-integration/${env.TARGET_BRANCH}", parameters: [
+                            string(name: 'DEPLOY_TAG', value: skipBuildLabel ? "master" : env.TARGET_BRANCH),
+                            booleanParam(name: 'SKIP_NS_CLEANUP', value: params.SKIP_NS_CLEANUP || skipNsCleanup),
+                        ]
+                    }
+                }
+                stage("gke-e2e") {
+                    when {
+                        expression {
+                            return params.E2E && !skipE2ELabel && !skipGke
+                        }
+                    }
+                    steps {
+                        echo "Running metering gke e2e tests"
+                        build job: "metering/operator-metering-gke-e2e/${env.TARGET_BRANCH}", parameters: [
+                            string(name: 'DEPLOY_TAG', value: skipBuildLabel ? "master" : env.TARGET_BRANCH),
                             booleanParam(name: 'SKIP_NS_CLEANUP', value: params.SKIP_NS_CLEANUP || skipNsCleanup),
                         ]
                     }

--- a/jenkins/openshift-e2e.groovy
+++ b/jenkins/openshift-e2e.groovy
@@ -1,0 +1,9 @@
+def testRunner = evaluate(readTrusted('jenkins/vars/testRunner.groovy'))
+
+testRunner {
+    testScript = "hack/e2e-ci.sh"
+    testType   = "e2e"
+    kubeconfigCredentialsID = 'openshift-metering-ci-kubeconfig'
+    deployPlatform = "openshift"
+    meteringHttpsAPI = true
+}

--- a/jenkins/openshift-integration.groovy
+++ b/jenkins/openshift-integration.groovy
@@ -1,0 +1,9 @@
+def testRunner = evaluate(readTrusted('jenkins/vars/testRunner.groovy'))
+
+testRunner {
+    testScript = "hack/integration-ci.sh"
+    testType   = "integration"
+    kubeconfigCredentialsID = 'openshift-metering-ci-kubeconfig'
+    deployPlatform = "openshift"
+    meteringHttpsAPI = true
+}


### PR DESCRIPTION
This updates our pipelines to define a pipeline per environment per test type, making for 4 jobs:

- openshift-integration
- openshift-e2e
- gke-integration
- gke-e2e

This PR updates the re-usable jenkins/vars/testRunner.groovy script so that it's parameterized by the differences in openshift and gke in addition to differences between e2e/integration, and then adds a pipeline file for each job.