### PR TITLE
pkg/operator: Properly store health checks in subdir of storage location

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -417,8 +417,12 @@ func (op *Reporting) Run(stopCh <-chan struct{}) error {
 	if err != nil {
 		return fmt.Errorf("no default storage configured, unable to setup health checker: %v", err)
 	}
+	newTableProperties, err := addTableNameToLocation(*tableProperties, "metering_health_check")
+	if err != nil {
+		return err
+	}
 
-	prestoHealthChecker := reporting.NewPrestoHealthChecker(op.logger, prestoQueryer, hiveTableManager, *tableProperties)
+	prestoHealthChecker := reporting.NewPrestoHealthChecker(op.logger, prestoQueryer, hiveTableManager, newTableProperties)
 	op.testWriteToPrestoFunc = func() bool {
 		return prestoHealthChecker.TestWriteToPrestoSingleFlight()
 	}


### PR DESCRIPTION
I noticed this when I looked in hdfs directly and found a bunch of files in the root of `/operator-metering/storage`. This properly puts health checks in a sub-directory for it's table.