### PR TITLE
Bugfix: PVC Request ReportGenerationQuery Storageclass

### DIFF
--- a/charts/openshift-reporting/templates/report-queries/pod-volume-request.yaml
+++ b/charts/openshift-reporting/templates/report-queries/pod-volume-request.yaml
@@ -44,7 +44,7 @@ spec:
       labels['persistentvolumeclaim'] as persistentvolumeclaim,
       element_at(labels, 'volumename') as persistentvolume,
           labels['namespace'] as namespace,
-          labels['storageclass'] as storageclass,
+          element_at(labels, 'storageclass') as storageclass,
           amount as volume_request_storage_bytes,
           timeprecision,
           amount * timeprecision as volume_request_storage_byte_seconds,


### PR DESCRIPTION
Changed direct array reference in pvc-request ReportGenerationQuery to use element_at