### PR TITLE
pkg/operator: Validate cron.expression is specified when using cron Schedule

### DIFF
--- a/pkg/operator/scheduled_reports.go
+++ b/pkg/operator/scheduled_reports.go
@@ -106,6 +106,9 @@ func getSchedule(reportSched cbTypes.ScheduledReportSchedule) (reportSchedule, e
 	var cronSpec string
 	switch reportSched.Period {
 	case cbTypes.ScheduledReportPeriodCron:
+		if reportSched.Cron == nil || reportSched.Cron.Expression == "" {
+			return nil, fmt.Errorf("spec.schedule.cron.expression must be specified!")
+		}
 		return cron.ParseStandard(reportSched.Cron.Expression)
 	case cbTypes.ScheduledReportPeriodHourly:
 		sched := reportSched.Hourly


### PR DESCRIPTION
A small fix in validation where we assumed a field was set. Caused a panic when unset.