### PR TITLE
Support setting max query length in presto and reporting-operator

### DIFF
--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -2,6 +2,7 @@ reporting-operator:
   spec:
     config:
       prometheusURL: "https://prometheus-k8s.openshift-monitoring.svc:9091/"
+      maxQueryLength: "10000000"
       tls:
         enabled: true
         createSecret: false
@@ -22,6 +23,8 @@ reporting-operator:
 presto:
   spec:
     presto:
+      config:
+        maxQueryLength: "10000000"
       securityContext:
         fsGroup: null
     hive:

--- a/charts/operator-metering/values.yaml
+++ b/charts/operator-metering/values.yaml
@@ -2,9 +2,12 @@ reporting-operator:
   spec:
     config:
       prometheusURL: "http://prometheus-k8s.monitoring.svc:9090/"
+      prestoMaxQueryLength: "10000000"
 presto:
   spec:
     presto:
+      config:
+        maxQueryLength: "10000000"
       securityContext:
         fsGroup: 0
     hive:

--- a/charts/presto/templates/presto-coordinator-config.yaml
+++ b/charts/presto/templates/presto-coordinator-config.yaml
@@ -21,6 +21,9 @@ data:
     discovery-server.enabled=true
     discovery.uri={{ .Values.spec.presto.config.discoveryURI }}
     node-scheduler.include-coordinator={{ .Values.spec.presto.coordinator.config.nodeSchedulerIncludeCoordinator }}
+{{- if .Values.spec.presto.config.maxQueryLength }}
+    query.max-length={{ .Values.spec.presto.config.maxQueryLength }}
+{{- end }}
 {{- if .Values.spec.presto.coordinator.config.taskConcurrency }}
     task.concurrency={{ .Values.spec.presto.coordinator.config.taskConcurrency }}
 {{- end }}

--- a/charts/presto/templates/presto-worker-config.yaml
+++ b/charts/presto/templates/presto-worker-config.yaml
@@ -20,6 +20,9 @@ data:
     coordinator=false
     discovery.uri={{ .Values.spec.presto.config.discoveryURI }}
     node-scheduler.include-coordinator={{ .Values.spec.presto.coordinator.config.nodeSchedulerIncludeCoordinator }}
+{{- if .Values.spec.presto.config.maxQueryLength }}
+    query.max-length={{ .Values.spec.presto.config.maxQueryLength }}
+{{- end }}
 {{- if .Values.spec.presto.coordinator.config.taskConcurrency }}
     task.concurrency={{ .Values.spec.presto.coordinator.config.taskConcurrency }}
 {{- end }}

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -11,6 +11,7 @@ spec:
     config:
       discoveryURI: http://presto:8080
       environment: production
+      # maxQueryLength: 1000000
       hiveMetastoreURI: thrift://hive-metastore:9083
 
     coordinator:

--- a/charts/reporting-operator/templates/reporting-operator-config.yaml
+++ b/charts/reporting-operator/templates/reporting-operator-config.yaml
@@ -20,3 +20,4 @@ data:
   leader-lease-duration: {{ .Values.spec.config.leaderLeaseDuration | quote }}
   presto-host: {{ .Values.spec.config.prestoHost | quote }}
   hive-host: {{ .Values.spec.config.hiveHost | quote }}
+  presto-max-query-length: {{ .Values.spec.config.prestoMaxQueryLength | quote }}

--- a/charts/reporting-operator/templates/reporting-operator-deployment.yaml
+++ b/charts/reporting-operator/templates/reporting-operator-deployment.yaml
@@ -115,6 +115,11 @@ spec:
             configMapKeyRef:
               name: reporting-operator-config
               key: enable-finalizers
+        - name: REPORTING_OPERATOR_PRESTO_MAX_QUERY_LENGTH
+          valueFrom:
+            configMapKeyRef:
+              name: reporting-operator-config
+              key: presto-max-query-length
         - name: REPORTING_OPERATOR_PRESTO_HOST
           valueFrom:
             configMapKeyRef:

--- a/charts/reporting-operator/values.yaml
+++ b/charts/reporting-operator/values.yaml
@@ -19,6 +19,8 @@ spec:
     promsumChunkSize: "5m"
     promsumStepSize: "60s"
 
+    prestoMaxQueryLength: "0"
+
     logLevel: "info"
     logReports: "false"
     logDDLQueries: "false"

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -78,6 +78,8 @@ func init() {
 	startCmd.Flags().DurationVar(&cfg.PrometheusQueryConfig.QueryInterval.Duration, "promsum-interval", operator.DefaultPrometheusQueryInterval, "controls how often the operator polls Prometheus for metrics")
 	startCmd.Flags().DurationVar(&cfg.PrometheusQueryConfig.StepSize.Duration, "promsum-step-size", operator.DefaultPrometheusQueryStepSize, "the query step size for Promethus query. This controls resolution of results")
 	startCmd.Flags().DurationVar(&cfg.PrometheusQueryConfig.ChunkSize.Duration, "promsum-chunk-size", operator.DefaultPrometheusQueryChunkSize, "controls how much the range query window sizeby limiting the range query to a range of time no longer than this duration")
+	startCmd.Flags().IntVar(&cfg.PrestoMaxQueryLength, "presto-max-query-length", 0, "If a non-zero positive value, specifies the max length a Presto query can be. This is used to control buffer sizes used for queries.")
+
 	startCmd.Flags().DurationVar(&cfg.LeaderLeaseDuration, "lease-duration", defaultLeaseDuration, "controls how much time elapses before declaring leader")
 
 	startCmd.Flags().BoolVar(&cfg.APITLSConfig.UseTLS, "use-tls", false, "If true, uses TLS to secure HTTP API traffix")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -90,6 +90,8 @@ type Config struct {
 	DisablePromsum   bool
 	EnableFinalizers bool
 
+	PrestoMaxQueryLength int
+
 	LogDMLQueries bool
 	LogDDLQueries bool
 
@@ -389,9 +391,14 @@ func (op *Reporting) Run(stopCh <-chan struct{}) error {
 		}
 	}
 
+	var prestoQueryBufferPool *sync.Pool
+	if op.cfg.PrestoMaxQueryLength > 0 {
+		bufferPool := prestostore.NewBufferPool(op.cfg.PrestoMaxQueryLength)
+		prestoQueryBufferPool = &bufferPool
+	}
 	op.reportResultsRepo = prestostore.NewReportResultsRepo(prestoQueryer)
 	op.reportGenerator = reporting.NewReportGenerator(op.logger, op.reportResultsRepo)
-	op.prometheusMetricsRepo = prestostore.NewPrometheusMetricsRepo(prestoQueryer)
+	op.prometheusMetricsRepo = prestostore.NewPrometheusMetricsRepo(prestoQueryer, prestoQueryBufferPool)
 	op.prestoViewCreator = &prestoViewCreator{queryer: prestoQueryer}
 
 	hiveTableManager := reporting.NewHiveTableManager(hiveQueryer)

--- a/pkg/operator/prestostore/prometheusmetric.go
+++ b/pkg/operator/prestostore/prometheusmetric.go
@@ -147,7 +147,7 @@ func StorePrometheusMetricsWithBuffer(queryBuf *bytes.Buffer, ctx context.Contex
 		newBufferSize := (bytesToWrite + queryBuf.Len())
 
 		// if writing the current metricValue to the buffer would exceed the
-		// bufferCapacity, preform the insert query, and reset the buffer
+		// bufferCapacity, perform the insert query, and reset the buffer
 		if newBufferSize > queryCap {
 			err := presto.InsertInto(queryer, tableName, queryBuf.String())
 			if err != nil {

--- a/pkg/operator/prestostore/prometheusmetric.go
+++ b/pkg/operator/prestostore/prometheusmetric.go
@@ -13,18 +13,14 @@ import (
 )
 
 const (
-	// prestoQueryCap is the maximum payload size a single SQL statement can contain
-	// before Presto will error due to the payload being too large.
-	prestoQueryCap = 1000000
+	// defaultPrestoQueryCap is the default maximum payload size a single SQL
+	// statement can contain before Presto will error due to the payload being
+	// too large.
+	defaultPrestoQueryCap = 1000000
 )
 
 var (
-	bufPool = sync.Pool{
-		New: func() interface{} {
-			// capacity prestoQueryCap, length 0
-			return bytes.NewBuffer(make([]byte, 0, prestoQueryCap))
-		},
-	}
+	defaultQueryBufferPool = NewBufferPool(defaultPrestoQueryCap)
 
 	promsumColumns = []presto.Column{
 		{Name: "amount", Type: "double"},
@@ -33,6 +29,15 @@ var (
 		{Name: "labels", Type: "map(varchar, varchar)"},
 	}
 )
+
+func NewBufferPool(capacity int) sync.Pool {
+	return sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(make([]byte, 0, capacity))
+		},
+	}
+
+}
 
 type PrometheusMetricsStorer interface {
 	StorePrometheusMetrics(ctx context.Context, tableName string, metrics []*PrometheusMetric) error
@@ -53,17 +58,25 @@ type PrometheusMetricsRepo interface {
 }
 
 type prometheusMetricRepo struct {
-	queryer db.Queryer
+	queryer         db.Queryer
+	queryBufferPool sync.Pool
 }
 
-func NewPrometheusMetricsRepo(queryer db.Queryer) *prometheusMetricRepo {
+func NewPrometheusMetricsRepo(queryer db.Queryer, queryBufferPool *sync.Pool) *prometheusMetricRepo {
+	if queryBufferPool == nil {
+		queryBufferPool = &defaultQueryBufferPool
+	}
 	return &prometheusMetricRepo{
-		queryer: queryer,
+		queryer:         queryer,
+		queryBufferPool: *queryBufferPool,
 	}
 }
 
 func (r *prometheusMetricRepo) StorePrometheusMetrics(ctx context.Context, tableName string, metrics []*PrometheusMetric) error {
-	return StorePrometheusMetrics(ctx, r.queryer, tableName, metrics)
+	queryBuf := r.queryBufferPool.Get().(*bytes.Buffer)
+	queryBuf.Reset()
+	defer r.queryBufferPool.Put(queryBuf)
+	return StorePrometheusMetricsWithBuffer(queryBuf, ctx, r.queryer, tableName, metrics)
 }
 
 func (r *prometheusMetricRepo) GetPrometheusMetrics(tableName string, start, end time.Time) ([]*PrometheusMetric, error) {
@@ -98,17 +111,15 @@ type PrometheusMetric struct {
 	Timestamp time.Time         `json:"timestamp"`
 }
 
-// StorePrometheusMetrics handles storing Prometheus metrics into the specified
-// Presto table.
-func StorePrometheusMetrics(ctx context.Context, queryer db.Queryer, tableName string, metrics []*PrometheusMetric) error {
-	queryBuf := bufPool.Get().(*bytes.Buffer)
-	queryBuf.Reset()
-	defer bufPool.Put(queryBuf)
+// storePrometheusMetricsWithBuffer handles storing Prometheus metrics into the
+// specified Presto table.
+func StorePrometheusMetricsWithBuffer(queryBuf *bytes.Buffer, ctx context.Context, queryer db.Queryer, tableName string, metrics []*PrometheusMetric) error {
+	bufferCapacity := queryBuf.Cap()
 
 	insertStatementLength := len(presto.FormatInsertQuery(tableName, ""))
 	// calculate the queryCap with the "INSERT INTO $table_name" portion
 	// accounted for
-	queryCap := prestoQueryCap - insertStatementLength
+	queryCap := bufferCapacity - insertStatementLength
 
 	for _, metric := range metrics {
 		metricValue := generatePrometheusMetricSQLValues(metric)
@@ -130,13 +141,13 @@ func StorePrometheusMetrics(ctx context.Context, queryer db.Queryer, tableName s
 			queryBuf.WriteString(",")
 		}
 
-		// There's a character limit of prestoQueryCap on insert
+		// There's a character limit of bufferCapacity on insert
 		// queries, so let's chunk them at that limit.
 		bytesToWrite := len(metricValue)
 		newBufferSize := (bytesToWrite + queryBuf.Len())
 
 		// if writing the current metricValue to the buffer would exceed the
-		// prestoQueryCap, preform the insert query, and reset the buffer
+		// bufferCapacity, preform the insert query, and reset the buffer
 		if newBufferSize > queryCap {
 			err := presto.InsertInto(queryer, tableName, queryBuf.String())
 			if err != nil {


### PR DESCRIPTION
Sets new default for maxQueryLength to 10,000,000 which is around 10Mb (ish)