### PR TITLE
charts/presto: move hive metastore timeout config into presto config

### DIFF
--- a/charts/presto/templates/_helpers.tpl
+++ b/charts/presto/templates/_helpers.tpl
@@ -7,8 +7,8 @@ hive.compression-codec=SNAPPY
 hive.hdfs.authentication.type=NONE
 hive.metastore.authentication.type=NONE
 hive.metastore.uri={{ .Values.spec.hive.config.metastoreURIs }}
-{{- if .Values.spec.hive.config.metastoreTimeout }}
-hive.metastore-timeout={{ .Values.spec.hive.config.metastoreTimeout }}
+{{- if .Values.spec.presto.config.metastoreTimeout }}
+hive.metastore-timeout={{ .Values.spec.presto.config.metastoreTimeout }}
 {{- end }}
 {{ end }}
 

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -14,6 +14,7 @@ spec:
       # maxQueryLength: 1000000
       hiveMetastoreURI: thrift://hive-metastore:9083
       nodeSchedulerIncludeCoordinator: true
+      metastoreTimeout: null
 
     coordinator:
       terminationGracePeriodSeconds: 30
@@ -115,8 +116,6 @@ spec:
       metastoreURIs: "thrift://hive-metastore:9083"
       useHdfsConfigMap: true
       hdfsConfigMapName: hdfs-config
-      # Uncomment to set a custom timeout for the metastore:
-      # metastoreTimeout: "20s"
 
     securityContext:
       runAsNonRoot: true


### PR DESCRIPTION
This only effects hive, so it should be a config value under
spec.presto.spec.presto.config instead of spec.presto.spec.hive.config