### PR TITLE
charts: Set JVM options for hdfs, hive and presto

### DIFF
--- a/charts/hdfs/templates/configmap.yaml
+++ b/charts/hdfs/templates/configmap.yaml
@@ -104,6 +104,18 @@ data:
         echo "Setting HADOOP_HEAPSIZE to ${HADOOP_HEAPSIZE}M"
     fi
 
+    # Set garbage collection settings
+    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps"
+    # Set JMX options
+    export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
+    # Set garbage collection logs
+    export GC_SETTINGS="${GC_SETTINGS} -Xloggc:${HADOOP_LOG_DIR}/gc-rm.log-$(date +'%Y%m%d%H%M')"
+
+    # set name node options
+    export HDFS_NAMENODE_OPTS="${HDFS_NAMENODE_OPTS} -Dhadoop.security.logger=INFO,RFAS ${GC_SETTINGS} ${JMX_OPTIONS}"
+    # set datanode options
+    export HDFS_DATANODE_OPTS="${HDFS_DATANODE_OPTS} -Dhadoop.security.logger=ERROR,RFAS ${GC_SETTINGS} ${JMX_OPTIONS}"
+
     # add UID to /etc/passwd if missing
     if ! whoami &> /dev/null; then
       if [ -w /etc/passwd ]; then

--- a/charts/presto/templates/hive-scripts-configmap.yaml
+++ b/charts/presto/templates/hive-scripts-configmap.yaml
@@ -50,8 +50,16 @@ data:
     ln -s -f /hive-config/hive-log4j2.properties $HIVE_HOME/conf/hive-log4j2.properties
     ln -s -f /hive-config/hive-exec-log4j2.properties $HIVE_HOME/conf/hive-exec-log4j2.properties
 
+    # Set garbage collection settings
+    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps"
+    # Set JMX options
+    export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
+    # Set garbage collection logs
+    export GC_SETTINGS="${GC_SETTINGS} -Xloggc:${HADOOP_LOG_DIR}/gc-rm.log-$(date +'%Y%m%d%H%M')"
+
     export HIVE_LOGLEVEL="${HIVE_LOGLEVEL:-INFO}"
+    export HADOOP_OPTS="${HADOOP_OPTS} ${GC_SETTINGS} ${JMX_OPTIONS}"
     export HIVE_METASTORE_HADOOP_OPTS=" -Dhive.log.level=${HIVE_LOGLEVEL} "
-    export HIVE_OPTS="$HIVE_OPTS --hiveconf hive.root.logger=${HIVE_LOGLEVEL},console "
+    export HIVE_OPTS="${HIVE_OPTS} --hiveconf hive.root.logger=${HIVE_LOGLEVEL},console "
 
     exec $@

--- a/charts/presto/templates/presto-coordinator-config.yaml
+++ b/charts/presto/templates/presto-coordinator-config.yaml
@@ -38,5 +38,5 @@ data:
     -XX:+UseGCOverheadLimit
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
-    -XX:OnOutOfMemoryError=kill -9 %p
+    -XX:+ExitOnOutOfMemoryError
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml

--- a/charts/presto/templates/presto-worker-config.yaml
+++ b/charts/presto/templates/presto-worker-config.yaml
@@ -37,5 +37,5 @@ data:
     -XX:+UseGCOverheadLimit
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
-    -XX:OnOutOfMemoryError=kill -9 %p
+    -XX:+ExitOnOutOfMemoryError
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml


### PR DESCRIPTION
Use ExitOnOutOfMemoryError instead of OnOutOfMemoryError=kill -9 %p
which doesn't work in a container when the JVM is PID 1 which can't be
killed. Also updates hdfs/hive to use the G1 garbage collector for consistency 
with Presto and be verbose when there are GC pauses or errors. Also enables 
JMX options which provide GC info/metrics. Taken from hadoop-env.sh and hive-env.sh.