### PR TITLE
Enable passing pre-existing secret with AWS credentials to hive/presto

### DIFF
--- a/Documentation/configuring-storage.md
+++ b/Documentation/configuring-storage.md
@@ -75,7 +75,7 @@ Replace `operator-metering-data` with the name of your bucket.
 Please note that this must be done before installation. Changing these settings after installation may result in unexpected behavior.
 
 Because the deployed HDFS cluster will not be used to store data, it may also be disabled.
-In `s3-storage.yaml`, this has already been done by setting `hdfs.enabled` to `false`.
+In `s3-storage.yaml`, this has already been done by setting `hdfs.enabled` to `false` and setting `presto.spec.hive.config.useHdfsConfigMap` to `false`.
 
 ## Using shared volumes for storage
 

--- a/charts/presto/templates/_helpers.tpl
+++ b/charts/presto/templates/_helpers.tpl
@@ -7,12 +7,6 @@ hive.compression-codec=SNAPPY
 hive.hdfs.authentication.type=NONE
 hive.metastore.authentication.type=NONE
 hive.metastore.uri={{ .Values.spec.hive.config.metastoreURIs }}
-{{- if .Values.spec.config.awsAccessKeyID }}
-hive.s3.aws-access-key={{ .Values.spec.config.awsAccessKeyID }}
-{{- end}}
-{{- if .Values.spec.config.awsSecretAccessKey }}
-hive.s3.aws-secret-key={{ .Values.spec.config.awsSecretAccessKey }}
-{{- end}}
 {{ end }}
 
 {{- define "presto-jmx-catalog-properties" -}}
@@ -46,6 +40,18 @@ connector.name=jmx
     resourceFieldRef:
       containerName: presto
       resource: limits.memory
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.spec.config.awsCredentialsSecretName }}"
+      key: aws-access-key-id
+      optional: true
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.spec.config.awsCredentialsSecretName }}"
+      key: aws-secret-access-key
+      optional: true
 {{- end }}
 
 {{- define "hive-env" }}
@@ -66,13 +72,13 @@ connector.name=jmx
 - name: AWS_ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
-      name: hive-secrets
+      name: "{{ .Values.spec.config.awsCredentialsSecretName }}"
       key: aws-access-key-id
       optional: true
 - name: AWS_SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
-      name: hive-secrets
+      name: "{{ .Values.spec.config.awsCredentialsSecretName }}"
       key: aws-secret-access-key
       optional: true
 {{- end }}

--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -30,6 +30,7 @@ spec:
       annotations:
         hive-configmap-hash: {{ include (print $.Template.BasePath "/hive-configmap.yaml") . | sha256sum }}
         hive-scripts-hash: {{ include (print $.Template.BasePath "/hive-scripts-configmap.yaml") . | sha256sum }}
+        presto-aws-credentials-secret-hash: {{ include (print $.Template.BasePath "/presto-aws-credentials-secret.yaml") . | sha256sum }}
 {{- if .Values.spec.hive.annotations }}
 {{ toYaml .Values.spec.hive.annotations | indent 8 }}
 {{- end }}

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         hive-configmap-hash: {{ include (print $.Template.BasePath "/hive-configmap.yaml") . | sha256sum }}
         hive-scripts-hash: {{ include (print $.Template.BasePath "/hive-scripts-configmap.yaml") . | sha256sum }}
-        hive-secrets-hash: {{ include (print $.Template.BasePath "/hive-secrets.yaml") . | sha256sum }}
+        presto-aws-credentials-secret-hash: {{ include (print $.Template.BasePath "/presto-aws-credentials-secret.yaml") . | sha256sum }}
 {{- if .Values.spec.hive.annotations }}
 {{ toYaml .Values.spec.hive.annotations | indent 8 }}
 {{- end }}

--- a/charts/presto/templates/presto-aws-credentials-secret.yaml
+++ b/charts/presto/templates/presto-aws-credentials-secret.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.spec.config.createAwsCredentialsSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: hive-secrets
+  name: presto-aws-credentials
 {{- block "extraMetadata" . }}
 {{- end }}
 data:
@@ -11,3 +12,4 @@ data:
 {{- if .Values.spec.config.awsSecretAccessKey }}
   aws-secret-access-key: {{ .Values.spec.config.awsSecretAccessKey | b64enc | quote}}
 {{- end}}
+{{- end -}}

--- a/charts/presto/templates/presto-common-config.yaml
+++ b/charts/presto/templates/presto-common-config.yaml
@@ -33,9 +33,9 @@ data:
     # set min to max to avoid pauses caused by heap expansion
     export MIN_HEAPSIZE="$MAX_HEAPSIZE"
 
+    JVM_CONFIG="${PRESTO_HOME}/etc/jvm.config"
     if [ -n "$MAX_HEAPSIZE" ]; then
       # add heapsize to jvm config if not already
-      JVM_CONFIG="${PRESTO_HOME}/etc/jvm.config"
       if ! grep -q -F 'Xmx' "$JVM_CONFIG"; then
         FLAG="-Xmx${MAX_HEAPSIZE}M"
         echo "Adding $FLAG to $JVM_CONFIG"

--- a/charts/presto/templates/presto-common-config.yaml
+++ b/charts/presto/templates/presto-common-config.yaml
@@ -58,6 +58,14 @@ data:
       echo "$NODE_ID" >> "$NODE_CONFIG"
     fi
 
+    # add AWS creds to hive catalog properties
+    HIVE_CATALOG_CONFIG="${PRESTO_HOME}/etc/catalog/hive.properties"
+    if ! grep -q -F 'hive.s3.aws-access-key' "$HIVE_CATALOG_CONFIG"; then
+      echo "Adding hive.s3.aws-access-key and hive.s3.aws-secret-key to $HIVE_CATALOG_CONFIG"
+      echo "hive.s3.aws-access-key=$AWS_ACCESS_KEY_ID" >> "$HIVE_CATALOG_CONFIG"
+      echo "hive.s3.aws-secret-key=$AWS_SECRET_ACCESS_KEY" >> "$HIVE_CATALOG_CONFIG"
+    fi
+
     # add UID to /etc/passwd if missing
     if ! whoami &> /dev/null; then
         if [ -w /etc/passwd ]; then

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -157,9 +157,10 @@ spec:
     annotations: {}
 
   config:
-    awsRegion: ""
     awsAccessKeyID: ""
     awsSecretAccessKey: ""
+    createAwsCredentialsSecret: true
+    awsCredentialsSecretName: presto-aws-credentials
 
     sharedVolume:
       enabled: false

--- a/manifests/metering-config/s3-storage.yaml
+++ b/manifests/metering-config/s3-storage.yaml
@@ -30,6 +30,9 @@ spec:
         # Replace these with your own AWS credentials
         awsAccessKeyID: "REPLACEME"
         awsSecretAccessKey: "REPLACEME"
+      hive:
+        config:
+          useHdfsConfigMap: false
 
   hdfs:
     # disable HDFS components when using S3 to avoid wasting resources.


### PR DESCRIPTION
This is to allow not having to pass aws credentials in the Metering CR directly.