### PR TITLE
Only validate non-zero imported metric count of ReportDataSources that are dependencies of queries being tested

### DIFF
--- a/pkg/operator/reporting/validate.go
+++ b/pkg/operator/reporting/validate.go
@@ -193,7 +193,7 @@ func GetDependentViewGenerationQueries(queryGetter reportGenerationQueryGetter, 
 		viewQueries = append(viewQueries, query)
 	}
 	dataSources := make([]*metering.ReportDataSource, 0, len(dataSourcesAccumulator))
-	for _, ds := range dataSources {
+	for _, ds := range dataSourcesAccumulator {
 		dataSources = append(dataSources, ds)
 	}
 
@@ -214,7 +214,7 @@ func GetDependentDynamicGenerationQueries(queryGetter reportGenerationQueryGette
 	}
 
 	dataSources := make([]*metering.ReportDataSource, 0, len(dataSourcesAccumulator))
-	for _, ds := range dataSources {
+	for _, ds := range dataSourcesAccumulator {
 		dataSources = append(dataSources, ds)
 	}
 
@@ -345,7 +345,7 @@ func GetDependentDataSources(dataSourceGetter reportDataSourceGetter, generation
 		return nil, err
 	}
 	dataSources := make([]*metering.ReportDataSource, 0, len(dataSourceAccumulator))
-	for _, ds := range dataSources {
+	for _, ds := range dataSourceAccumulator {
 		dataSources = append(dataSources, ds)
 	}
 	return dataSources, nil

--- a/pkg/operator/reporting/validate.go
+++ b/pkg/operator/reporting/validate.go
@@ -140,18 +140,25 @@ func GetGenerationQueryDependencies(
 	scheduledReportGetter scheduledReportGetter,
 	generationQuery *metering.ReportGenerationQuery,
 ) (*ReportGenerationQueryDependencies, error) {
-	viewQueries, err := GetDependentViewGenerationQueries(queryGetter, generationQuery)
+	viewQueries, viewQueriesDataSources, err := GetDependentViewGenerationQueries(queryGetter, dataSourceGetter, generationQuery)
 	if err != nil {
 		return nil, err
 	}
-	dynamicQueries, err := GetDependentDynamicGenerationQueries(queryGetter, generationQuery)
+	dynamicQueries, dynamicQueriesDataSources, err := GetDependentDynamicGenerationQueries(queryGetter, dataSourceGetter, generationQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	dataSources, err := GetDependentDataSources(dataSourceGetter, generationQuery)
-	if err != nil {
-		return nil, err
+	// deduplicate the list of ReportDataSources
+	seen := make(map[string]struct{})
+	allDs := append(viewQueriesDataSources, dynamicQueriesDataSources...)
+	var dataSources []*metering.ReportDataSource
+	for _, ds := range allDs {
+		if _, exists := seen[ds.Name]; exists {
+			continue
+		}
+		dataSources = append(dataSources, ds)
+		seen[ds.Name] = struct{}{}
 	}
 
 	reports, err := GetDependentReports(reportGetter, generationQuery)
@@ -173,32 +180,45 @@ func GetGenerationQueryDependencies(
 	}, nil
 }
 
-func GetDependentViewGenerationQueries(queryGetter reportGenerationQueryGetter, generationQuery *metering.ReportGenerationQuery) ([]*metering.ReportGenerationQuery, error) {
+func GetDependentViewGenerationQueries(queryGetter reportGenerationQueryGetter, dataSourceGetter reportDataSourceGetter, generationQuery *metering.ReportGenerationQuery) ([]*metering.ReportGenerationQuery, []*metering.ReportDataSource, error) {
 	viewReportQueriesAccumulator := make(map[string]*metering.ReportGenerationQuery)
-	err := GetDependentGenerationQueriesMemoized(queryGetter, generationQuery, 0, maxDepth, viewReportQueriesAccumulator, false)
+	dataSourcesAccumulator := make(map[string]*metering.ReportDataSource)
+	err := GetDependentGenerationQueriesWithDataSourcesMemoized(queryGetter, dataSourceGetter, generationQuery, 0, maxDepth, viewReportQueriesAccumulator, dataSourcesAccumulator, false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	viewQueries := make([]*metering.ReportGenerationQuery, 0, len(viewReportQueriesAccumulator))
 	for _, query := range viewReportQueriesAccumulator {
 		viewQueries = append(viewQueries, query)
 	}
-	return viewQueries, nil
+	dataSources := make([]*metering.ReportDataSource, 0, len(dataSourcesAccumulator))
+	for _, ds := range dataSources {
+		dataSources = append(dataSources, ds)
+	}
+
+	return viewQueries, dataSources, nil
 }
 
-func GetDependentDynamicGenerationQueries(queryGetter reportGenerationQueryGetter, generationQuery *metering.ReportGenerationQuery) ([]*metering.ReportGenerationQuery, error) {
+func GetDependentDynamicGenerationQueries(queryGetter reportGenerationQueryGetter, dataSourceGetter reportDataSourceGetter, generationQuery *metering.ReportGenerationQuery) ([]*metering.ReportGenerationQuery, []*metering.ReportDataSource, error) {
 	dynamicReportQueriesAccumulator := make(map[string]*metering.ReportGenerationQuery)
-	err := GetDependentGenerationQueriesMemoized(queryGetter, generationQuery, 0, maxDepth, dynamicReportQueriesAccumulator, true)
+	dataSourcesAccumulator := make(map[string]*metering.ReportDataSource)
+	err := GetDependentGenerationQueriesWithDataSourcesMemoized(queryGetter, dataSourceGetter, generationQuery, 0, maxDepth, dynamicReportQueriesAccumulator, dataSourcesAccumulator, true)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	dynamicQueries := make([]*metering.ReportGenerationQuery, 0, len(dynamicReportQueriesAccumulator))
 	for _, query := range dynamicReportQueriesAccumulator {
 		dynamicQueries = append(dynamicQueries, query)
 	}
-	return dynamicQueries, nil
+
+	dataSources := make([]*metering.ReportDataSource, 0, len(dataSourcesAccumulator))
+	for _, ds := range dataSources {
+		dataSources = append(dataSources, ds)
+	}
+
+	return dynamicQueries, dataSources, nil
 }
 
 type reportGenerationQueryGetter interface {
@@ -221,6 +241,38 @@ func NewReportGenerationQueryClientGetter(getter meteringClient.ReportGeneration
 	return reportGenerationQueryGetterFunc(func(namespace, name string) (*metering.ReportGenerationQuery, error) {
 		return getter.ReportGenerationQueries(namespace).Get(name, metav1.GetOptions{})
 	})
+}
+
+func GetDependentGenerationQueriesWithDataSourcesMemoized(queryGetter reportGenerationQueryGetter, dataSourceGetter reportDataSourceGetter, generationQuery *metering.ReportGenerationQuery, depth, maxDepth int, queriesAccumulator map[string]*metering.ReportGenerationQuery, dataSourceAccumulator map[string]*metering.ReportDataSource, dynamicQueries bool) error {
+	if depth >= maxDepth {
+		return fmt.Errorf("detected a cycle at depth %d for generationQuery %s", depth, generationQuery.Name)
+	}
+	var queries []string
+	if dynamicQueries {
+		queries = generationQuery.Spec.DynamicReportQueries
+	} else {
+		queries = generationQuery.Spec.ReportQueries
+	}
+	for _, queryName := range queries {
+		if _, exists := queriesAccumulator[queryName]; exists {
+			continue
+		}
+		genQuery, err := queryGetter.getReportGenerationQuery(generationQuery.Namespace, queryName)
+		if err != nil {
+			return err
+		}
+		// get dependent ReportDataSources
+		err = GetDependentDataSourcesMemoized(dataSourceGetter, genQuery, dataSourceAccumulator)
+		if err != nil {
+			return err
+		}
+		err = GetDependentGenerationQueriesWithDataSourcesMemoized(queryGetter, dataSourceGetter, genQuery, depth+1, maxDepth, queriesAccumulator, dataSourceAccumulator, dynamicQueries)
+		if err != nil {
+			return err
+		}
+		queriesAccumulator[genQuery.Name] = genQuery
+	}
+	return nil
 }
 
 func GetDependentGenerationQueriesMemoized(queryGetter reportGenerationQueryGetter, generationQuery *metering.ReportGenerationQuery, depth, maxDepth int, queriesAccumulator map[string]*metering.ReportGenerationQuery, dynamicQueries bool) error {
@@ -272,14 +324,29 @@ func NewReportDataSourceClientGetter(getter meteringClient.ReportDataSourcesGett
 	})
 }
 
-func GetDependentDataSources(dataSourceGetter reportDataSourceGetter, generationQuery *metering.ReportGenerationQuery) ([]*metering.ReportDataSource, error) {
-	dataSources := make([]*metering.ReportDataSource, len(generationQuery.Spec.DataSources))
-	for i, dataSourceName := range generationQuery.Spec.DataSources {
+func GetDependentDataSourcesMemoized(dataSourceGetter reportDataSourceGetter, generationQuery *metering.ReportGenerationQuery, dataSourceAccumulator map[string]*metering.ReportDataSource) error {
+	for _, dataSourceName := range generationQuery.Spec.DataSources {
+		if _, exists := dataSourceAccumulator[dataSourceName]; exists {
+			continue
+		}
 		dataSource, err := dataSourceGetter.getReportDataSource(generationQuery.Namespace, dataSourceName)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		dataSources[i] = dataSource
+		dataSourceAccumulator[dataSource.Name] = dataSource
+	}
+	return nil
+}
+
+func GetDependentDataSources(dataSourceGetter reportDataSourceGetter, generationQuery *metering.ReportGenerationQuery) ([]*metering.ReportDataSource, error) {
+	dataSourceAccumulator := make(map[string]*metering.ReportDataSource)
+	err := GetDependentDataSourcesMemoized(dataSourceGetter, generationQuery, dataSourceAccumulator)
+	if err != nil {
+		return nil, err
+	}
+	dataSources := make([]*metering.ReportDataSource, 0, len(dataSourceAccumulator))
+	for _, ds := range dataSources {
+		dataSources = append(dataSources, ds)
 	}
 	return dataSources, nil
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/operator-framework/operator-metering/pkg/operator"
 	"github.com/operator-framework/operator-metering/test/framework"
 )
 
@@ -200,7 +201,12 @@ func TestReportingE2E(t *testing.T) {
 		// used by our test cases are initialized
 		testFramework.RequireReportGenerationQueriesReady(t, queries, time.Second*5, waitTimeout)
 
-		periodStart, periodEnd := testFramework.CollectMetricsOnce(t)
+		var periodStart, periodEnd time.Time
+		var collectResp operator.CollectPromsumDataResponse
+		t.Run("TestMetricsCollection", func(t *testing.T) {
+			periodStart, periodEnd, collectResp = testFramework.CollectMetricsOnce(t)
+			testFramework.RequireReportDataSourcesForQueryHaveData(t, queries, collectResp)
+		})
 
 		t.Run("TestReportsProduceData", func(t *testing.T) {
 			testReportsProduceData(t, testFramework, periodStart, periodEnd, reportsProduceDataTestCases)

--- a/test/framework/collect.go
+++ b/test/framework/collect.go
@@ -15,7 +15,7 @@ import (
 // imported
 const collectionSize = 30 * time.Minute
 
-func (f *Framework) CollectMetricsOnce(t *testing.T) (time.Time, time.Time) {
+func (f *Framework) CollectMetricsOnce(t *testing.T) (time.Time, time.Time, operator.CollectPromsumDataResponse) {
 	t.Helper()
 	f.collectOnce.Do(func() {
 		// Use UTC, Prometheus uses UTCf for timestamps
@@ -50,9 +50,7 @@ func (f *Framework) CollectMetricsOnce(t *testing.T) (time.Time, time.Time) {
 		require.NoError(t, err, "expected to unmarshal CollectPrometheusData response as JSON")
 		t.Logf("CollectPromsumDataResponse: %s", spew.Sdump(collectResp))
 		require.NotEmpty(t, collectResp.Results, "expected multiple import results")
-		for _, result := range collectResp.Results {
-			require.NotZerof(t, result.MetricsImportedCount, "expected metric import count for ReportDataSource %s to not be zero", result.ReportDataSource)
-		}
+		f.collectPromsumDataResponse = collectResp
 	})
-	return f.reportStart, f.reportEnd
+	return f.reportStart, f.reportEnd, f.collectPromsumDataResponse
 }

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	meteringv1alpha1 "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1alpha1"
+	"github.com/operator-framework/operator-metering/pkg/operator"
 )
 
 type Framework struct {
@@ -21,10 +22,11 @@ type Framework struct {
 	Namespace      string
 	DefaultTimeout time.Duration
 
-	protocol    string
-	collectOnce sync.Once
-	reportStart time.Time
-	reportEnd   time.Time
+	protocol                   string
+	collectOnce                sync.Once
+	reportStart                time.Time
+	reportEnd                  time.Time
+	collectPromsumDataResponse operator.CollectPromsumDataResponse
 }
 
 // New initializes a test framework and returns it.


### PR DESCRIPTION
Previously CollectMetricsOnce blindly assumed all ReportDataSources
should have non-zero metrics, but we're getting to a point where we
aren't always using every ReportDataSource in every e2e env, so we need
the ability to only validate the metric import count for a
ReportDataSource is non-zero if it's a direct dependency of the queries
we're testing.