### PR TITLE
Support setting tolerations and affinity for all pods

### DIFF
--- a/charts/hdfs/templates/datanode-statefulset.yaml
+++ b/charts/hdfs/templates/datanode-statefulset.yaml
@@ -71,6 +71,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.spec.datanode.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.spec.datanode.tolerations }}
+      tolerations:
+{{ toYaml .Values.spec.datanode.tolerations | indent 8 }}
+{{- end }}
       initContainers:
       # wait-for-namenode exists because for some reason the datanode is unable
       # to connect to the namenode if it starts before the namenode's DNS name

--- a/charts/hdfs/templates/namenode-statefulset.yaml
+++ b/charts/hdfs/templates/namenode-statefulset.yaml
@@ -89,6 +89,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.spec.namenode.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.spec.namenode.tolerations }}
+      tolerations:
+{{ toYaml .Values.spec.namenode.tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: hdfs-namenode
         image: "{{ .Values.spec.image.repository }}:{{ .Values.spec.image.tag }}"

--- a/charts/hdfs/values.yaml
+++ b/charts/hdfs/values.yaml
@@ -28,6 +28,7 @@ spec:
 
 
     nodeSelector: {}
+    tolerations: {}
 
     affinity:
       podAntiAffinity:
@@ -61,6 +62,7 @@ spec:
         cpu: "250m"
 
     nodeSelector: {}
+    tolerations: {}
 
     affinity:
       podAntiAffinity:

--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -41,6 +41,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.spec.hive.metastore.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.spec.hive.metastore.tolerations }}
+      tolerations:
+{{ toYaml .Values.spec.hive.metastore.tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: metastore
         command: ["/hive-scripts/entrypoint.sh"]

--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -45,6 +45,10 @@ spec:
       tolerations:
 {{ toYaml .Values.spec.hive.metastore.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.spec.hive.metastore.affinity }}
+      affinity:
+{{ toYaml .Values.spec.hive.metastore.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: metastore
         command: ["/hive-scripts/entrypoint.sh"]

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -41,6 +41,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.spec.hive.server.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.spec.hive.server.tolerations }}
+      tolerations:
+{{ toYaml .Values.spec.hive.server.tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: hiveserver2
         command: ["/hive-scripts/entrypoint.sh"]

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -45,6 +45,10 @@ spec:
       tolerations:
 {{ toYaml .Values.spec.hive.server.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.spec.hive.server.affinity }}
+      affinity:
+{{ toYaml .Values.spec.hive.server.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: hiveserver2
         command: ["/hive-scripts/entrypoint.sh"]

--- a/charts/presto/templates/presto-coordinator-deployment.yaml
+++ b/charts/presto/templates/presto-coordinator-deployment.yaml
@@ -45,6 +45,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.spec.presto.coordinator.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.spec.presto.coordinator.tolerations }}
+      tolerations:
+{{ toYaml .Values.spec.presto.coordinator.tolerations | indent 8 }}
+{{- end }}
       initContainers:
       - name: copy-presto-config
         image: "{{ .Values.spec.presto.image.repository }}:{{ .Values.spec.presto.image.tag }}"

--- a/charts/presto/templates/presto-worker-deployment.yaml
+++ b/charts/presto/templates/presto-worker-deployment.yaml
@@ -45,6 +45,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.spec.presto.worker.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.spec.presto.worker.tolerations }}
+      tolerations:
+{{ toYaml .Values.spec.presto.worker.tolerations | indent 8 }}
+{{- end }}
       initContainers:
       - name: copy-presto-config
         image: "{{ .Values.spec.presto.image.repository }}:{{ .Values.spec.presto.image.tag }}"

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -142,6 +142,7 @@ spec:
 
       nodeSelector: {}
       tolerations: {}
+      affinity: {}
 
     server:
       config:
@@ -156,6 +157,7 @@ spec:
 
       nodeSelector: {}
       tolerations: {}
+      affinity: {}
 
     labels: {}
     annotations: {}

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -41,6 +41,7 @@ spec:
           cpu: "2"
 
       nodeSelector: {}
+      tolerations: {}
 
       affinity:
         podAntiAffinity:
@@ -79,6 +80,7 @@ spec:
           cpu: "2"
 
       nodeSelector: {}
+      tolerations: {}
 
       affinity:
         podAntiAffinity:
@@ -139,6 +141,7 @@ spec:
         size: "5Gi"
 
       nodeSelector: {}
+      tolerations: {}
 
     server:
       config:
@@ -152,6 +155,7 @@ spec:
           cpu: "100m"
 
       nodeSelector: {}
+      tolerations: {}
 
     labels: {}
     annotations: {}

--- a/charts/reporting-operator/templates/reporting-operator-deployment.yaml
+++ b/charts/reporting-operator/templates/reporting-operator-deployment.yaml
@@ -48,6 +48,10 @@ spec:
       tolerations:
 {{ toYaml .Values.spec.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.spec.affinity }}
+      affinity:
+{{ toYaml .Values.spec.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: reporting-operator
         image: "{{ .Values.spec.image.repository }}:{{ .Values.spec.image.tag }}"

--- a/charts/reporting-operator/templates/reporting-operator-deployment.yaml
+++ b/charts/reporting-operator/templates/reporting-operator-deployment.yaml
@@ -44,6 +44,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.spec.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.spec.tolerations }}
+      tolerations:
+{{ toYaml .Values.spec.tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: reporting-operator
         image: "{{ .Values.spec.image.repository }}:{{ .Values.spec.image.tag }}"

--- a/charts/reporting-operator/values.yaml
+++ b/charts/reporting-operator/values.yaml
@@ -146,6 +146,7 @@ spec:
   annotations: {}
   nodeSelector: {}
   tolerations: {}
+  affinity: {}
 
   service:
     annotations: {}

--- a/charts/reporting-operator/values.yaml
+++ b/charts/reporting-operator/values.yaml
@@ -145,6 +145,7 @@ spec:
   labels: {}
   annotations: {}
   nodeSelector: {}
+  tolerations: {}
 
   service:
     annotations: {}


### PR DESCRIPTION
Some pods supported setting affinity (hdfs, and presto) but others didn't, and
nothing supports tolerations yet which is necessary to run on dedicated pools
of nodes. Affinity is useful for improving reliability when nodes fail by
ensuring pods run on different nodes or across AZs.