### PR TITLE
charts/reporting-operator: Make node-memory/cpu-capacity/allocatable queries filterable

### DIFF
--- a/charts/reporting-operator/templates/custom-resources/report-queries/node-cpu.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/node-cpu.yaml
@@ -1,7 +1,7 @@
 apiVersion: metering.openshift.io/v1alpha1
 kind: ReportGenerationQuery
 metadata:
-  name: "node-cpu-capacity"
+  name: "node-cpu-capacity-raw"
   labels:
     operator-metering: "true"
 {{- block "extraMetadata" . }}
@@ -45,7 +45,53 @@ spec:
 apiVersion: metering.openshift.io/v1alpha1
 kind: ReportGenerationQuery
 metadata:
-  name: "node-cpu-allocatable"
+  name: "node-cpu-capacity"
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  reportQueries:
+  - "node-cpu-capacity-raw"
+  view:
+    disabled: true
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: node
+    type: string
+    unit: kubernetes_node
+  - name: resource_id
+    type: string
+  - name: node_capacity_cpu_core_seconds
+    type: double
+    unit: cpu_core_seconds
+  inputs:
+  - name: ReportingStart
+  - name: ReportingEnd
+  query: |
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      node,
+      resource_id,
+      sum(node_capacity_cpu_core_seconds) as node_capacity_cpu_core_seconds
+    FROM {| generationQueryViewName "node-cpu-capacity-raw" |}
+    WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+    AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+    GROUP BY node, resource_id
+    ORDER BY node, resource_id ASC, node_capacity_cpu_core_seconds DESC
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "node-cpu-allocatable-raw"
   labels:
     operator-metering: "true"
 {{- block "extraMetadata" . }}
@@ -88,6 +134,52 @@ spec:
 apiVersion: metering.openshift.io/v1alpha1
 kind: ReportGenerationQuery
 metadata:
+  name: "node-cpu-allocatable"
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  reportQueries:
+  - "node-cpu-allocatable-raw"
+  view:
+    disabled: true
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: node
+    type: string
+    unit: kubernetes_node
+  - name: resource_id
+    type: string
+  - name: node_allocatable_cpu_core_seconds
+    type: double
+    unit: cpu_core_seconds
+  inputs:
+  - name: ReportingStart
+  - name: ReportingEnd
+  query: |
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      node,
+      resource_id,
+      sum(node_allocatable_cpu_core_seconds) as node_allocatable_cpu_core_seconds
+    FROM {| generationQueryViewName "node-cpu-allocatable-raw" |}
+    WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+    AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+    GROUP BY node, resource_id
+    ORDER BY node, resource_id ASC, node_allocatable_cpu_core_seconds DESC
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
   name: "node-cpu-utilization"
   labels:
     operator-metering: "true"
@@ -95,7 +187,7 @@ metadata:
 {{- end }}
 spec:
   reportQueries:
-  - "node-cpu-allocatable"
+  - "node-cpu-allocatable-raw"
   - "pod-cpu-request-raw"
   view:
     disabled: true
@@ -133,7 +225,7 @@ spec:
       SELECT min("timestamp") as node_allocatable_data_start,
         max("timestamp") as node_allocatable_data_end,
         sum(node_allocatable_cpu_core_seconds) as node_allocatable_cpu_core_seconds
-      FROM {| generationQueryViewName "node-cpu-allocatable" |}
+      FROM {| generationQueryViewName "node-cpu-allocatable-raw" |}
         WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     ), pod_cpu_consumption AS (

--- a/charts/reporting-operator/templates/custom-resources/report-queries/node-memory.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/node-memory.yaml
@@ -1,7 +1,7 @@
 apiVersion: metering.openshift.io/v1alpha1
 kind: ReportGenerationQuery
 metadata:
-  name: "node-memory-capacity"
+  name: "node-memory-capacity-raw"
   labels:
     operator-metering: "true"
 {{- block "extraMetadata" . }}
@@ -46,7 +46,53 @@ spec:
 apiVersion: metering.openshift.io/v1alpha1
 kind: ReportGenerationQuery
 metadata:
-  name: "node-memory-allocatable"
+  name: "node-memory-capacity"
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  reportQueries:
+  - "node-memory-capacity-raw"
+  view:
+    disabled: true
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: node
+    type: string
+    unit: kubernetes_node
+  - name: resource_id
+    type: string
+  - name: node_capacity_memory_byte_seconds
+    type: double
+    unit: memory_byte_seconds
+  inputs:
+  - name: ReportingStart
+  - name: ReportingEnd
+  query: |
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      node,
+      resource_id,
+      sum(node_capacity_memory_byte_seconds) as node_capacity_memory_byte_seconds
+    FROM {| generationQueryViewName "node-memory-capacity-raw" |}
+    WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+    AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+    GROUP BY node, resource_id
+    ORDER BY node, resource_id ASC, node_capacity_memory_byte_seconds DESC
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "node-memory-allocatable-raw"
   labels:
     operator-metering: "true"
 {{- block "extraMetadata" . }}
@@ -91,6 +137,52 @@ spec:
 apiVersion: metering.openshift.io/v1alpha1
 kind: ReportGenerationQuery
 metadata:
+  name: "node-memory-allocatable"
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  reportQueries:
+  - "node-memory-allocatable-raw"
+  view:
+    disabled: true
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: node
+    type: string
+    unit: kubernetes_node
+  - name: resource_id
+    type: string
+  - name: node_allocatable_memory_byte_seconds
+    type: double
+    unit: memory_byte_seconds
+  inputs:
+  - name: ReportingStart
+  - name: ReportingEnd
+  query: |
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      node,
+      resource_id,
+      sum(node_allocatable_memory_byte_seconds) as node_allocatable_memory_byte_seconds
+    FROM {| generationQueryViewName "node-memory-allocatable-raw" |}
+    WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+    AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+    GROUP BY node, resource_id
+    ORDER BY node, resource_id ASC, node_allocatable_memory_byte_seconds DESC
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
   name: "node-memory-utilization"
   labels:
     operator-metering: "true"
@@ -98,7 +190,7 @@ metadata:
 {{- end }}
 spec:
   reportQueries:
-  - "node-memory-allocatable"
+  - "node-memory-allocatable-raw"
   - "pod-memory-request-raw"
   view:
     disabled: true
@@ -139,7 +231,7 @@ spec:
       SELECT min("timestamp") as node_allocatable_data_start,
         max("timestamp") as node_allocatable_data_end,
         sum(node_allocatable_memory_byte_seconds) as node_allocatable_memory_byte_seconds
-      FROM {| generationQueryViewName "node-memory-allocatable" |}
+      FROM {| generationQueryViewName "node-memory-allocatable-raw" |}
         WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     ), pod_memory_consumption AS (

--- a/charts/reporting-operator/templates/custom-resources/report-queries/pod-cpu.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/pod-cpu.yaml
@@ -329,7 +329,7 @@ metadata:
 spec:
   reportQueries:
   - "pod-cpu-request-raw"
-  - "node-cpu-allocatable"
+  - "node-cpu-allocatable-raw"
   view:
     disabled: true
   columns:
@@ -364,7 +364,7 @@ spec:
       SELECT min("timestamp") as node_allocatable_data_start,
         max("timestamp") as node_allocatable_data_end,
         sum(node_allocatable_cpu_core_seconds) as node_allocatable_cpu_core_seconds
-      FROM {| generationQueryViewName "node-cpu-allocatable" |}
+      FROM {| generationQueryViewName "node-cpu-allocatable-raw" |}
         WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     ), pod_cpu_consumption AS (

--- a/charts/reporting-operator/templates/custom-resources/report-queries/pod-memory.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/pod-memory.yaml
@@ -328,7 +328,7 @@ metadata:
 spec:
   reportQueries:
   - "pod-memory-request-raw"
-  - "node-memory-allocatable"
+  - "node-memory-allocatable-raw"
   view:
     disabled: true
   columns:
@@ -366,7 +366,7 @@ spec:
       SELECT min("timestamp") as node_allocatable_data_start,
         max("timestamp") as node_allocatable_data_end,
         sum(node_allocatable_memory_byte_seconds) as node_allocatable_memory_byte_seconds
-      FROM {| generationQueryViewName "node-memory-allocatable" |}
+      FROM {| generationQueryViewName "node-memory-allocatable-raw" |}
         WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     ), pod_memory_consumption AS (


### PR DESCRIPTION
Moves the aliasing to a -raw suffixed query and adds a query with
reportingStart/reportingEnd inputs to replace the previous.