### PR TITLE
charts/presto: Make JVM configuration more parameterized and tunable

### DIFF
--- a/Documentation/install-metering.md
+++ b/Documentation/install-metering.md
@@ -17,8 +17,8 @@ Operator Metering requires the following components:
     - The prometheus-operator repository's [kube-prometheus instructions][kube-prometheus] are the standard way of achieving Prometheus cluster-monitoring.
     - At a minimum, we require kube-state-metrics, node-exporter, and built-in Kubernetes target metrics.
     - Openshift 3.10 or newer includes monitoring via the [openshift-montoring playbook](https://github.com/openshift/openshift-ansible/tree/master/playbooks/openshift-monitoring).
-- 4GB Memory and 2 CPU Cores available cluster capacity.
-- At least 1 node with 2GB available memory (the highest memory request for a single Operator Metering Pod)
+- 4GB Memory and 4 CPU Cores available cluster capacity.
+- Minimum resources needed for the largest single pod is 2 GB of memory and 2 CPU cores.
     - Memory and CPU consumption may often be lower, but will spike when running reports, or collecting data for larger clusters.
 - A properly configured kubectl to access the Kubernetes cluster.
 

--- a/charts/presto/templates/_helpers.tpl
+++ b/charts/presto/templates/_helpers.tpl
@@ -46,8 +46,6 @@ connector.name=jmx
     resourceFieldRef:
       containerName: presto
       resource: limits.memory
-- name: JAVA_MAX_MEM_RATIO
-  value: "50"
 {{- end }}
 
 {{- define "hive-env" }}

--- a/charts/presto/templates/presto-common-config.yaml
+++ b/charts/presto/templates/presto-common-config.yaml
@@ -30,12 +30,24 @@ data:
         echo "Setting Presto JVM Max Heap Size to ${MAX_HEAPSIZE}M"
     fi
 
-    # add heapsize to jvm config if not already
-    JVM_CONFIG="${PRESTO_HOME}/etc/jvm.config"
-    if ! grep -q -F 'Xmx' "$JVM_CONFIG"; then
-      FLAG="-Xmx${MAX_HEAPSIZE}M"
-      echo "Adding $FLAG to $JVM_CONFIG"
-      echo "$FLAG" >> "$JVM_CONFIG"
+    # set min to max to avoid pauses caused by heap expansion
+    export MIN_HEAPSIZE="$MAX_HEAPSIZE"
+
+    if [ -n "$MAX_HEAPSIZE" ]; then
+      # add heapsize to jvm config if not already
+      JVM_CONFIG="${PRESTO_HOME}/etc/jvm.config"
+      if ! grep -q -F 'Xmx' "$JVM_CONFIG"; then
+        FLAG="-Xmx${MAX_HEAPSIZE}M"
+        echo "Adding $FLAG to $JVM_CONFIG"
+        echo "$FLAG" >> "$JVM_CONFIG"
+      fi
+    fi
+    if [ -n "$MIN_HEAPSIZE" ]; then
+      if ! grep -q -F 'Xms' "$JVM_CONFIG"; then
+        FLAG="-Xms${MIN_HEAPSIZE}M"
+        echo "Adding $FLAG to $JVM_CONFIG"
+        echo "$FLAG" >> "$JVM_CONFIG"
+      fi
     fi
 
     # add node id to node config

--- a/charts/presto/templates/presto-coordinator-config.yaml
+++ b/charts/presto/templates/presto-coordinator-config.yaml
@@ -20,7 +20,7 @@ data:
     coordinator=true
     discovery-server.enabled=true
     discovery.uri={{ .Values.spec.presto.config.discoveryURI }}
-    node-scheduler.include-coordinator={{ .Values.spec.presto.coordinator.config.nodeSchedulerIncludeCoordinator }}
+    node-scheduler.include-coordinator={{ .Values.spec.presto.config.nodeSchedulerIncludeCoordinator }}
 {{- if .Values.spec.presto.config.maxQueryLength }}
     query.max-length={{ .Values.spec.presto.config.maxQueryLength }}
 {{- end }}

--- a/charts/presto/templates/presto-coordinator-config.yaml
+++ b/charts/presto/templates/presto-coordinator-config.yaml
@@ -17,6 +17,7 @@ data:
   config.properties: |
     http-server.http.port=8080
     jmx.rmiserver.port=8081
+    jmx.rmiregistry.port=8081
     coordinator=true
     discovery-server.enabled=true
     discovery.uri={{ .Values.spec.presto.config.discoveryURI }}
@@ -37,9 +38,36 @@ data:
   jvm.config: |
     -server
     -XX:+UseG1GC
-    -XX:G1HeapRegionSize=32M
     -XX:+UseGCOverheadLimit
+{{- if .Values.spec.presto.coordinator.config.jvm.G1HeapRegionSize }}
+    -XX:G1HeapRegionSize={{ .Values.spec.presto.coordinator.config.jvm.G1HeapRegionSize }}
+{{- end }}
+{{- if .Values.spec.presto.coordinator.config.jvm.parallelGCThreads }}
+    -XX:ParallelGCThreads={{ .Values.spec.presto.coordinator.config.jvm.parallelGCThreads }}
+{{- end }}
+{{- if .Values.spec.presto.coordinator.config.jvm.concGCThreads }}
+    -XX:ConcGCThreads={{ .Values.spec.presto.coordinator.config.jvm.concGCThreads }}
+{{- end }}
+{{- if .Values.spec.presto.coordinator.config.jvm.permSize }}
+    -XX:PermSize={{ .Values.spec.presto.coordinator.config.jvm.permSize }}
+{{- end }}
+{{- if .Values.spec.presto.coordinator.config.jvm.maxGcPauseMillis }}
+    -XX:MaxGCPauseMillis={{ .Values.spec.presto.coordinator.config.jvm.maxGcPauseMillis }}
+{{- end }}
+{{- if .Values.spec.presto.coordinator.config.jvm.initiatingHeapOccupancyPercent }}
+    -XX:InitiatingHeapOccupancyPercent={{ .Values.spec.presto.coordinator.config.jvm.initiatingHeapOccupancyPercent }}
+{{- end }}
+{{- range .Values.spec.presto.coordinator.config.jvm.extraFlags }}
+    {{ . }}
+{{- end }}
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
+    -Dcom.sun.management.jmxremote
+    -Dcom.sun.management.jmxremote.local.only=false
+    -Dcom.sun.management.jmxremote.ssl=false
+    -Dcom.sun.management.jmxremote.authenticate=false
+    -Dcom.sun.management.jmxremote.port=8081
+    -Dcom.sun.management.jmxremote.rmi.port=8081
+    -Djava.rmi.server.hostname=127.0.0.1

--- a/charts/presto/templates/presto-coordinator-deployment.yaml
+++ b/charts/presto/templates/presto-coordinator-deployment.yaml
@@ -72,6 +72,9 @@ spec:
         command: ['/presto-common/entrypoint.sh']
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
         env:
+        - name: JAVA_MAX_MEM_RATIO
+          value: "{{ .Values.spec.presto.coordinator.config.jvm.percentMemoryLimitAsHeap }}"
+          optional: true
 {{- include "presto-common-env" . | indent 8 }}
         ports:
         - name: http

--- a/charts/presto/templates/presto-worker-config.yaml
+++ b/charts/presto/templates/presto-worker-config.yaml
@@ -19,7 +19,7 @@ data:
     jmx.rmiserver.port=8081
     coordinator=false
     discovery.uri={{ .Values.spec.presto.config.discoveryURI }}
-    node-scheduler.include-coordinator={{ .Values.spec.presto.coordinator.config.nodeSchedulerIncludeCoordinator }}
+    node-scheduler.include-coordinator={{ .Values.spec.presto.config.nodeSchedulerIncludeCoordinator }}
 {{- if .Values.spec.presto.config.maxQueryLength }}
     query.max-length={{ .Values.spec.presto.config.maxQueryLength }}
 {{- end }}

--- a/charts/presto/templates/presto-worker-config.yaml
+++ b/charts/presto/templates/presto-worker-config.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
 data:
   log.properties: |
-    com.facebook.presto={{ upper .Values.spec.presto.coordinator.config.logLevel }}
+    com.facebook.presto={{ upper .Values.spec.presto.worker.config.logLevel }}
 
   node.properties: |
     node.data-dir=/var/presto/data
@@ -17,28 +17,56 @@ data:
   config.properties: |
     http-server.http.port=8080
     jmx.rmiserver.port=8081
+    jmx.rmiregistry.port=8081
     coordinator=false
     discovery.uri={{ .Values.spec.presto.config.discoveryURI }}
     node-scheduler.include-coordinator={{ .Values.spec.presto.config.nodeSchedulerIncludeCoordinator }}
 {{- if .Values.spec.presto.config.maxQueryLength }}
     query.max-length={{ .Values.spec.presto.config.maxQueryLength }}
 {{- end }}
-{{- if .Values.spec.presto.coordinator.config.taskConcurrency }}
-    task.concurrency={{ .Values.spec.presto.coordinator.config.taskConcurrency }}
+{{- if .Values.spec.presto.worker.config.taskConcurrency }}
+    task.concurrency={{ .Values.spec.presto.worker.config.taskConcurrency }}
 {{- end }}
-{{- if .Values.spec.presto.coordinator.config.taskMaxWorkerThreads }}
-    task.max-worker-threads: {{ .Values.spec.presto.coordinator.config.taskMaxWorkerThreads }}
+{{- if .Values.spec.presto.worker.config.taskMaxWorkerThreads }}
+    task.max-worker-threads: {{ .Values.spec.presto.worker.config.taskMaxWorkerThreads }}
 {{- end }}
-{{- if .Values.spec.presto.coordinator.config.taskMinDrivers }}
-    task.min-drivers: {{ .Values.spec.presto.coordinator.config.taskMinDrivers }}
+{{- if .Values.spec.presto.worker.config.taskMinDrivers }}
+    task.min-drivers: {{ .Values.spec.presto.worker.config.taskMinDrivers }}
 {{- end }}
 
   jvm.config: |
     -server
     -XX:+UseG1GC
-    -XX:G1HeapRegionSize=32M
     -XX:+UseGCOverheadLimit
+{{- if .Values.spec.presto.worker.config.jvm.G1HeapRegionSize }}
+    -XX:G1HeapRegionSize={{ .Values.spec.presto.worker.config.jvm.G1HeapRegionSize }}
+{{- end }}
+{{- if .Values.spec.presto.worker.config.jvm.parallelGCThreads }}
+    -XX:ParallelGCThreads={{ .Values.spec.presto.worker.config.jvm.parallelGCThreads }}
+{{- end }}
+{{- if .Values.spec.presto.worker.config.jvm.concGCThreads }}
+    -XX:ConcGCThreads={{ .Values.spec.presto.worker.config.jvm.concGCThreads }}
+{{- end }}
+{{- if .Values.spec.presto.worker.config.jvm.permSize }}
+    -XX:PermSize={{ .Values.spec.presto.worker.config.jvm.permSize }}
+{{- end }}
+{{- if .Values.spec.presto.worker.config.jvm.maxGcPauseMillis }}
+    -XX:MaxGCPauseMillis={{ .Values.spec.presto.worker.config.jvm.maxGcPauseMillis }}
+{{- end }}
+{{- if .Values.spec.presto.worker.config.jvm.initiatingHeapOccupancyPercent }}
+    -XX:InitiatingHeapOccupancyPercent={{ .Values.spec.presto.worker.config.jvm.initiatingHeapOccupancyPercent }}
+{{- end }}
+{{- range .Values.spec.presto.worker.config.jvm.extraFlags }}
+    {{ . }}
+{{- end }}
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
+    -Dcom.sun.management.jmxremote
+    -Dcom.sun.management.jmxremote.local.only=false
+    -Dcom.sun.management.jmxremote.ssl=false
+    -Dcom.sun.management.jmxremote.authenticate=false
+    -Dcom.sun.management.jmxremote.port=8081
+    -Dcom.sun.management.jmxremote.rmi.port=8081
+    -Djava.rmi.server.hostname=127.0.0.1

--- a/charts/presto/templates/presto-worker-deployment.yaml
+++ b/charts/presto/templates/presto-worker-deployment.yaml
@@ -72,6 +72,9 @@ spec:
         command: ['/presto-common/entrypoint.sh']
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
         env:
+        - name: JAVA_MAX_MEM_RATIO
+          value: "{{ .Values.spec.presto.worker.config.jvm.percentMemoryLimitAsHeap }}"
+          optional: true
 {{- include "presto-common-env" . | indent 8 }}
         ports:
         - name: http

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -21,6 +21,24 @@ spec:
         logLevel: info
         taskMaxWorkerThreads: null
         taskMinDrivers: null
+        jvm:
+          G1HeapRegionSize: null
+          parallelGCThreads: null
+          concGCThreads: null
+          permSize: null
+          maxGcPauseMillis: 200
+          initiatingHeapOccupancyPercent: null
+          # use 50% of our memory limit by default for java heap size
+          percentMemoryLimitAsHeap: "50"
+          extraFlags: []
+
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "2"
+        limits:
+          memory: "2Gi"
+          cpu: "2"
 
       nodeSelector: {}
 
@@ -34,14 +52,6 @@ spec:
                 values:
                 - presto
             topologyKey: "kubernetes.io/hostname"
-
-      resources:
-        requests:
-          memory: "1536Mi"
-          cpu: "300m"
-        limits:
-          memory: "2048Mi"
-          cpu: "1000m"
 
     worker:
       replicas: 0
@@ -50,6 +60,23 @@ spec:
         logLevel: info
         taskMaxWorkerThreads: null
         taskMinDrivers: null
+        jvm:
+          G1HeapRegionSize: null
+          parallelGCThreads: null
+          concGCThreads: null
+          permSize: null
+          maxGcPauseMillis: null
+          initiatingHeapOccupancyPercent: null
+          percentMemoryLimitAsHeap: "50"
+          extraFlags: []
+
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "2"
+        limits:
+          memory: "2Gi"
+          cpu: "2"
 
       nodeSelector: {}
 
@@ -63,14 +90,6 @@ spec:
                 values:
                 - presto
             topologyKey: "kubernetes.io/hostname"
-
-      resources:
-        requests:
-          memory: "1536Mi"
-          cpu: "300m"
-        limits:
-          memory: "2048Mi"
-          cpu: "1000m"
 
     labels: {}
     annotations: {}

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -107,7 +107,7 @@ spec:
       resources:
         requests:
           memory: "650Mi"
-          cpu: "100m"
+          cpu: "500m"
         limits:
           memory: "650Mi"
           cpu: "500m"
@@ -126,10 +126,10 @@ spec:
         logLevel: info
       resources:
         requests:
-          memory: "400Mi"
+          memory: "500Mi"
           cpu: "100m"
         limits:
-          memory: "400Mi"
+          memory: "500Mi"
           cpu: "100m"
 
       nodeSelector: {}

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -13,12 +13,12 @@ spec:
       environment: production
       # maxQueryLength: 1000000
       hiveMetastoreURI: thrift://hive-metastore:9083
+      nodeSchedulerIncludeCoordinator: true
 
     coordinator:
       terminationGracePeriodSeconds: 30
       config:
         logLevel: info
-        nodeSchedulerIncludeCoordinator: true
         taskMaxWorkerThreads: null
         taskMinDrivers: null
 


### PR DESCRIPTION
Allows tweaking various GC settings which is becoming necessary to
optimize the performance of Presto based on resources available.

Fully enable jmx for debugging. This allows using jconsole against
Presto's 8081 port and other Java debugging tool.

Increase presto resource requests/limits slightly

Also fix task configuration values on worker. They were set to use the
spec.presto.coordinator values but need to use the worker values.