### PR TITLE
manifests,charts,hack: Move ServiceMonitors to openshift-metering chart

### DIFF
--- a/charts/openshift-metering/templates/monitoring-rbac.yaml
+++ b/charts/openshift-metering/templates/monitoring-rbac.yaml
@@ -1,13 +1,16 @@
+{{- if .Values.monitoring.enabled }}
+# Grant Prometheus permissions to discover our services, endpoints, and pods so
+# it can figure out what needs to be monitored.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-k8s
-  namespace: openshift-metering
+{{- block "extraMetadata" . }}
+{{- end }}
 rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
   - services
   - endpoints
   - pods
@@ -22,7 +25,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: openshift-metering
+{{- block "extraMetadata" . }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -30,4 +34,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
-  namespace: openshift-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
+{{- end }}

--- a/charts/openshift-metering/templates/presto-service-monitor.yaml
+++ b/charts/openshift-metering/templates/presto-service-monitor.yaml
@@ -1,12 +1,12 @@
+{{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: metering-presto
-  namespace: openshift-monitoring
-  labels:
-    k8s-app: metering-presto
+{{- block "extraMetadata" . }}
+{{- end }}
 spec:
-  jobLabel: k8s-app
+  jobLabel: app
   endpoints:
   - port: metrics
     interval: 30s
@@ -17,4 +17,5 @@ spec:
       metrics: "true"
   namespaceSelector:
     matchNames:
-    - openshift-metering
+    - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/openshift-metering/templates/reporting-operator-service-monitor.yaml
+++ b/charts/openshift-metering/templates/reporting-operator-service-monitor.yaml
@@ -1,19 +1,19 @@
+{{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: metering-reporting-operator
-  namespace: openshift-monitoring
-  labels:
-    k8s-app: metering-reporting-operator
+{{- block "extraMetadata" . }}
+{{- end }}
 spec:
-  jobLabel: k8s-app
+  jobLabel: app
   endpoints:
   - port: metrics
     scheme: "https"
     interval: 30s
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-      serverName: reporting-operator-metrics.openshift-metering.svc
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: reporting-operator-metrics.{{ .Release.Namespace }}.svc
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   selector:
     matchLabels:
@@ -21,4 +21,5 @@ spec:
       metrics: "true"
   namespaceSelector:
     matchNames:
-    - openshift-metering
+    - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -17,6 +17,10 @@ permissions:
   reportingViewers: []
   reportExporters: []
 
+monitoring:
+  enabled: true
+  namespace: openshift-monitoring
+
 openshift-reporting:
   enabled: true
 

--- a/hack/openshift-install.sh
+++ b/hack/openshift-install.sh
@@ -24,5 +24,11 @@ if [ "$METERING_INSTALL_REPORTING_OPERATOR_EXTRA_CLUSTERROLEBINDING" == "true" ]
         --dry-run -o json | kubectl replace -f -
 fi
 
+echo "Labeling namespace ${METERING_NAMESPACE} with 'openshift.io/cluster-monitoring=true'"
+kubectl label \
+    --overwrite \
+    namespace "${METERING_NAMESPACE}" \
+    "openshift.io/cluster-monitoring=true"
+
 export DEPLOY_PLATFORM=openshift
 "${ROOT_DIR}/hack/install.sh" "$@"

--- a/manifests/deploy/common-helm-operator-values.yaml
+++ b/manifests/deploy/common-helm-operator-values.yaml
@@ -28,9 +28,15 @@ serviceAccountName: metering-operator
 rbac:
   roleName: metering-operator
   rules:
+  # grant access to metering resources
   - apiGroups: ["metering.openshift.io"]
     resources: ["*"]
     verbs: ["*"]
+  # grant access to monitoring resources for optional monitoring integration
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["*"]
+    verbs: ["*"]
+  # access to most core resources that can be created by metering
   - apiGroups:
     - ""
     resources:

--- a/manifests/deploy/openshift/alm/metering.0.12.0-latest.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/alm/metering.0.12.0-latest.clusterserviceversion.yaml
@@ -38,6 +38,12 @@ spec:
             verbs:
             - '*'
           - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - '*'
+            verbs:
+            - '*'
+          - apiGroups:
             - ""
             resources:
             - pods

--- a/manifests/deploy/openshift/helm-operator/metering-operator-role.yaml
+++ b/manifests/deploy/openshift/helm-operator/metering-operator-role.yaml
@@ -10,6 +10,12 @@ rules:
     verbs:
     - '*'
   - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - '*'
+    verbs:
+    - '*'
+  - apiGroups:
     - ""
     resources:
     - pods


### PR DESCRIPTION
Take advantage of the new multi-namespace watch feature of
cluster-monitoring and prometheus-operator.

Moves the ServiceMonitors to be openshift-metering chart and sets them
to be created by default. Adds creates rbac polices that enable
Prometheus to perform it's kubernetes service discovery to discover
scrape targets.

Updates openshift install script to label namespace for scraping by Prometheus.