### PR TITLE
charts/presto: Set imagePullSecrets for hive statefulsets

### DIFF
--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -111,6 +111,10 @@ spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: {{ .Values.spec.hive.terminationGracePeriodSeconds }}
       serviceAccount: hive
+{{- if .Values.spec.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.spec.imagePullSecrets | indent 8 }}
+{{- end }}
       volumes:
       - name: hive-config
         configMap:

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -115,6 +115,10 @@ spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: {{ .Values.spec.hive.terminationGracePeriodSeconds }}
       serviceAccount: hive
+{{- if .Values.spec.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.spec.imagePullSecrets | indent 8 }}
+{{- end }}
       volumes:
       - name: hive-config
         configMap:


### PR DESCRIPTION
To allow pulling private images for Hive such as the OCP images.