### PR TITLE
charts/{hdfs,presto}: Store presto, hive, hdfs GC logs into an emptyDir

### DIFF
--- a/charts/hdfs/templates/configmap.yaml
+++ b/charts/hdfs/templates/configmap.yaml
@@ -105,11 +105,12 @@ data:
     fi
 
     # Set garbage collection settings
-    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps"
+    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError"
     # Set JMX options
     export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
     # Set garbage collection logs
-    export GC_SETTINGS="${GC_SETTINGS} -Xloggc:${HADOOP_LOG_DIR}/gc-rm.log-$(date +'%Y%m%d%H%M')"
+    export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"
+    export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
 
     # set name node options
     export HDFS_NAMENODE_OPTS="${HDFS_NAMENODE_OPTS} -Dhadoop.security.logger=INFO,RFAS ${GC_SETTINGS} ${JMX_OPTIONS}"

--- a/charts/hdfs/templates/datanode-statefulset.yaml
+++ b/charts/hdfs/templates/datanode-statefulset.yaml
@@ -181,6 +181,8 @@ spec:
           defaultMode: 0555
       - name: namenode-empty
         emptyDir: {}
+      - name: hadoop-logs
+        mountPath: /opt/hadoop/logs
   volumeClaimTemplates:
   - metadata:
       name: "hdfs-datanode-data"

--- a/charts/hdfs/templates/namenode-statefulset.yaml
+++ b/charts/hdfs/templates/namenode-statefulset.yaml
@@ -143,6 +143,8 @@ spec:
         # required for openshift
         - name: datanode-empty
           mountPath: /hadoop/dfs/data
+        - name: hadoop-logs
+          mountPath: /opt/hadoop/logs
         resources:
 {{ toYaml .Values.spec.namenode.resources | indent 10 }}
       serviceAccount: hdfs
@@ -156,6 +158,8 @@ spec:
           name: hdfs-config
           defaultMode: 0555
       - name: datanode-empty
+        emptyDir: {}
+      - name: hadoop-logs
         emptyDir: {}
   volumeClaimTemplates:
   - metadata:

--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -115,6 +115,8 @@ spec:
         emptyDir: {}
       - name: datanode-empty
         emptyDir: {}
+      - name: hadoop-logs
+        emptyDir: {}
       - name: hive-metastore-db-data
 {{- if .Values.spec.hive.metastore.storage.create }}
         persistentVolumeClaim:

--- a/charts/presto/templates/hive-scripts-configmap.yaml
+++ b/charts/presto/templates/hive-scripts-configmap.yaml
@@ -51,11 +51,12 @@ data:
     ln -s -f /hive-config/hive-exec-log4j2.properties $HIVE_HOME/conf/hive-exec-log4j2.properties
 
     # Set garbage collection settings
-    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps"
+    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError"
     # Set JMX options
     export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
     # Set garbage collection logs
-    export GC_SETTINGS="${GC_SETTINGS} -Xloggc:${HADOOP_LOG_DIR}/gc-rm.log-$(date +'%Y%m%d%H%M')"
+    export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"
+    export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
 
     export HIVE_LOGLEVEL="${HIVE_LOGLEVEL:-INFO}"
     export HADOOP_OPTS="${HADOOP_OPTS} ${GC_SETTINGS} ${JMX_OPTIONS}"

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -122,6 +122,8 @@ spec:
         emptyDir: {}
       - name: hive-metastore-db-data
         emptyDir: {}
+      - name: hadoop-logs
+        emptyDir: {}
 {{- if .Values.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data
         persistentVolumeClaim:

--- a/charts/presto/templates/presto-coordinator-config.yaml
+++ b/charts/presto/templates/presto-coordinator-config.yaml
@@ -71,3 +71,8 @@ data:
     -Dcom.sun.management.jmxremote.port=8081
     -Dcom.sun.management.jmxremote.rmi.port=8081
     -Djava.rmi.server.hostname=127.0.0.1
+    -verbose:gc
+    -XX:+PrintGCDetails
+    -XX:+PrintGCTimeStamps
+    -XX:+PrintGCDateStamps
+    -Xloggc:/var/presto/logs/gc.log

--- a/charts/presto/templates/presto-coordinator-deployment.yaml
+++ b/charts/presto/templates/presto-coordinator-deployment.yaml
@@ -92,6 +92,8 @@ spec:
           mountPath: /opt/jmx_exporter/config
         - name: presto-data
           mountPath: /var/presto/data
+        - name: presto-logs
+          mountPath: /var/presto/logs
 {{- if .Values.spec.config.sharedVolume.enabled }}
         - name: hive-warehouse-data
           mountPath: {{ .Values.spec.config.sharedVolume.mountPath }}
@@ -115,6 +117,8 @@ spec:
       - name: presto-etc
         emptyDir: {}
       - name: presto-data
+        emptyDir: {}
+      - name: presto-logs
         emptyDir: {}
 {{- if .Values.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data

--- a/charts/presto/templates/presto-worker-config.yaml
+++ b/charts/presto/templates/presto-worker-config.yaml
@@ -70,3 +70,8 @@ data:
     -Dcom.sun.management.jmxremote.port=8081
     -Dcom.sun.management.jmxremote.rmi.port=8081
     -Djava.rmi.server.hostname=127.0.0.1
+    -verbose:gc
+    -XX:+PrintGCDetails
+    -XX:+PrintGCTimeStamps
+    -XX:+PrintGCDateStamps
+    -Xloggc:/var/presto/logs/gc.log

--- a/charts/presto/templates/presto-worker-deployment.yaml
+++ b/charts/presto/templates/presto-worker-deployment.yaml
@@ -92,6 +92,8 @@ spec:
           mountPath: /opt/jmx_exporter/config
         - name: presto-data
           mountPath: /var/presto/data
+        - name: presto-logs
+          mountPath: /var/presto/logs
 {{- if .Values.spec.config.sharedVolume.enabled }}
         - name: hive-warehouse-data
           mountPath: {{ .Values.spec.config.sharedVolume.mountPath }}
@@ -115,6 +117,8 @@ spec:
       - name: presto-etc
         emptyDir: {}
       - name: presto-data
+        emptyDir: {}
+      - name: presto-logs
         emptyDir: {}
 {{- if .Values.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data


### PR DESCRIPTION
Hive/hdfs were unable to write logs with current settings due to
HADOOP_LOG_DIR being unset and the logs attempting to be written to /.
This updates both to set HADOOP_LOG_DIR to $HADOOP_HOME/logs and updates
presto pods to store logs in /var/presto/logs also.