### PR TITLE
cmd,pkg: Support disabling write-health-check

### DIFF
--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -75,6 +75,7 @@ func init() {
 	startCmd.Flags().BoolVar(&cfg.LogDMLQueries, "log-dml-queries", false, "logDMLQueries controls if we log data manipulation queries made via Presto (SELECT, INSERT, etc)")
 	startCmd.Flags().BoolVar(&cfg.LogDDLQueries, "log-ddl-queries", false, "logDDLQueries controls if we log data definition language queries made via Hive (CREATE TABLE, DROP TABLE, etc)")
 	startCmd.Flags().BoolVar(&cfg.EnableFinalizers, "enable-finalizers", false, "If enabled, then finalizers will be set on some resources to ensure the reporting-operator is able to perform cleanup before the resource is deleted from the API")
+	startCmd.Flags().BoolVar(&cfg.DisableWriteHealthCheck, "disable-write-health-check", false, "if true, the reporting-operator will not attempt to write to presto as a health check")
 
 	startCmd.Flags().DurationVar(&cfg.PrometheusQueryConfig.QueryInterval.Duration, "promsum-interval", operator.DefaultPrometheusQueryInterval, "controls how often the operator polls Prometheus for metrics")
 	startCmd.Flags().DurationVar(&cfg.PrometheusQueryConfig.StepSize.Duration, "promsum-step-size", operator.DefaultPrometheusQueryStepSize, "the query step size for Promethus query. This controls resolution of results")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -88,10 +88,11 @@ type Config struct {
 	Namespace  string
 	Kubeconfig string
 
-	HiveHost         string
-	PrestoHost       string
-	DisablePromsum   bool
-	EnableFinalizers bool
+	HiveHost                string
+	PrestoHost              string
+	DisablePromsum          bool
+	DisableWriteHealthCheck bool
+	EnableFinalizers        bool
 
 	PrestoMaxQueryLength int
 
@@ -423,8 +424,15 @@ func (op *Reporting) Run(stopCh <-chan struct{}) error {
 	}
 
 	prestoHealthChecker := reporting.NewPrestoHealthChecker(op.logger, prestoQueryer, hiveTableManager, newTableProperties)
-	op.testWriteToPrestoFunc = func() bool {
-		return prestoHealthChecker.TestWriteToPrestoSingleFlight()
+	if op.cfg.DisableWriteHealthCheck {
+		op.testWriteToPrestoFunc = func() bool {
+			op.logger.Debugf("configured to skip checking ability to write to presto")
+			return true
+		}
+	} else {
+		op.testWriteToPrestoFunc = func() bool {
+			return prestoHealthChecker.TestWriteToPrestoSingleFlight()
+		}
 	}
 	op.testReadFromPrestoFunc = func() bool {
 		return prestoHealthChecker.TestReadFromPrestoSingleFlight()
@@ -459,18 +467,22 @@ func (op *Reporting) Run(stopCh <-chan struct{}) error {
 		srvErrChan <- fmt.Errorf("HTTP API server error: %v", srvErr)
 	}()
 
-	// Poll until we can write to presto
-	op.logger.Info("testing ability to write to Presto")
-	err = wait.PollUntil(time.Second*5, func() (bool, error) {
-		if op.testWriteToPrestoFunc() {
-			return true, nil
+	if op.cfg.DisableWriteHealthCheck {
+		op.logger.Info("configured to skip checking ability to write to presto")
+	} else {
+		// Poll until we can write to presto
+		op.logger.Info("testing ability to write to Presto")
+		err = wait.PollUntil(time.Second*5, func() (bool, error) {
+			if op.testWriteToPrestoFunc() {
+				return true, nil
+			}
+			return false, nil
+		}, stopCh)
+		if err != nil {
+			return err
 		}
-		return false, nil
-	}, stopCh)
-	if err != nil {
-		return err
+		op.logger.Info("writes to Presto are succeeding")
 	}
-	op.logger.Info("writes to Presto are succeeding")
 
 	op.logger.Info("basic initialization completed")
 	op.setInitialized()


### PR DESCRIPTION
Useful for testing reporting-operator locally without a storage location
created. I am using this for testing another install of reporting-operator
which likely will not use HDFS by default and may need a different
default storage location.