### PR TITLE
Add superset chart for interacting with Presto

### DIFF
--- a/charts/openshift-metering/requirements.yaml
+++ b/charts/openshift-metering/requirements.yaml
@@ -10,3 +10,7 @@ dependencies:
   version: 0.1.0
   repository: "file://../hdfs"
   condition: hdfs.enabled
+- name: superset
+  version: 1.0.0
+  repository: "file://../superset"
+  condition: superset.enabled

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -38,3 +38,18 @@ hdfs:
 
     securityContext:
       fsGroup: null
+
+superset:
+  enabled: false
+  datasources:
+  - fileName: "metering-presto.yaml"
+    content: |-
+      databases:
+      - allow_ctas: true
+        database_name: metering-presto
+        expose_in_sqllab: true
+        extra: "{\r\n    \"metadata_params\": {},\r\n    \"engine_params\": {},\r\n    \"\
+          metadata_cache_timeout\": {},\r\n    \"schemas_allowed_for_csv_upload\": []\r\n\
+          }\r\n"
+        sqlalchemy_uri: presto://presto:8080
+        tables: []

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -31,8 +31,8 @@ presto:
       securityContext:
         fsGroup: null
 hdfs:
+  enabled: true
   spec:
-    enabled: true
     config:
       datanodeDataDirPerms: "775"
 

--- a/charts/operator-metering/requirements.yaml
+++ b/charts/operator-metering/requirements.yaml
@@ -10,3 +10,7 @@ dependencies:
   version: 0.1.0
   repository: "file://../hdfs"
   condition: hdfs.enabled
+- name: superset
+  version: 1.0.0
+  repository: "file://../superset"
+  condition: superset.enabled

--- a/charts/operator-metering/values.yaml
+++ b/charts/operator-metering/values.yaml
@@ -21,3 +21,18 @@ hdfs:
       datanodeDataDirPerms: "775"
     securityContext:
       fsGroup: 0
+
+superset:
+  enabled: false
+  datasources:
+  - fileName: "metering-presto.yaml"
+    content: |-
+      databases:
+      - allow_ctas: true
+        database_name: metering-presto
+        expose_in_sqllab: true
+        extra: "{\r\n    \"metadata_params\": {},\r\n    \"engine_params\": {},\r\n    \"\
+          metadata_cache_timeout\": {},\r\n    \"schemas_allowed_for_csv_upload\": []\r\n\
+          }\r\n"
+        sqlalchemy_uri: presto://presto:8080
+        tables: []

--- a/charts/operator-metering/values.yaml
+++ b/charts/operator-metering/values.yaml
@@ -15,8 +15,8 @@ presto:
         fsGroup: 0
 
 hdfs:
+  enabled: true
   spec:
-    enabled: true
     config:
       datanodeDataDirPerms: "775"
     securityContext:

--- a/charts/superset/.helmignore
+++ b/charts/superset/.helmignore
@@ -1,0 +1,24 @@
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -1,0 +1,14 @@
+appVersion: 0.24.0
+description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence
+  web application
+home: https://github.com/apache/incubator-superset
+icon: https://superset.incubator.apache.org/_images/s.png
+keywords:
+- bi
+maintainers:
+- email: alitari67@gmail.com
+  name: alitari
+name: superset
+sources:
+- https://github.com/apache/incubator-superset
+version: 1.0.0

--- a/charts/superset/README.md
+++ b/charts/superset/README.md
@@ -1,0 +1,94 @@
+# Apache superset
+
+## Introduction
+
+This chart bootstraps an [Apache superset](https://superset.incubator.apache.org/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## TL;DR;
+
+```bash
+$ helm install stable/superset
+```
+
+## Prerequisites
+
+- Kubernetes 1.9+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure (Only when persisting data)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/superset
+```
+
+The command deploys Superset on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+| Parameter                  | Description                                     | Default                                                      |
+| -------------------------- | ----------------------------------------------- | ------------------------------------------------------------ |
+| `image.repository`         | `superset` image repository                     | `amancevice/superset`                                        |
+| `image.tag`                | `superset` image tag                            | `0.24.0`                                                     |
+| `image.pullPolicy`         | Image pull policy                               | `IfNotPresent`                                               |
+| `configFile`               | Content of [`superset_config.py`](https://superset.incubator.apache.org/installation.html)                     | See values.yaml](./values.yaml)              |
+| `initFile`                 | Content of init shell script                    | See [values.yaml](./values.yaml)                             |
+| `replicas`                 | Number of replicas of superset                  | `1`                                                          |
+| `extraEnv`                      | Extra environment variables passed to pods      | `{}`                                                          |
+| `extraEnvFromSecret`            | The name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment | `""`                                                          |
+| `persistence.enabled`      | Enable persistence                              | `false`                                                      |
+| `persistence.existingClaim`| Provide an existing PersistentVolumeClaim       | `""`                                                         |
+| `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                              |
+| `persistence.size`         | Size of data volume                             | `8Gi`                                                        |
+| `resources`                | CPU/Memory resource requests/limits             | Memory: `256Mi`, CPU: `50m`   / Memory: `500Mi`, CPU: `500m` |
+| `service.port`             | TCP port                                        | `9000`                                                       |
+| `service.type`             | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                  |
+| `nodeSelector`             | Node labels for pod assignment                  | {}                                                           |
+| `tolerations`              | Toleration labels for pod assignment            | []                                                           |
+| `livenessProbe`            | Parameter for liveness probe                    | See [values.yaml](./values.yaml)                             |
+| `readinessProbe`           | Parameter for readiness probe                   | See [values.yaml](./values.yaml)                             |
+| `ingress.enabled`          | Create an ingress resource when true            | `false`                                                      |
+| `ingress.annotations`      | ingress annotations                             | {}                                                           |
+| `ingress.hosts`            | ingress hosts                                   | `[superset.domain.com]`                                      |
+| `ingress.path`             | ingress path                                    | `\`                                                          |
+| `ingress.tls`              | ingress tls                                     | `[]`                                                         |
+
+ see [values.yaml](./values.yaml)
+
+## Init script
+
+There is a script (`init_superset.sh`) which is called at the entrypoint of the container. It initialzes the db and creates an user account. You can configure the content with `initFile`. E.g. in order to change admin password and load examples:
+
+```yaml
+initFile: |-
+  /usr/local/bin/superset-init --username admin --firstname myfirstname --lastname mylastname --email admin@fab.org --password mypassword
+  superset load_examples
+  superset runserver
+```
+
+## Persistence
+
+The [superset image](https://hub.docker.com/r/amancevice/superset/) mounts the SQLite DB file (`superset.db`) on path `/var/lib/superset`. The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning. If the PersistentVolumeClaim should not be managed by the chart, define `persistence.existingClaim`.
+
+### Existing PersistentVolumeClaims
+
+1. Create the PersistentVolumeClaim with name `superset-pvc` in the same namespace
+1. Install the chart
+
+```bash
+$ helm install --set persistence.enabled=true,persistence.existingClaim=superset-pvc stable/superset
+```

--- a/charts/superset/templates/NOTES.txt
+++ b/charts/superset/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Superset can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
+{{ template "superset.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+Initially you can login with username/password: admin/admin.
+
+{{- if not .Values.persistence.enabled }}
+WARNING: Persistence is DISABLED !
+{{- end }}

--- a/charts/superset/templates/_helpers.tpl
+++ b/charts/superset/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "superset.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "superset.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "superset.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/superset/templates/datasources-configmap.yaml
+++ b/charts/superset/templates/datasources-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "superset.fullname" . }}-datasources
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- block "extraMetadata" . }}
+{{- end }}
+data:
+{{- range $i, $value := .Values.datasources }}
+  {{ $value.fileName }}: |
+{{ $value.content | indent 4}}
+{{- end }}

--- a/charts/superset/templates/deployment.yaml
+++ b/charts/superset/templates/deployment.yaml
@@ -1,0 +1,153 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "superset.fullname" . }}
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "superset.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "superset.fullname" . }}
+      labels:
+        app: {{ template "superset.name" . }}
+        chart: {{ template "superset.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 8 }}
+{{- end }}
+      annotations:
+        superset-scripts-config-hash: {{ include (print $.Template.BasePath "/scripts-configmap.yaml") . | sha256sum }}
+        superset-env-secret-hash: {{ include (print $.Template.BasePath "/env-secret.yaml") . | sha256sum }}
+        superset-config-secret-hash: {{ include (print $.Template.BasePath "/server-config-secret.yaml") . | sha256sum }}
+        superset-datasources-config-hash: {{ include (print $.Template.BasePath "/datasources-configmap.yaml") . | sha256sum }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+{{- end }}
+      volumes:
+        - name: superset-scripts
+          configMap:
+            name: {{ template "superset.fullname" . }}-scripts
+            defaultMode: 0774
+        - name: superset-server-config
+          secret:
+            secretName: {{ template "superset.fullname" . }}-config
+        - name: superset-datasources-config
+          configMap:
+            name: {{ template "superset.fullname" . }}-datasources
+        - name: storage-volume
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "superset.fullname" . }}{{- end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      initContainers:
+        - name: superset-init
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/superset-scripts/entrypoint.sh"]
+          args: ["/superset-scripts/init_superset.sh"]
+          volumeMounts:
+            - name: superset-server-config
+              mountPath: /etc/superset
+            - name: superset-scripts
+              mountPath: /superset-scripts
+            - name: superset-datasources-config
+              mountPath: /superset-datasources
+            - name: storage-volume
+              mountPath: /var/lib/superset
+          ports:
+            - name: http
+              containerPort: 8088
+              protocol: TCP
+          env:
+            - name: "DATASOURCES_DIRECTORY"
+              value: "/superset-datasources"
+          {{- range $key, $value := .Values.extraEnv }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ template "superset.fullname" . }}-env
+        {{- if .Values.extraEnvFromSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvFromSecret }}
+        {{- end }}
+    {{- with .Values.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+      containers:
+        - name: superset
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/superset-scripts/entrypoint.sh"]
+          args: ["gunicorn", "superset:app" ]
+          volumeMounts:
+            - name: superset-server-config
+              mountPath: /etc/superset
+            - name: superset-scripts
+              mountPath: /superset-scripts
+            - name: superset-datasources-config
+              mountPath: /superset-datasources
+            - name: storage-volume
+              mountPath: /var/lib/superset
+          ports:
+            - name: http
+              containerPort: 8088
+              protocol: TCP
+          env:
+            - name: "DATASOURCES_DIRECTORY"
+              value: "/superset-datasources"
+          {{- range $key, $value := .Values.extraEnv }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ template "superset.fullname" . }}-env
+        {{- if .Values.extraEnvFromSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvFromSecret }}
+        {{- end }}
+    {{- with .Values.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/superset/templates/env-secret.yaml
+++ b/charts/superset/templates/env-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "superset.fullname" . }}-env
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- block "extraMetadata" . }}
+{{- end }}
+type: Opaque
+data:
+  ADMIN_USERNAME: {{ .Values.adminUsername | b64enc | quote }}
+  ADMIN_PASSWORD: {{ .Values.adminPassword | b64enc | quote }}
+  ADMIN_EMAIL: {{ .Values.adminEmail | b64enc | quote }}
+  ADMIN_FIRSTNAME: {{ .Values.adminFirstName | b64enc | quote }}
+  ADMIN_LASTNAME: {{ .Values.adminLastName | b64enc | quote }}

--- a/charts/superset/templates/ingress.yaml
+++ b/charts/superset/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "superset.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/superset/templates/pvc.yaml
+++ b/charts/superset/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.persistence.enabled -}}
+{{- if not .Values.persistence.existingClaim -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "superset.fullname" . }}
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  accessModes:
+{{ toYaml .Values.persistence.accessModes | indent 4 }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.persistence.size }}"
+{{- end -}}
+{{- end -}}

--- a/charts/superset/templates/scripts-configmap.yaml
+++ b/charts/superset/templates/scripts-configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "superset.fullname" . }}-scripts
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- block "extraMetadata" . }}
+{{- end }}
+data:
+  init_superset.sh: |
+{{ .Values.initSupersetScript | indent 4 }}
+  entrypoint.sh: |
+    #!/bin/bash
+    # add UID to /etc/passwd if missing
+    if ! whoami &> /dev/null; then
+      if [ -w /etc/passwd ]; then
+        echo "${USER_NAME:-superset}:x:$(id -u):0:${USER_NAME:-superset} user:${HOME}:/sbin/nologin" >> /etc/passwd
+      fi
+    fi
+
+    exec "$@"

--- a/charts/superset/templates/server-config-secret.yaml
+++ b/charts/superset/templates/server-config-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "superset.fullname" . }}-config
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- block "extraMetadata" . }}
+{{- end }}
+type: Opaque
+data:
+  superset_config.py: {{ .Values.configFile | b64enc | quote }}

--- a/charts/superset/templates/svc.yaml
+++ b/charts/superset/templates/svc.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "superset.fullname" . }}
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
+  selector:
+    app: {{ template "superset.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -1,0 +1,205 @@
+# Default values for superset.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+replicaCount: 1
+
+## Set default image, imageTag, and imagePullPolicy.
+image:
+  repository: "quay.io/coreos/superset"
+  tag: "metering-master-test"
+  pullPolicy: "Always"
+
+datasources: []
+
+adminUsername: "admin"
+adminPassword: "admin"
+adminEmail: "admin@example.org"
+adminFirstName: "admin"
+adminLastName: "admin"
+
+initSupersetScript: |-
+  #!/bin/bash
+  echo "running superset init script"
+  echo "creating admin user"
+  /usr/local/bin/superset-init \
+    --username "$ADMIN_USERNAME" \
+    --firstname "$ADMIN_FIRSTNAME" \
+    --lastname "$ADMIN_LASTNAME" \
+    --email "$ADMIN_EMAIL" \
+    --password "$ADMIN_PASSWORD"
+  echo "importing datasources"
+  superset import_datasources -p "$DATASOURCES_DIRECTORY"
+
+configFile: |-
+  #---------------------------------------------------------
+  # Superset specific config
+  #---------------------------------------------------------
+  ROW_LIMIT = 5000
+  SUPERSET_WORKERS = 2
+
+  SUPERSET_WEBSERVER_PORT = 8088
+  #---------------------------------------------------------
+
+  #---------------------------------------------------------
+  # Flask App Builder configuration
+  #---------------------------------------------------------
+  # Your App secret key
+  SECRET_KEY = '\2\1thisismyscretkey\1\2\e\y\y\h'
+
+  # The SQLAlchemy connection string to your database backend
+  # This connection defines the path to the database that stores your
+  # superset metadata (slices, connections, tables, dashboards, ...).
+  # Note that the connection information to connect to the datasources
+  # you want to explore are managed directly in the web UI
+  SQLALCHEMY_DATABASE_URI = 'sqlite:////var/lib/superset/superset.db'
+
+
+  # Flask-WTF flag for CSRF
+  WTF_CSRF_ENABLED = True
+  # Add endpoints that need to be exempt from CSRF protection
+  WTF_CSRF_EXEMPT_LIST = []
+
+  # Set this API key to enable Mapbox visualizations
+  MAPBOX_API_KEY = ''
+
+## Extra environment variables that will be passed onto deployment pod
+##
+extraEnv: {}
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for secret keys, etc
+##
+extraEnvFromSecret: ""
+
+persistence:
+
+  ## If true, superset server will create/use a Persistent Volume Claim
+    ## If false, use emptyDir
+    ##
+  enabled: true
+
+  ## superset data Persistent Volume access modes
+  ## Must match those of existing PV or dynamic provisioner
+  ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  accessModes:
+    - ReadWriteOnce
+
+  ## superset data Persistent Volume size
+  ##
+  size: 8Gi
+
+  ## superset server data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
+  ## Superset data Persistent Volume existing claim name
+  ## Requires server.persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  existingClaim: ""
+
+## Expose the superset service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  type: ClusterIP
+  port: 9000
+
+  ## service annotations
+  annotations: {}
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    # external-dns.alpha.kubernetes.io/hostname: "superset.domain.com"
+
+  ## loadbalancer source ranges. only used when service.type is "LoadBalancer"
+  loadBalancerSourceRanges: []
+  # - 172.31.0.0/16
+
+
+ingress:
+  ## If true, superset Ingress will be created
+  ##
+  enabled: false
+
+  ## superset Ingress annotations
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: 'true'
+
+  ## superset Ingress hostnames
+  ## Must be provided if Ingress is enabled
+  ##
+  hosts:
+    - superset.domain.com
+
+  ## superset Ingress path
+  ## Optional, allows specifying paths for more flexibility
+  ## E.g. Traefik ingress likes paths
+  ##
+  path: /
+
+  ## superset Ingress TLS configuration
+  ## Secrets must be manually created in the namespace
+  ##
+  tls: []
+  #   - secretName: superset-server-tls
+  #     hosts:
+  #       - superset.domain.com
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+tolerations: []
+
+## Affinity and anti-affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+#  requests:
+#    cpu: 50m
+#    memory: 256Mi
+#  limits:
+#    cpu: 500m
+#    memory: 750Mi
+
+labels: {}
+annotations: {}
+
+## Configure liveness/readiness params
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+##
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 80
+  timeoutSeconds: 5
+  periodSeconds: 10
+  failureThreshold: 2
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 60
+  timeoutSeconds: 5
+  periodSeconds: 10
+  failureThreshold: 2
+
+
+securityContext:
+  runAsNonRoot: true

--- a/manifests/metering-config/superset.yaml
+++ b/manifests/metering-config/superset.yaml
@@ -1,0 +1,7 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: Metering
+metadata:
+  name: "operator-metering"
+spec:
+  superset:
+    enabled: true


### PR DESCRIPTION
Allows building visualizations from the reports and raw data available via
Presto.  Disabled by default. Can be enabled by setting spec.superset.enabled
to true in Metering CR.

Based on https://github.com/helm/charts/tree/master/stable/superset