### PR TITLE
charts/openshift-metering: Add config option to disable creating prometheus rbac resources

### DIFF
--- a/charts/openshift-metering/templates/monitoring-rbac.yaml
+++ b/charts/openshift-metering/templates/monitoring-rbac.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.monitoring.enabled }}
+{{- if and .Values.monitoring.enabled .Values.monitoring.createRBAC }}
 # Grant Prometheus permissions to discover our services, endpoints, and pods so
 # it can figure out what needs to be monitored.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: prometheus-k8s
+  name: metering-prometheus-k8s
 {{- block "extraMetadata" . }}
 {{- end }}
 rules:
@@ -24,13 +24,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: prometheus-k8s
+  name: metering-prometheus-k8s
 {{- block "extraMetadata" . }}
 {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: prometheus-k8s
+  name: metering-prometheus-k8s
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -20,6 +20,7 @@ permissions:
 monitoring:
   enabled: true
   namespace: openshift-monitoring
+  createRBAC: true
 
 openshift-reporting:
   enabled: true


### PR DESCRIPTION
Also renames them to have a metering-prefix to make conflicts with other
default role/rolebinding names less likely.