### PR TITLE
manifests,hack,jenkins: Deploy default set of ScheduledReports in continuous-upgrade job

### DIFF
--- a/hack/deploy-continuous-upgrade.sh
+++ b/hack/deploy-continuous-upgrade.sh
@@ -2,13 +2,36 @@
 set -e
 
 DIR=$(dirname "${BASH_SOURCE}")
+ROOT_DIR=$(dirname "${BASH_SOURCE}")/..
+source "${ROOT_DIR}/hack/common.sh"
 
 # Used in deploy.sh
-export DOCKER_USERNAME="$DOCKER_CREDS_USR"
-export DOCKER_PASSWORD="$DOCKER_CREDS_PSW"
+export DOCKER_USERNAME="${DOCKER_CREDS_USR:-}"
+export DOCKER_PASSWORD="${DOCKER_CREDS_PSW:-}"
 
 export HDFS_NAMENODE_STORAGE_SIZE="20Gi"
 export HDFS_DATANODE_STORAGE_SIZE="30Gi"
 
-export METERING_CREATE_PULL_SECRET=true
+export UNINSTALL_METERING_BEFORE_INSTALL="${UNINSTALL_METERING_BEFORE_INSTALL:-false}"
+
 "$DIR/deploy-custom.sh"
+
+echo "Deploying default ScheduledReports"
+
+HOURLY=( \
+    "$MANIFESTS_DIR/reports/cluster-capacity-hourly.yaml" \
+    "$MANIFESTS_DIR/reports/cluster-usage-hourly.yaml" \
+    "$MANIFESTS_DIR/reports/cluster-utilization-hourly.yaml" \
+    "$MANIFESTS_DIR/reports/namespace-usage-hourly.yaml" \
+)
+DAILY=( \
+    "$MANIFESTS_DIR/reports/cluster-capacity-daily.yaml" \
+    "$MANIFESTS_DIR/reports/cluster-usage-daily.yaml" \
+    "$MANIFESTS_DIR/reports/cluster-utilization-daily.yaml" \
+    "$MANIFESTS_DIR/reports/namespace-usage-daily.yaml" \
+)
+
+echo "Creating hourly reports"
+kube-install "${HOURLY[@]}"
+echo "Creating daily reports"
+kube-install "${DAILY[@]}"

--- a/jenkins/vars/testRunner.groovy
+++ b/jenkins/vars/testRunner.groovy
@@ -84,12 +84,13 @@ spec:
         stages {
             stage('Run Tests') {
                 environment {
-                    KUBECONFIG                   = credentials("${pipelineParams.kubeconfigCredentialsID}")
-                    TEST_OUTPUT_DIR              = "${env.OUTPUT_DIR}/${commonPrefix}-tests"
-                    TEST_OUTPUT_PATH             = "${env.WORKSPACE}/${env.TEST_OUTPUT_DIR}"
-                    FINAL_POD_LOGS_LOG_FILE_PATH = "${env.TEST_OUTPUT_PATH}/logs/final-pod-descriptions-logs.log"
-                    DEPLOY_PLATFORM              = "${pipelineParams.deployPlatform}"
-                    METERING_HTTPS_API           = "${pipelineParams.meteringHttpsAPI ?: false}"
+                    KUBECONFIG                        = credentials("${pipelineParams.kubeconfigCredentialsID}")
+                    TEST_OUTPUT_DIR                   = "${env.OUTPUT_DIR}/${commonPrefix}-tests"
+                    TEST_OUTPUT_PATH                  = "${env.WORKSPACE}/${env.TEST_OUTPUT_DIR}"
+                    FINAL_POD_LOGS_LOG_FILE_PATH      = "${env.TEST_OUTPUT_PATH}/logs/final-pod-descriptions-logs.log"
+                    DEPLOY_PLATFORM                   = "${pipelineParams.deployPlatform}"
+                    METERING_HTTPS_API                = "${pipelineParams.meteringHttpsAPI ?: false}"
+                    METERING_CREATE_PULL_SECRET       = "true"
                     UNINSTALL_METERING_BEFORE_INSTALL = "${(pipelineParams.uninstallMeteringBeforeInstall != null) ? pipelineParams.uninstallMeteringBeforeInstall : true}"
                 }
                 steps {

--- a/manifests/reports/cluster-capacity-daily.yaml
+++ b/manifests/reports/cluster-capacity-daily.yaml
@@ -1,0 +1,29 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-cpu-capacity-daily
+spec:
+  generationQuery: "cluster-cpu-capacity"
+  # this configures the this report to aggregate the hourly one
+  inputs:
+  - name: ClusterCpuCapacityReportName
+    value: cluster-cpu-capacity-hourly
+  schedule:
+    period: "daily"
+  gracePeriod: 1h # delay running 1 hour so that the hourly report has time to run
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-memory-capacity-daily
+spec:
+  generationQuery: "cluster-memory-capacity"
+  # this configures the this report to aggregate the hourly one
+  inputs:
+  - name: ClusterMemoryCapacityReportName
+    value: cluster-memory-capacity-hourly
+  schedule:
+    period: "daily"
+  gracePeriod: 1h # delay running 1 hour so that the hourly report has time to run

--- a/manifests/reports/cluster-capacity-hourly.yaml
+++ b/manifests/reports/cluster-capacity-hourly.yaml
@@ -1,0 +1,20 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-cpu-capacity-hourly
+spec:
+  generationQuery: "cluster-cpu-capacity"
+  schedule:
+    period: "hourly"
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-memory-capacity-hourly
+spec:
+  generationQuery: "cluster-memory-capacity"
+  schedule:
+    period: "hourly"
+

--- a/manifests/reports/cluster-usage-daily.yaml
+++ b/manifests/reports/cluster-usage-daily.yaml
@@ -1,0 +1,29 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-cpu-usage-daily
+spec:
+  generationQuery: "cluster-cpu-usage"
+  # this configures the this report to aggregate the hourly one
+  inputs:
+  - name: ClusterCpuusageReportName
+    value: cluster-cpu-usage-hourly
+  schedule:
+    period: "daily"
+  gracePeriod: 1h # delay running 1 hour so that the hourly report has time to run
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-memory-usage-daily
+spec:
+  generationQuery: "cluster-memory-usage"
+  # this configures the this report to aggregate the hourly one
+  inputs:
+  - name: ClusterMemoryusageReportName
+    value: cluster-memory-usage-hourly
+  schedule:
+    period: "daily"
+  gracePeriod: 1h # delay running 1 hour so that the hourly report has time to run

--- a/manifests/reports/cluster-usage-hourly.yaml
+++ b/manifests/reports/cluster-usage-hourly.yaml
@@ -1,0 +1,51 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-cpu-usage-hourly
+spec:
+  generationQuery: "cluster-cpu-usage"
+  schedule:
+    period: "hourly"
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-memory-usage-hourly
+spec:
+  generationQuery: "cluster-memory-usage"
+  schedule:
+    period: "hourly"
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-cpu-usage-daily
+spec:
+  generationQuery: "cluster-cpu-usage"
+  # this configures the this report to aggregate the hourly one
+  inputs:
+  - name: ClusterCpuusageReportName
+    value: cluster-cpu-usage-hourly
+  schedule:
+    period: "daily"
+  gracePeriod: 1h # delay running 1 hour so that the hourly report has time to run
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-memory-usage-daily
+spec:
+  generationQuery: "cluster-memory-usage"
+  # this configures the this report to aggregate the hourly one
+  inputs:
+  - name: ClusterMemoryusageReportName
+    value: cluster-memory-usage-hourly
+  schedule:
+    period: "daily"
+  gracePeriod: 1h # delay running 1 hour so that the hourly report has time to run

--- a/manifests/reports/cluster-utilization-daily.yaml
+++ b/manifests/reports/cluster-utilization-daily.yaml
@@ -1,0 +1,27 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-cpu-utilization-daily
+spec:
+  generationQuery: "cluster-cpu-utilization"
+  inputs:
+  - name: ClusterCpuUtilizationReportName
+    value: cluster-cpu-utilization-hourly
+  schedule:
+    period: "daily"
+  gracePeriod: 2h # delay running 2 hours so that the hourly report has time to run
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-memory-utilization-daily
+spec:
+  generationQuery: "cluster-memory-utilization"
+  inputs:
+  - name: ClusterMemoryUtilizationReportName
+    value: cluster-memory-utilization-hourly
+  schedule:
+    period: "daily"
+  gracePeriod: 2h # delay running 2 hours so that the hourly report has time to run

--- a/manifests/reports/cluster-utilization-hourly.yaml
+++ b/manifests/reports/cluster-utilization-hourly.yaml
@@ -1,0 +1,32 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-cpu-utilization-hourly
+spec:
+  generationQuery: "cluster-cpu-utilization"
+  inputs:
+  - name: ClusterCpuCapacityReportName
+    value: cluster-cpu-capacity-hourly
+  - name: ClusterCpuUsageReportName
+    value: cluster-cpu-usage-hourly
+  schedule:
+    period: "hourly"
+  gracePeriod: 1h # delay running 1 hour so the usage and capacity report has time to run
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: cluster-memory-utilization-hourly
+spec:
+  generationQuery: "cluster-memory-utilization"
+  inputs:
+  - name: ClusterMemoryCapacityReportName
+    value: cluster-memory-capacity-hourly
+  - name: ClusterMemoryUsageReportName
+    value: cluster-memory-usage-hourly
+  schedule:
+    period: "hourly"
+  gracePeriod: 1h # delay running 1 hour so the usage and capacity report has time to run
+

--- a/manifests/reports/namespace-usage-daily.yaml
+++ b/manifests/reports/namespace-usage-daily.yaml
@@ -1,0 +1,21 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: namespace-memory-usage-daily
+spec:
+  generationQuery: "namespace-memory-usage"
+  schedule:
+    period: "daily"
+  gracePeriod: 1h # delay running 1 hour so that the hourly report has time to run
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: namespace-cpu-usage-daily
+spec:
+  generationQuery: "namespace-cpu-usage"
+  schedule:
+    period: "daily"
+  gracePeriod: 1h # delay running 1 hour so that the hourly report has time to run

--- a/manifests/reports/namespace-usage-hourly.yaml
+++ b/manifests/reports/namespace-usage-hourly.yaml
@@ -1,0 +1,19 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: namespace-memory-usage-hourly
+spec:
+  generationQuery: "namespace-memory-usage"
+  schedule:
+    period: "hourly"
+
+---
+
+apiVersion: metering.openshift.io/v1alpha1
+kind: ScheduledReport
+metadata:
+  name: namespace-cpu-usage-hourly
+spec:
+  generationQuery: "namespace-cpu-usage"
+  schedule:
+    period: "hourly"


### PR DESCRIPTION
This should ensure we're continuously reportings in the continuous upgrade job.
Future steps would be to run more reports, but also to write tests in Go to validate they produce what we want.