### PR TITLE
reporting-operator: add pvc-usage and capacity

### DIFF
--- a/charts/reporting-operator/templates/custom-resources/prom-queries/persistentvolumeclaim-capacity.yaml
+++ b/charts/reporting-operator/templates/custom-resources/prom-queries/persistentvolumeclaim-capacity.yaml
@@ -1,0 +1,11 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportPrometheusQuery
+metadata:
+  name: persistentvolumeclaim-capacity-bytes
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  query: |
+    kubelet_volume_stats_capacity_bytes

--- a/charts/reporting-operator/templates/custom-resources/prom-queries/persistentvolumeclaim-usage.yaml
+++ b/charts/reporting-operator/templates/custom-resources/prom-queries/persistentvolumeclaim-usage.yaml
@@ -1,0 +1,11 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportPrometheusQuery
+metadata:
+  name: persistentvolumeclaim-usage-bytes
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  query: |
+    kubelet_volume_stats_used_bytes

--- a/charts/reporting-operator/templates/custom-resources/report-queries/persistentvolumeclaim-capacity.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/persistentvolumeclaim-capacity.yaml
@@ -1,0 +1,44 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "persistentvolumeclaim-capacity-raw"
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  reportDataSources:
+  - "persistentvolumeclaim-capacity-bytes"
+  columns:
+  - name: namespace
+    type: string
+  - name: persistentvolumeclaim
+    type: string
+  - name: labels
+    type: map<string, string>
+    tableHidden: true
+  - name: persistentvolumeclaim_capacity_bytes
+    type: double
+    unit: bytes
+  - name: timeprecision
+    type: double
+    unit: seconds
+  - name: persistentvolumeclaim_capacity_byte_seconds
+    type: double
+    unit: byte_seconds
+  - name: timestamp
+    type: timestamp
+    unit: date
+  - name: dt
+    type: string
+  query: |
+    SELECT
+        labels['exported_namespace'] as namespace,
+        labels['persistentvolumeclaim'] as persistentvolumeclaim,
+        labels,
+        amount as persistentvolumeclaim_capacity_bytes,
+        timeprecision,
+        amount * timeprecision as persistentvolumeclaim_capacity_byte_seconds,
+        "timestamp",
+        dt
+    FROM {| dataSourceTableName "persistentvolumeclaim-capacity-bytes" |}

--- a/charts/reporting-operator/templates/custom-resources/report-queries/persistentvolumeclaim-usage.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/persistentvolumeclaim-usage.yaml
@@ -1,0 +1,44 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "persistentvolumeclaim-usage-raw"
+  labels:
+    operator-metering: "true"
+{{- block "extraMetadata" . }}
+{{- end }}
+spec:
+  reportDataSources:
+  - "persistentvolumeclaim-usage-bytes"
+  columns:
+  - name: namespace
+    type: string
+  - name: persistentvolumeclaim
+    type: string
+  - name: labels
+    type: map<string, string>
+    tableHidden: true
+  - name: persistentvolumeclaim_usage_bytes
+    type: double
+    unit: bytes
+  - name: timeprecision
+    type: double
+    unit: seconds
+  - name: persistentvolumeclaim_usage_byte_seconds
+    type: double
+    unit: byte_seconds
+  - name: timestamp
+    type: timestamp
+    unit: date
+  - name: dt
+    type: string
+  query: |
+    SELECT
+        labels['exported_namespace'] as namespace,
+        labels['persistentvolumeclaim'] as persistentvolumeclaim,
+        labels,
+        amount as persistentvolumeclaim_usage_bytes,
+        timeprecision,
+        amount * timeprecision as persistentvolumeclaim_usage_byte_seconds,
+        "timestamp",
+        dt
+    FROM {| dataSourceTableName "persistentvolumeclaim-usage-bytes" |}

--- a/charts/reporting-operator/values.yaml
+++ b/charts/reporting-operator/values.yaml
@@ -108,6 +108,14 @@ spec:
         spec:
           promsum:
             query: "node-capacity-cpu-cores"
+      persistentvolumeclaim-capacity-bytes:
+        spec:
+          promsum:
+            query: "persistentvolumeclaim-capacity-bytes"
+      persistentvolumeclaim-usage-bytes:
+        spec:
+          promsum:
+            query: "persistentvolumeclaim-usage-bytes"
 
   resources:
     requests:


### PR DESCRIPTION
This is the basic I'm using to figure out my non-raw rgq. I was using pod-memory as one of the examples to look at. 