### PR TITLE
Documentation: Fix broken links in new Exposing the reporting API doc

### DIFF
--- a/Documentation/common-configuration.md
+++ b/Documentation/common-configuration.md
@@ -21,10 +21,3 @@ See [latest-versions.yaml][latest-versions] for an example of setting the reposi
 [kube-prometheus]: https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus
 [node-selectors-config]: ../manifests/metering-config/custom-node-selectors.yaml
 [resource-limits]: ../manifests/metering-config/resource-limits.yaml
-[route]: https://docs.openshift.com/container-platform/3.11/dev_guide/routes.html
-[kube-svc]: https://kubernetes.io/docs/concepts/services-networking/service/
-[load-balancer-svc]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
-[node-port-svc]: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
-[service-certs]: https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets
-[oauth-proxy]: https://github.com/openshift/oauth-proxy
-[expose-route-config]: ../manifests/metering-config/expose-route.yaml

--- a/Documentation/configuring-reporting-operator.md
+++ b/Documentation/configuring-reporting-operator.md
@@ -105,3 +105,11 @@ In this example the externalIP of the LoadBalancer is `35.227.172.86` and the po
 ```
 curl "http://35.227.172.86:8080/api/v1/scheduledreports/get?name=cluster-memory-capacity-hourly&format=tab"
 ```
+
+[route]: https://docs.openshift.com/container-platform/3.11/dev_guide/routes.html
+[kube-svc]: https://kubernetes.io/docs/concepts/services-networking/service/
+[load-balancer-svc]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+[node-port-svc]: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+[service-certs]: https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets
+[oauth-proxy]: https://github.com/openshift/oauth-proxy
+[expose-route-config]: ../manifests/metering-config/expose-route.yaml


### PR DESCRIPTION
After moving the content to a new file I forgot to move the link references too.