### PR TITLE
charts/reporting-operator: Fix usage query double counting

### DIFF
--- a/charts/reporting-operator/templates/custom-resources/prom-queries/pod-cpu-usage.yaml
+++ b/charts/reporting-operator/templates/custom-resources/prom-queries/pod-cpu-usage.yaml
@@ -36,4 +36,4 @@ metadata:
 {{- end }}
 spec:
   query: |
-    label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
+    label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",container_name!="",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)

--- a/charts/reporting-operator/templates/custom-resources/prom-queries/pod-memory-usage.yaml
+++ b/charts/reporting-operator/templates/custom-resources/prom-queries/pod-memory-usage.yaml
@@ -36,4 +36,4 @@ metadata:
 {{- end }}
 spec:
   query: |
-    sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
+    sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!="",pod_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)


### PR DESCRIPTION
I've heard of a double counting report for metering and recently I noticed some
values looked larger than I know they are in the Prometheus UI using these
queries and the built-in Prometheus recording rules.  When I looked in Grafana
I noticed the values were closer to what I expected. They key difference is
Grafana is also not using the recording rules from Prometheus, but is running
the aggregations directly, and I noticed it had container_name!="" in it's
label filters where the recording rules don't and our queries don't either.

When testing these queries manually with container_name!="" I found this to
produce more accurate values that are closer to what I was expecting and
measuring manually.

Also updated these same queries used in upstream recording rules: https://github.com/openshift/cluster-monitoring-operator/pull/153