### PR TITLE
Makefile: Try to compile e2e/integration tests in test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,8 @@ vendor: Gopkg.toml
 
 test:
 	go test -coverprofile=$(COVERAGE_OUTFILE) ./pkg/...
+	go test -c -o bin/e2e-tests ./test/e2e
+	go test -c -o bin/integration-tests ./test/integration
 
 test-docker:
 	docker run -i $(METERING_E2E_IMAGE):$(IMAGE_TAG) bash -c 'make test'


### PR DESCRIPTION
Fail early if e2e/integration can't be compiled after running unit tests.