### PR TITLE
Fix AWS ReportDataSource

### DIFF
--- a/charts/reporting-operator/templates/custom-resources/report-queries/aws-billing.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/aws-billing.yaml
@@ -11,7 +11,7 @@ spec:
   reportDataSources:
   - "aws-billing"
   reportQueries:
-  - "node-memory-allocatable"
+  - "node-memory-allocatable-raw"
   columns:
   - name: resource_id
     type: string
@@ -28,7 +28,7 @@ spec:
   query: |
     WITH resource_id_list AS (
       SELECT resource_id
-      FROM {| generationQueryViewName "node-memory-allocatable" |}
+      FROM {| generationQueryViewName "node-memory-allocatable-raw" |}
       GROUP BY resource_id
     )
     SELECT lineItem_resourceId as resource_id,

--- a/charts/reporting-operator/templates/custom-resources/report-queries/pod-cpu-aws.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/pod-cpu-aws.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   reportQueries:
   - "pod-cpu-request-raw"
-  - "node-cpu-allocatable"
+  - "node-cpu-allocatable-raw"
   dynamicReportQueries:
   - "aws-ec2-billing-data"
   view:
@@ -53,7 +53,7 @@ spec:
       SELECT min("timestamp") as node_allocatable_data_start,
         max("timestamp") as node_allocatable_data_end,
         sum(node_allocatable_cpu_core_seconds) as node_allocatable_cpu_core_seconds
-      FROM {| generationQueryViewName "node-cpu-allocatable" |}
+      FROM {| generationQueryViewName "node-cpu-allocatable-raw" |}
         WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
         AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
@@ -100,7 +100,7 @@ metadata:
 spec:
   reportQueries:
   - "pod-cpu-usage-raw"
-  - "node-cpu-allocatable"
+  - "node-cpu-allocatable-raw"
   dynamicReportQueries:
   - "aws-ec2-billing-data"
   view:
@@ -143,7 +143,7 @@ spec:
       SELECT min("timestamp") as node_allocatable_data_start,
         max("timestamp") as node_allocatable_data_end,
         sum(node_allocatable_cpu_core_seconds) as node_allocatable_cpu_core_seconds
-      FROM {| generationQueryViewName "node-cpu-allocatable" |}
+      FROM {| generationQueryViewName "node-cpu-allocatable-raw" |}
         WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
         AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'

--- a/charts/reporting-operator/templates/custom-resources/report-queries/pod-memory-aws.yaml
+++ b/charts/reporting-operator/templates/custom-resources/report-queries/pod-memory-aws.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   reportQueries:
   - "pod-memory-request-raw"
-  - "node-memory-allocatable"
+  - "node-memory-allocatable-raw"
   dynamicReportQueries:
   - "aws-ec2-billing-data"
   view:
@@ -53,7 +53,7 @@ spec:
       SELECT min("timestamp") as node_allocatable_data_start,
         max("timestamp") as node_allocatable_data_end,
         sum(node_allocatable_memory_byte_seconds) as node_allocatable_memory_byte_seconds
-      FROM {| generationQueryViewName "node-memory-allocatable" |}
+      FROM {| generationQueryViewName "node-memory-allocatable-raw" |}
         WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
         AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
@@ -101,7 +101,7 @@ metadata:
 spec:
   reportQueries:
   - "pod-memory-usage-raw"
-  - "node-memory-allocatable"
+  - "node-memory-allocatable-raw"
   dynamicReportQueries:
   - "aws-ec2-billing-data"
   view:
@@ -144,7 +144,7 @@ spec:
       SELECT min("timestamp") as node_allocatable_data_start,
         max("timestamp") as node_allocatable_data_end,
         sum(node_allocatable_memory_byte_seconds) as node_allocatable_memory_byte_seconds
-      FROM {| generationQueryViewName "node-memory-allocatable" |}
+      FROM {| generationQueryViewName "node-memory-allocatable-raw" |}
         WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
         AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'

--- a/pkg/operator/aws_usage_hive.go
+++ b/pkg/operator/aws_usage_hive.go
@@ -51,5 +51,5 @@ func (op *Reporting) createAWSUsageTable(logger logrus.FieldLogger, dataSource *
 		SerdeRowProperties: reportingutil.AWSUsageHiveSerdeProps,
 		External:           true,
 	}
-	return op.createTableWith(logger, dataSource, cbTypes.SchemeGroupVersion.WithKind("ReportDataSource"), params, properties)
+	return op.createTableAndCR(logger, dataSource, cbTypes.SchemeGroupVersion.WithKind("ReportDataSource"), params, properties)
 }


### PR DESCRIPTION
AWS Billing tables are external so we don't want to modify the location
by appending the table's name to the location.

The queries were broken when I previously made the node-cpu/memory-allocatable-raw
queries, which were intended to be the re-usable views, and all queries except the AWS ones
got updated to use the -raw one, so this fixes that as well.