### PR TITLE
Add cluster utilization reports that compare usage and capacity

### DIFF
--- a/charts/reporting-operator/templates/custom-resources/report-queries/cluster-capacity.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/cluster-capacity.yaml
@@ -36,8 +36,6 @@ metadata:
   name: "cluster-cpu-capacity"
   labels:
     operator-metering: "true"
-  labels:
-    operator-metering: "true"
 {{- block "extraMetadata" . }}
 {{- end }}
 spec:
@@ -63,31 +61,26 @@ spec:
   inputs:
   - name: ReportingStart
   - name: ReportingEnd
-  - name: AggregatedReportName
+  - name: ClusterCpuCapacityReportName
   query: |
-    {|/* Default values */|}
-    {|- $inputs := dict "from" (generationQueryViewName "cluster-cpu-capacity-raw") "start" "timestamp"  "end" "timestamp" -|}
-    {|/* Handle aggregating a sub-report */|}
-    {|- if .Report.Inputs.AggregatedReportName -|}
-    {|- $_ := set $inputs "from" (.Report.Inputs.AggregatedReportName | scheduledReportTableName) -|}
-    {|- $_ := set $inputs "start" "period_start" -|}
-    {|- $_ := set $inputs "end" "period_end" -|}
-    {|- end -|}
     SELECT
       timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}' AS period_start,
       timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
-    {|- if .Report.Inputs.AggregatedReportName -|}
+    {|- if .Report.Inputs.ClusterCpuCapacityReportName |}
       sum(total_cluster_capacity_cpu_core_hours) as total_cluster_capacity_cpu_core_hours,
       avg(avg_cluster_capacity_cpu_cores) as avg_cluster_capacity_cpu_cores,
       avg(avg_node_count) AS avg_node_count
+      FROM {| .Report.Inputs.ClusterCpuCapacityReportName | scheduledReportTableName |}
+      WHERE period_start  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+      AND period_end <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     {|- else |}
       sum(cpu_core_seconds) / 60 / 60 as total_cluster_capacity_cpu_core_hours,
       avg(cpu_cores) as avg_cluster_capacity_cpu_cores,
       avg(node_count) AS avg_node_count
+      FROM {| generationQueryViewName "cluster-cpu-capacity-raw" |}
+      WHERE "timestamp"  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+      AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     {|- end |}
-    FROM {| $inputs.from |}
-    WHERE "{| $inputs.start |}"  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
-    AND "{| $inputs.end |}"  < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
 
 ---
 
@@ -129,8 +122,6 @@ metadata:
   name: "cluster-memory-capacity"
   labels:
     operator-metering: "true"
-  labels:
-    operator-metering: "true"
 {{- block "extraMetadata" . }}
 {{- end }}
 spec:
@@ -156,28 +147,23 @@ spec:
   inputs:
   - name: ReportingStart
   - name: ReportingEnd
-  - name: AggregatedReportName
+  - name: ClusterMemoryCapacityReportName
   query: |
-    {|/* Default values */|}
-    {|- $inputs := dict "from" (generationQueryViewName "cluster-memory-capacity-raw") "start" "timestamp"  "end" "timestamp" -|}
-    {|/* Handle aggregating a sub-report */|}
-    {|- if .Report.Inputs.AggregatedReportName -|}
-    {|- $_ := set $inputs "from" (.Report.Inputs.AggregatedReportName | scheduledReportTableName) -|}
-    {|- $_ := set $inputs "start" "period_start" -|}
-    {|- $_ := set $inputs "end" "period_end" -|}
-    {|- end |}
     SELECT
       timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}' AS period_start,
       timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
-    {|- if .Report.Inputs.AggregatedReportName |}
+    {|- if .Report.Inputs.ClusterMemoryCapacityReportName |}
       sum(total_cluster_capacity_memory_byte_hours) as total_cluster_capacity_memory_byte_hours,
       avg(avg_cluster_capacity_memory_bytes) as avg_cluster_capacity_memory_bytes,
       avg(avg_node_count) AS avg_node_count
+      FROM {| .Report.Inputs.ClusterMemoryCapacityReportName | scheduledReportTableName |}
+      WHERE period_start  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+      AND period_end <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     {|- else |}
       sum(memory_byte_seconds) / 60 / 60 as total_cluster_capacity_memory_byte_hours,
       avg(memory_bytes) as avg_cluster_capacity_memory_bytes,
       avg(node_count) AS avg_node_count
+      FROM {| generationQueryViewName "cluster-memory-capacity-raw" |}
+      WHERE "timestamp"  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+      AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     {|- end |}
-    FROM {| $inputs.from |}
-    WHERE "{| $inputs.start |}"  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
-    AND "{| $inputs.end |}"  < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'

--- a/charts/reporting-operator/templates/custom-resources/report-queries/cluster-usage.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/cluster-usage.yaml
@@ -36,8 +36,6 @@ metadata:
   name: "cluster-cpu-usage"
   labels:
     operator-metering: "true"
-  labels:
-    operator-metering: "true"
 {{- block "extraMetadata" . }}
 {{- end }}
 spec:
@@ -63,31 +61,26 @@ spec:
   inputs:
   - name: ReportingStart
   - name: ReportingEnd
-  - name: AggregatedReportName
+  - name: ClusterCpuUsageReportName
   query: |
-    {|/* Default values */|}
-    {|- $inputs := dict "from" (generationQueryViewName "cluster-cpu-usage-raw") "start" "timestamp"  "end" "timestamp" -|}
-    {|/* Handle aggregating a sub-report */|}
-    {|- if .Report.Inputs.AggregatedReportName -|}
-    {|- $_ := set $inputs "from" (.Report.Inputs.AggregatedReportName | scheduledReportTableName) -|}
-    {|- $_ := set $inputs "start" "period_start" -|}
-    {|- $_ := set $inputs "end" "period_end" -|}
-    {|- end -|}
     SELECT
       timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}' AS period_start,
       timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
-    {|- if .Report.Inputs.AggregatedReportName -|}
+    {|- if .Report.Inputs.ClusterCpuUsageReportName |}
       sum(total_cluster_usage_cpu_core_hours) as total_cluster_usage_cpu_core_hours,
       avg(avg_cluster_usage_cpu_cores) as avg_cluster_usage_cpu_cores,
       avg(avg_pod_count) AS avg_pod_count
+      FROM {| .Report.Inputs.ClusterCpuUsageReportName | scheduledReportTableName |}
+      WHERE period_start  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+      AND period_end <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     {|- else |}
       sum(cpu_core_seconds) / 60 / 60 as total_cluster_usage_cpu_core_hours,
       avg(cpu_cores) as avg_cluster_usage_cpu_cores,
       avg(pod_count) AS avg_pod_count
+      FROM {| generationQueryViewName "cluster-cpu-usage-raw" |}
+      WHERE "timestamp"  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+      AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     {|- end |}
-    FROM {| $inputs.from |}
-    WHERE "{| $inputs.start |}"  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
-    AND "{| $inputs.end |}"  < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
 
 ---
 
@@ -129,8 +122,6 @@ metadata:
   name: "cluster-memory-usage"
   labels:
     operator-metering: "true"
-  labels:
-    operator-metering: "true"
 {{- block "extraMetadata" . }}
 {{- end }}
 spec:
@@ -156,28 +147,23 @@ spec:
   inputs:
   - name: ReportingStart
   - name: ReportingEnd
-  - name: AggregatedReportName
+  - name: ClusterMemoryUsageReportName
   query: |
-    {|/* Default values */|}
-    {|- $inputs := dict "from" (generationQueryViewName "cluster-memory-usage-raw") "start" "timestamp"  "end" "timestamp" -|}
-    {|/* Handle aggregating a sub-report */|}
-    {|- if .Report.Inputs.AggregatedReportName -|}
-    {|- $_ := set $inputs "from" (.Report.Inputs.AggregatedReportName | scheduledReportTableName) -|}
-    {|- $_ := set $inputs "start" "period_start" -|}
-    {|- $_ := set $inputs "end" "period_end" -|}
-    {|- end -|}
     SELECT
       timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}' AS period_start,
       timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
-    {|- if .Report.Inputs.AggregatedReportName -|}
+    {|- if .Report.Inputs.ClusterMemoryUsageReportName |}
       sum(total_cluster_usage_memory_byte_hours) as total_cluster_usage_memory_byte_hours,
       avg(avg_cluster_usage_memory_bytes) as avg_cluster_usage_memory_bytes,
       avg(avg_pod_count) AS avg_pod_count
+      FROM {| .Report.Inputs.ClusterMemoryUsageReportName | scheduledReportTableName |}
+      WHERE period_start  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+      AND period_end <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     {|- else |}
       sum(memory_byte_seconds) / 60 / 60 as total_cluster_usage_memory_byte_hours,
       avg(memory_bytes) as avg_cluster_usage_memory_bytes,
       avg(pod_count) AS avg_pod_count
+      FROM {| generationQueryViewName "cluster-memory-usage-raw" |}
+      WHERE "timestamp"  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+      AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     {|- end |}
-    FROM {| $inputs.from |}
-    WHERE "{| $inputs.start |}"  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
-    AND "{| $inputs.end |}"  < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'

--- a/charts/reporting-operator/templates/custom-resources/report-queries/cluster-utilization.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/cluster-utilization.yaml
@@ -1,0 +1,182 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "cluster-cpu-utilization"
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  dynamicReportQueries:
+  - cluster-cpu-capacity
+  - cluster-cpu-usage
+  view:
+    disabled: true
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: total_cluster_capacity_cpu_core_hours
+    type: double
+    unit: cpu_core_hours
+  - name: total_cluster_usage_cpu_core_hours
+    type: double
+    unit: cpu_core_hours
+  - name: cluster_cpu_utilization_percent
+    type: double
+  - name: avg_cluster_capacity_cpu_cores
+    type: double
+    unit: cpu_cores
+  - name: avg_cluster_usage_cpu_cores
+    type: double
+    unit: cpu_cores
+  - name: avg_node_count
+    type: double
+  - name: avg_pod_count
+    type: double
+  - name: avg_pod_per_node_count
+    type: double
+  inputs:
+  - name: ReportingStart
+  - name: ReportingEnd
+  - name: ClusterCpuUtilizationReportName
+  - name: ClusterCpuCapacityReportName
+  - name: ClusterCpuUsageReportName
+  query: |
+    {|/* Handle aggregating a sub-report */|}
+    {|- if .Report.Inputs.ClusterCpuUtilizationReportName -|}
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      sum(total_cluster_capacity_cpu_core_hours) AS total_cluster_capacity_cpu_core_hours,
+      sum(total_cluster_usage_cpu_core_hours) AS total_cluster_usage_cpu_core_hours,
+      avg(cluster_cpu_utilization_percent) AS cluster_cpu_utilization_percent,
+      avg(avg_cluster_capacity_cpu_cores) AS avg_cluster_capacity_cpu_cores,
+      avg(avg_cluster_usage_cpu_cores) AS avg_cluster_usage_cpu_cores,
+      avg(avg_node_count) AS avg_node_count,
+      avg(avg_pod_count) AS avg_pod_count,
+      avg(avg_pod_per_node_count) AS avg_pod_per_node_count
+    FROM {| .Report.Inputs.ClusterCpuUtilizationReportName | scheduledReportTableName |}
+    WHERE period_start  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+    AND period_end <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+    {|- else -|}
+    {|- if or (and (not .Report.Inputs.ClusterCpuCapacityReportName) .Report.Inputs.ClusterCpuUsageReportName) (and (not .Report.Inputs.ClusterCpuUsageReportName) .Report.Inputs.ClusterCpuCapacityReportName) -|}
+    {|- fail "input ClusterCpuCapacityReportName and ClusterCpuUsageReportName must both be set" -|}
+    {|- end -|}
+    WITH cluster_cpu_capacity AS (
+      {| renderReportGenerationQuery "cluster-cpu-capacity" . |}
+    ), cluster_cpu_usage AS (
+      {| renderReportGenerationQuery "cluster-cpu-usage" . |}
+    )
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      capacity.total_cluster_capacity_cpu_core_hours,
+      usage.total_cluster_usage_cpu_core_hours,
+      usage.total_cluster_usage_cpu_core_hours / capacity.total_cluster_capacity_cpu_core_hours AS cluster_cpu_utilization_percent,
+      capacity.avg_cluster_capacity_cpu_cores,
+      usage.avg_cluster_usage_cpu_cores,
+      capacity.avg_node_count,
+      usage.avg_pod_count,
+      usage.avg_pod_count / capacity.avg_node_count AS avg_pod_per_node_count
+    FROM cluster_cpu_usage AS usage
+    JOIN cluster_cpu_capacity AS capacity
+    ON capacity.period_start = usage.period_start
+    AND capacity.period_end = usage.period_end
+    {|- end -|}
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "cluster-memory-utilization"
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  dynamicReportQueries:
+  - cluster-memory-capacity
+  - cluster-memory-usage
+  view:
+    disabled: true
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: total_cluster_capacity_memory_byte_hours
+    type: double
+    unit: memory_byte_hours
+  - name: total_cluster_usage_memory_byte_hours
+    type: double
+    unit: memory_byte_hours
+  - name: cluster_memory_utilization_percent
+    type: double
+  - name: avg_cluster_capacity_memory_bytes
+    type: double
+    unit: memory_bytes
+  - name: avg_cluster_usage_memory_bytes
+    type: double
+    unit: memory_bytes
+  - name: avg_node_count
+    type: double
+  - name: avg_pod_count
+    type: double
+  - name: avg_pod_per_node_count
+    type: double
+  inputs:
+  - name: ReportingStart
+  - name: ReportingEnd
+  - name: ClusterMemoryUtilizationReportName
+  - name: ClusterMemoryCapacityReportName
+  - name: ClusterMemoryUsageReportName
+  query: |
+    {|/* Handle aggregating a sub-report */|}
+    {|- if .Report.Inputs.ClusterMemoryUtilizationReportName -|}
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      sum(total_cluster_capacity_memory_byte_hours) AS total_cluster_capacity_memory_byte_hours,
+      sum(total_cluster_usage_memory_byte_hours) AS total_cluster_usage_memory_byte_hours,
+      avg(cluster_memory_utilization_percent) AS cluster_memory_utilization_percent,
+      avg(avg_cluster_capacity_memory_bytes) AS avg_cluster_capacity_memory_bytes,
+      avg(avg_cluster_usage_memory_bytes) AS avg_cluster_usage_memory_bytes,
+      avg(avg_node_count) AS avg_node_count,
+      avg(avg_pod_count) AS avg_pod_count,
+      avg(avg_pod_per_node_count) AS avg_pod_per_node_count
+    FROM {| .Report.Inputs.ClusterMemoryUtilizationReportName | scheduledReportTableName |}
+    WHERE period_start  >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+    AND period_end <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+    {|- else -|}
+    {|/* Validate both inputs are specified if only one is specified*/|}
+    {|- if or (and (not .Report.Inputs.ClusterMemoryCapacityReportName) .Report.Inputs.ClusterMemoryUsageReportName) (and (not .Report.Inputs.ClusterMemoryUsageReportName) .Report.Inputs.ClusterMemoryCapacityReportName) -|}
+    {|- fail "input ClusterMemoryCapacityReportName and ClusterMemoryUsageReportName must both be set" -|}
+    {|- end -|}
+    WITH cluster_memory_capacity AS (
+      {| renderReportGenerationQuery "cluster-memory-capacity" . |}
+    ), cluster_memory_usage AS (
+      {| renderReportGenerationQuery "cluster-memory-usage" . |}
+    )
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      capacity.total_cluster_capacity_memory_byte_hours,
+      usage.total_cluster_usage_memory_byte_hours,
+      usage.total_cluster_usage_memory_byte_hours / capacity.total_cluster_capacity_memory_byte_hours AS cluster_memory_utilization_percent,
+      capacity.avg_cluster_capacity_memory_bytes,
+      usage.avg_cluster_usage_memory_bytes,
+      capacity.avg_node_count,
+      usage.avg_pod_count,
+      usage.avg_pod_count / capacity.avg_node_count AS avg_pod_per_node_count
+    FROM cluster_memory_usage AS usage
+    JOIN cluster_memory_capacity AS capacity
+    ON capacity.period_start = usage.period_start
+    AND capacity.period_end = usage.period_end
+    {|- end -|}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -183,6 +183,18 @@ func TestReportingE2E(t *testing.T) {
 			timeout:       reportTestTimeout,
 		},
 		{
+			name:          "cluster-cpu-utilization",
+			queryName:     "cluster-cpu-utilization",
+			newReportFunc: testFramework.NewSimpleReport,
+			timeout:       reportTestTimeout,
+		},
+		{
+			name:          "cluster-memory-utilization",
+			queryName:     "cluster-memory-utilization",
+			newReportFunc: testFramework.NewSimpleReport,
+			timeout:       reportTestTimeout,
+		},
+		{
 			name:          "aws-ec2-cluster-cost",
 			queryName:     "aws-ec2-cluster-cost",
 			newReportFunc: testFramework.NewSimpleReport,


### PR DESCRIPTION
This also updates all these cluster wide reports to use a different input
name matching the query's name so that inputs for sub-report names don't
have overlapping inputs parameters.

Base on #482 