### PR TITLE
charts/presto: Configure hive server and metastore readiness/liveness probes

### DIFF
--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -59,6 +59,14 @@ spec:
         - name: meta
           containerPort: 9083
           protocol: TCP
+{{- if .Values.spec.hive.metastore.readinessProbe }}
+        readinessProbe:
+{{ toYaml .Values.spec.hive.metastore.readinessProbe | indent 10 }}
+{{- end }}
+{{- if .Values.spec.hive.metastore.livenessProbe }}
+        livenessProbe:
+{{ toYaml .Values.spec.hive.metastore.livenessProbe | indent 10 }}
+{{- end }}
         env:
         - name: HIVE_LOGLEVEL
           value: {{ upper .Values.spec.hive.metastore.config.logLevel | quote}}

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -62,6 +62,14 @@ spec:
         - name: ui
           containerPort: 10002
           protocol: TCP
+{{- if .Values.spec.hive.server.readinessProbe }}
+        readinessProbe:
+{{ toYaml .Values.spec.hive.server.readinessProbe | indent 10 }}
+{{- end }}
+{{- if .Values.spec.hive.server.livenessProbe }}
+        livenessProbe:
+{{ toYaml .Values.spec.hive.server.livenessProbe | indent 10 }}
+{{- end }}
         terminationMessagePath: /dev/termination-log
         env:
         - name: HIVE_LOGLEVEL

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -142,6 +142,25 @@ spec:
         class: null
         size: "5Gi"
 
+      readinessProbe:
+       initialDelaySeconds: 60
+       timeoutSeconds: 15
+       periodSeconds: 20
+       successThreshold: 1
+       failureThreshold: 3
+       tcpSocket:
+         port: 9083
+      livenessProbe:
+       initialDelaySeconds: 90
+       timeoutSeconds: 15
+       periodSeconds: 30
+       successThreshold: 1
+       failureThreshold: 3
+       tcpSocket:
+         port: 9083
+
+      livenessProbe: {}
+
       nodeSelector: {}
       tolerations: []
       affinity: {}
@@ -156,6 +175,23 @@ spec:
         limits:
           memory: "500Mi"
           cpu: "100m"
+
+      readinessProbe:
+       initialDelaySeconds: 60
+       timeoutSeconds: 15
+       periodSeconds: 20
+       successThreshold: 1
+       failureThreshold: 3
+       tcpSocket:
+         port: 10000
+      livenessProbe:
+       initialDelaySeconds: 90
+       timeoutSeconds: 15
+       periodSeconds: 30
+       successThreshold: 1
+       failureThreshold: 3
+       tcpSocket:
+         port: 10000
 
       nodeSelector: {}
       tolerations: []


### PR DESCRIPTION
This should at least cause the pods to restart if they get to a point where we're unable to talk to the thrift RPC port. Overall it's still a very simple liveness and readiness check that we should look to improve, but I believe something here is better than nothing.