### PR TITLE
charts/reporting-operator: Allow accessing reporting API route using http

### DIFF
--- a/charts/reporting-operator/templates/route.yaml
+++ b/charts/reporting-operator/templates/route.yaml
@@ -10,6 +10,7 @@ spec:
     targetPort: http
   tls:
     termination: Reencrypt
+    insecureEdgeTerminationPolicy: Allow
   to:
     kind: Service
     name: reporting-operator


### PR DESCRIPTION
Since service serving certificates are self-signed, in some cases it can
be useful to allow accessing the reporting API over http when systems
can't be configured to trust the certificate or ignore the error.