### PR TITLE
Improve authorization support

### DIFF
--- a/Documentation/configuring-reporting-operator.md
+++ b/Documentation/configuring-reporting-operator.md
@@ -41,9 +41,9 @@ Additionally, on Openshift:
 - We deploy the [Openshift OAuth proxy][oauth-proxy] as a side-car container for reporting-operator, which protects the reporting API with authentication
 
 There are a few ways to do authentication, you can use service account tokens for authentication, and/or you can also use a static username/password via an httpasswd file.
-
+See the [openshift authentication](#openshift-authentication) section below for details on how authentication and authorization works.
 See the [expose-route.yaml][expose-route-config] configuration for an example of setting enabling an Openshift route and configuring authentication with both options enabled.
-See the [openshift authentication][#openshift-authentication] section below for details on how authentication is done.
+
 Make sure you modify the `reporting-operator.spec.authProxy.httpasswdData` and `reporting-operator.spec.authProxy.cookieSeed` values.
 
 Once installed with the customized configuration to enable the route, you should query in your namespace to check for the route:
@@ -70,26 +70,6 @@ And to authenticate using a username and password, use basic authentication:
 ```
 curl -u testuser:password123 -k "https://metering-openshift-metering.apps.example.com/api/v1/reports/get?name=cluster-memory-capacity-hourly&format=tab"
 ```
-
-#### Openshift Authentication
-
-When the following options are set to true, it enables authenticating using a bearer token from a serviceAccount or for your user when querying the reporting rest API:
-
-- `reporting-operator.spec.authProxy.subjectAccessReviewEnabled`
-- `reporting-operator.spec.authProxy.delegateURLsEnabled`
-
-When authentication is enabled, the Bearer token used to query the reporting API of the user or serviceAccount must be granted access using one of the following roles:
-
-- `report-exporter`
-- `reporting-admin`
-- `reporting-viewer`
-- `metering-admin`
-- `metering-viewer`
-
-Alternatively, you may use any role which has rules granting `get` permissions to `reports/export`, meaning, `get` access to the `export` _sub-resource_ of the `Report` resources in the namespace of the `reporting-operator`, eg: `admin` and `cluster-admin`.
-
-By default, the `reporting-operator` and `metering-operator` serviceAccounts both have these permissions, and their tokens may be used for authentication.
-In this document, most examples will prefer this method.
 
 ### Load Balancer/Node Port services
 
@@ -129,6 +109,44 @@ In this example the externalIP of the LoadBalancer is `35.227.172.86` and the po
 curl "http://35.227.172.86:8080/api/v1/reports/get?name=cluster-memory-capacity-hourly&format=tab"
 ```
 
+### Openshift Authentication
+
+Authentication can be enabled by setting the options below to true.
+Enabling authentication configures the reporting-operator pod to run the Openshift auth-proxy as a sidecar container in the pod.
+This adjusts the ports so that the reporting-operator API isn't exposed directly, but instead is proxied to via the auth-proxy sidecar container.
+
+- `reporting-operator.spec.authProxy.enabled`
+- `reporting-operator.spec.authProxy.cookieSeed`
+
+#### Token Authentication
+
+When the following options are set to true, authentication using a bearer token is enabled for the reporting rest API.
+Bearer tokens may come from serviceAccounts or users.
+
+- `reporting-operator.spec.authProxy.subjectAccessReviewEnabled`
+- `reporting-operator.spec.authProxy.delegateURLsEnabled`
+
+When authentication is enabled, the Bearer token used to query the reporting API of the user or serviceAccount must be granted access using one of the following roles:
+
+- `report-exporter`
+- `reporting-admin`
+- `reporting-viewer`
+- `metering-admin`
+- `metering-viewer`
+
+Alternatively, you may use any role which has rules granting `get` permissions to `reports/export`.
+Meaning: `get` access to the `export` _sub-resource_ of the `Report` resources in the namespace of the `reporting-operator`.
+For example: `admin` and `cluster-admin`.
+
+By default, the `reporting-operator` and `metering-operator` serviceAccounts both have these permissions, and their tokens may be used for authentication.
+In this document, most examples will prefer this method.
+
+#### Basic Authentication (username/password)
+
+If `reporting-operator.spec.authProxy.htpasswdData` is non-empty, it's contents must be that of an [htpasswd file](https://httpd.apache.org/docs/2.4/programs/htpasswd.html).
+When set, you can use [HTTP basic authentication][basic-auth-rfc] to provide your username and password that has a corresponding entry in the `htpasswdData` contents.
+
+
 [route]: https://docs.openshift.com/container-platform/3.11/dev_guide/routes.html
 [kube-svc]: https://kubernetes.io/docs/concepts/services-networking/service/
 [load-balancer-svc]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
@@ -136,3 +154,4 @@ curl "http://35.227.172.86:8080/api/v1/reports/get?name=cluster-memory-capacity-
 [service-certs]: https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets
 [oauth-proxy]: https://github.com/openshift/oauth-proxy
 [expose-route-config]: ../manifests/metering-config/expose-route.yaml
+[basic-auth-rfc]: https://tools.ietf.org/html/rfc7617

--- a/Documentation/configuring-reporting-operator.md
+++ b/Documentation/configuring-reporting-operator.md
@@ -120,7 +120,7 @@ This adjusts the ports so that the reporting-operator API isn't exposed directly
 
 #### Token Authentication
 
-When the following options are set to true, authentication using a bearer token is enabled for the reporting rest API.
+When the following options are set to true, authentication using a bearer token is enabled for the reporting REST API.
 Bearer tokens may come from serviceAccounts or users.
 
 - `reporting-operator.spec.authProxy.subjectAccessReviewEnabled`
@@ -134,6 +134,9 @@ When authentication is enabled, the Bearer token used to query the reporting API
 - `metering-admin`
 - `metering-viewer`
 
+The metering-operator is capable of creating RoleBindings for you, granting these permissions by specifying a list of subjects in the Metering `spec.permissions` section.
+For an example see the [advanced-auth.yaml][advanced-auth-config] example configuration.
+
 Alternatively, you may use any role which has rules granting `get` permissions to `reports/export`.
 Meaning: `get` access to the `export` _sub-resource_ of the `Report` resources in the namespace of the `reporting-operator`.
 For example: `admin` and `cluster-admin`.
@@ -146,7 +149,6 @@ In this document, most examples will prefer this method.
 If `reporting-operator.spec.authProxy.htpasswdData` is non-empty, it's contents must be that of an [htpasswd file](https://httpd.apache.org/docs/2.4/programs/htpasswd.html).
 When set, you can use [HTTP basic authentication][basic-auth-rfc] to provide your username and password that has a corresponding entry in the `htpasswdData` contents.
 
-
 [route]: https://docs.openshift.com/container-platform/3.11/dev_guide/routes.html
 [kube-svc]: https://kubernetes.io/docs/concepts/services-networking/service/
 [load-balancer-svc]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
@@ -155,3 +157,4 @@ When set, you can use [HTTP basic authentication][basic-auth-rfc] to provide you
 [oauth-proxy]: https://github.com/openshift/oauth-proxy
 [expose-route-config]: ../manifests/metering-config/expose-route.yaml
 [basic-auth-rfc]: https://tools.ietf.org/html/rfc7617
+[advanced-auth-config]: ../manifests/metering-config/advanced-auth.yaml

--- a/Documentation/configuring-reporting-operator.md
+++ b/Documentation/configuring-reporting-operator.md
@@ -43,6 +43,7 @@ Additionally, on Openshift:
 There are a few ways to do authentication, you can use service account tokens for authentication, and/or you can also use a static username/password via an httpasswd file.
 
 See the [expose-route.yaml][expose-route-config] configuration for an example of setting enabling an Openshift route and configuring authentication with both options enabled.
+See the [openshift authentication][#openshift-authentication] section below for details on how authentication is done.
 Make sure you modify the `reporting-operator.spec.authProxy.httpasswdData` and `reporting-operator.spec.authProxy.cookieSeed` values.
 
 Once installed with the customized configuration to enable the route, you should query in your namespace to check for the route:
@@ -69,6 +70,26 @@ And to authenticate using a username and password, use basic authentication:
 ```
 curl -u testuser:password123 -k "https://metering-openshift-metering.apps.example.com/api/v1/reports/get?name=cluster-memory-capacity-hourly&format=tab"
 ```
+
+#### Openshift Authentication
+
+When the following options are set to true, it enables authenticating using a bearer token from a serviceAccount or for your user when querying the reporting rest API:
+
+- `reporting-operator.spec.authProxy.subjectAccessReviewEnabled`
+- `reporting-operator.spec.authProxy.delegateURLsEnabled`
+
+When authentication is enabled, the Bearer token used to query the reporting API of the user or serviceAccount must be granted access using one of the following roles:
+
+- `report-exporter`
+- `reporting-admin`
+- `reporting-viewer`
+- `metering-admin`
+- `metering-viewer`
+
+Alternatively, you may use any role which has rules granting `get` permissions to `reports/export`, meaning, `get` access to the `export` _sub-resource_ of the `Report` resources in the namespace of the `reporting-operator`, eg: `admin` and `cluster-admin`.
+
+By default, the `reporting-operator` and `metering-operator` serviceAccounts both have these permissions, and their tokens may be used for authentication.
+In this document, most examples will prefer this method.
 
 ### Load Balancer/Node Port services
 

--- a/charts/openshift-metering/templates/rolebindings.yaml
+++ b/charts/openshift-metering/templates/rolebindings.yaml
@@ -91,3 +91,27 @@ subjects:
   apiGroup: "{{ .apiGroup }}"
 {{- end }}
 {{- end }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: report-exporters
+{{- block "extraMetadata" . }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: report-exporter
+subjects:
+{{- range .Values.permissions.reportExporters }}
+- kind: "{{ .kind }}"
+  name: "{{ .name }}"
+{{- if .namespace }}
+  namespace: "{{ .namespace }}"
+{{- end }}
+{{- if .apiGroup }}
+  apiGroup: "{{ .apiGroup }}"
+{{- end }}
+{{- end }}

--- a/charts/openshift-metering/templates/rolebindings.yaml
+++ b/charts/openshift-metering/templates/rolebindings.yaml
@@ -1,0 +1,93 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metering-admins
+{{- block "extraMetadata" . }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metering-admin
+subjects:
+{{- range .Values.permissions.meteringAdmins }}
+- kind: "{{ .kind }}"
+  name: "{{ .name }}"
+{{- if .namespace }}
+  namespace: "{{ .namespace }}"
+{{- end }}
+{{- if .apiGroup }}
+  apiGroup: "{{ .apiGroup }}"
+{{- end }}
+{{- end }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metering-viewers
+{{- block "extraMetadata" . }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metering-viewer
+subjects:
+{{- range .Values.permissions.meteringViewers }}
+- kind: "{{ .kind }}"
+  name: "{{ .name }}"
+{{- if .namespace }}
+  namespace: "{{ .namespace }}"
+{{- end }}
+{{- if .apiGroup }}
+  apiGroup: "{{ .apiGroup }}"
+{{- end }}
+{{- end }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: reporting-admins
+{{- block "extraMetadata" . }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: reporting-admin
+subjects:
+{{- range .Values.permissions.reportingAdmins }}
+- kind: "{{ .kind }}"
+  name: "{{ .name }}"
+{{- if .namespace }}
+  namespace: "{{ .namespace }}"
+{{- end }}
+{{- if .apiGroup }}
+  apiGroup: "{{ .apiGroup }}"
+{{- end }}
+{{- end }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: reporting-viewers
+{{- block "extraMetadata" . }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: reporting-viewer
+subjects:
+{{- range .Values.permissions.reportingViewers }}
+- kind: "{{ .kind }}"
+  name: "{{ .name }}"
+{{- if .namespace }}
+  namespace: "{{ .namespace }}"
+{{- end }}
+{{- if .apiGroup }}
+  apiGroup: "{{ .apiGroup }}"
+{{- end }}
+{{- end }}

--- a/charts/openshift-metering/templates/roles.yaml
+++ b/charts/openshift-metering/templates/roles.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: metering-admin
+{{- block "extraMetadata" . }}
+{{- end }}
+rules:
+- apiGroups: ["metering.openshift.io"]
+  resources: ["*"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: metering-viewer
+{{- block "extraMetadata" . }}
+{{- end }}
+rules:
+- apiGroups: ["metering.openshift.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: reporting-admin
+{{- block "extraMetadata" . }}
+{{- end }}
+rules:
+- apiGroups: ["metering.openshift.io"]
+  resources:
+  - reports
+  - reportgenerationqueries
+  - reportdatasources
+  - reportprometheusqueries
+  - prestotables
+  - storagelocations
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: reporting-viewer
+{{- block "extraMetadata" . }}
+{{- end }}
+rules:
+- apiGroups: ["metering.openshift.io"]
+  resources:
+  - reports
+  - reportgenerationqueries
+  - reportdatasources
+  - reportprometheusqueries
+  - prestotables
+  - storagelocations
+  verbs: ["get", "list", "watch"]
+

--- a/charts/openshift-metering/templates/roles.yaml
+++ b/charts/openshift-metering/templates/roles.yaml
@@ -34,6 +34,7 @@ rules:
 - apiGroups: ["metering.openshift.io"]
   resources:
   - reports
+  - reports/export
   - reportgenerationqueries
   - reportdatasources
   - reportprometheusqueries
@@ -53,6 +54,7 @@ rules:
 - apiGroups: ["metering.openshift.io"]
   resources:
   - reports
+  - reports/export
   - reportgenerationqueries
   - reportdatasources
   - reportprometheusqueries
@@ -60,3 +62,16 @@ rules:
   - storagelocations
   verbs: ["get", "list", "watch"]
 
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: report-exporter
+{{- block "extraMetadata" . }}
+{{- end }}
+rules:
+- apiGroups: ["metering.openshift.io"]
+  resources:
+  - reports/export
+  verbs: ["get"]

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -10,6 +10,12 @@ defaultStorage:
     tableProperties:
       location: "hdfs://hdfs-namenode-proxy:9820/operator_metering/storage/"
 
+permissions:
+  meteringViewers: []
+  meteringAdmins: []
+  reportingAdmins: []
+  reportingViewers: []
+
 openshift-reporting:
   enabled: true
 

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -15,6 +15,7 @@ permissions:
   meteringAdmins: []
   reportingAdmins: []
   reportingViewers: []
+  reportExporters: []
 
 openshift-reporting:
   enabled: true

--- a/charts/reporting-operator/templates/reporting-operator-deployment.yaml
+++ b/charts/reporting-operator/templates/reporting-operator-deployment.yaml
@@ -212,6 +212,11 @@ spec:
       - name: reporting-operator-auth-proxy
         image: "{{ .Values.spec.authProxy.image.repository }}:{{ .Values.spec.authProxy.image.tag }}"
         imagePullPolicy: {{ .Values.spec.authProxy.image.pullPolicy }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         args:
         - -provider=openshift
         - -https-address=:8081
@@ -232,10 +237,10 @@ spec:
         - -email-domain=*
 {{- end }}
 {{- if .Values.spec.authProxy.subjectAccessReviewEnabled }}
-        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - '-openshift-sar={{- .Values.spec.authProxy.subjectAccessReviewPolicy | trim -}}'
 {{- end }}
 {{- if .Values.spec.authProxy.delegateURLsEnabled }}
-        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+        - '-openshift-delegate-urls={{- .Values.spec.authProxy.delegateURLsPolicy | trim -}}'
 {{- end }}
         ports:
         - name: auth-proxy

--- a/charts/reporting-operator/values.yaml
+++ b/charts/reporting-operator/values.yaml
@@ -114,9 +114,14 @@ spec:
     cookieSeed: ""
 
     createAuthProxyClusterRole: false
+
+    subjectAccessReviewPolicy: |-
+      {"group": "metering.openshift.io", "resource": "reports", "namespace": "$(NAMESPACE)", "subresource": "export", "verb": "get"}
+    delegateURLsPolicy: |-
+      {"/": {"group": "metering.openshift.io", "resource": "reports", "namespace": "$(NAMESPACE)", "subresource": "export", "verb": "get"}}
+
     subjectAccessReviewEnabled: false
     delegateURLsEnabled: false
-
     authenticatedEmailsSecretName: reporting-operator-auth-proxy-authenticated-emails
     authenticatedEmailsEnabled: false
     createAuthenticatedEmailsSecret: true

--- a/manifests/metering-config/advanced-auth.yaml
+++ b/manifests/metering-config/advanced-auth.yaml
@@ -1,0 +1,57 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: Metering
+metadata:
+  name: "operator-metering"
+spec:
+  permissions:
+    # anyone in the "metering-admins" group can create, update, delete, etc any
+    # metering.openshift.io resources in the namespace.
+    # This also grants permissions to get query report results from the reporting REST API.
+    meteringAdmins:
+    - kind: Group
+      name: metering-admins
+    # Same as above except read only access and for the metering-viewers group.
+    meteringViewers:
+    - kind: Group
+      name: metering-viewers
+    # the default serviceaccount in the namespace "my-custom-ns" can:
+    # create, update, delete, etc reports.
+    # This also gives permissions query the results from the reporting REST API.
+    reportingAdmins:
+    - kind: ServiceAccount
+      name: default
+      namespace: my-custom-ns
+    # anyone in the group reporting-readers can get, list, watch reports, and
+    # query report results from the reporting REST API.
+    reportingViewers:
+    - kind: Group
+      name: reporting-readers
+    # anyone in the group cluster-admins can query report results
+    # from the reporting REST API. So can the user bob-from-accounting.
+    reportExporters:
+    - kind: Group
+      name: cluster-admins
+    - kind: User
+      name: bob-from-accounting
+
+  reporting-operator:
+    spec:
+      route:
+        enabled: true
+
+      authProxy:
+        enabled: true
+        # cookieSeed is used to protect the cookie created if accessing the API
+        # via your browser.
+        #
+        # generate a 32 character random string using a command of your choice,
+        # for example: `openssl rand -base64 32 | head -c32; echo`
+        # cookieSeed: "RCFE+QpwGWL2bupP+wv4EIOnYlbaRmto"
+        #
+        # change REPLACEME to the output of your command
+        cookieSeed: "REPLACEME"
+
+        # Enables authenticating using a bearer token from a serviceAccount or
+        # for your user.
+        subjectAccessReviewEnabled: true
+        delegateURLsEnabled: true

--- a/manifests/metering-config/expose-route.yaml
+++ b/manifests/metering-config/expose-route.yaml
@@ -14,7 +14,7 @@ spec:
         # htpasswdData can contain htpasswd file contents for allowing auth
         # using a static list of usernames and their password hashes.
         #
-        # username is 'testuser' password is 'testpassword123'
+        # username is 'testuser' password is 'password123'
         # generated htpasswdData using: `htpasswd -nb -s testuser password123`
         # htpasswdData: |
         #   testuser:{SHA}y/2sYAj5yrQIN4TL0YdPdmGNKpc=
@@ -33,6 +33,10 @@ spec:
         # change REPLACEME to the output of your command
         cookieSeed: "REPLACEME"
 
-        # enables authenticating using a serviceAccount token
+        # Enables authenticating using a bearer token from a serviceAccount or user.
+        # It must have have one of the following roles:
+        # "report-exporter", "reporting-admin" or "reporting-viewer"
+        # or it must have permissions granting "GET reports/export":
+        # the export subresource of "reports".
         subjectAccessReviewEnabled: true
         delegateURLsEnabled: true


### PR DESCRIPTION
- Adds support for creating rolebindings granting access to various metering resources via roles.
- Changes permissions required to query reporting API with authentication enabled from GET namespaces to GET reports/export sub-resource.
- Adds support for granting permission to reporting API by creating a rolebinding which grants the reports/export GET permission.