### PR TITLE
charts/presto: Support configuring hive metastore client timeout

### DIFF
--- a/charts/presto/templates/hive-configmap.yaml
+++ b/charts/presto/templates/hive-configmap.yaml
@@ -51,6 +51,12 @@ data:
         <name>hive.default.fileformat</name>
         <value>{{ .Values.spec.hive.config.defaultFileFormat }}</value>
       </property>
+{{- if .Values.spec.hive.config.metastoreClientSocketTimeout }}
+      <property>
+        <name>hive.metastore.client.socket.timeout</name>
+        <value>{{ .Values.spec.hive.config.metastoreClientSocketTimeout }}</value>
+      </property>
+{{- end }}
     </configuration>
 
 

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -116,6 +116,7 @@ spec:
       metastoreURIs: "thrift://hive-metastore:9083"
       useHdfsConfigMap: true
       hdfsConfigMapName: hdfs-config
+      metastoreClientSocketTimeout: null
 
     securityContext:
       runAsNonRoot: true


### PR DESCRIPTION
Used by hive server clients to communicate with hive metastore