### PR TITLE
reporting-operator-local: allow custom prom host

### DIFF
--- a/Documentation/manual-install.md
+++ b/Documentation/manual-install.md
@@ -122,7 +122,7 @@ Next, run the install script for your platform (see above).
 After running the install script, figure out where your Prometheus pod is running.
 By default the `run-reporting-operator-local` Makefile target assumes that the pod is in the `openshift-monitoring` namespace and can be queried using the label selector `app=prometheus`.
 
-If you're Prometheus is located somewhere, else, you can override the defaults using the environment variables `METERING_PROMETHEUS_NAMESPACE` and `METERING_PROMTHEUS_LABEL_SELECTOR` to the namespace your Prometheus pod is in, and the label selector for querying Prometheus.
+If your Prometheus is located somewhere else, you can override the defaults using the environment variables `METERING_PROMETHEUS_NAMESPACE` and `METERING_PROMTHEUS_LABEL_SELECTOR` to the namespace your Prometheus pod is in, and the label selector for querying Prometheus. Alternatively, if you wish to specify your Prometheus with a host, set `METERING_PROMETHEUS_PORT_FORWARD` to false and `METERING_PROMETHEUS_HOST` to the host/port of your instance.
 
 Ex (these are the defaults):
 ```

--- a/hack/run-local-with-port-forward.sh
+++ b/hack/run-local-with-port-forward.sh
@@ -23,10 +23,15 @@ echo Starting hive port-forward
 kubectl -n "$METERING_NAMESPACE" \
     port-forward "svc/hive-server" 9992:10000 &
 
-echo Starting Prometheus port-forward
-kubectl -n "$METERING_PROMETHEUS_NAMESPACE" \
-    port-forward "svc/${METERING_PROMETHEUS_SVC}" \
-    9993:"${METERING_PROMETHEUS_SVC_PORT}" &
+if [[ -v METERING_PROMETHEUS_HOST ]]; then
+    echo Skipping Prometheus port-forward
+else
+    echo Starting Prometheus port-forward
+    : "${METERING_PROMETHEUS_HOST:=127.0.0.1:9993}"
+    kubectl -n "$METERING_PROMETHEUS_NAMESPACE" \
+        port-forward "svc/${METERING_PROMETHEUS_SVC}" \
+        9993:"${METERING_PROMETHEUS_SVC_PORT}" &
+fi
 
 sleep 6
 
@@ -44,7 +49,7 @@ set -x
     --namespace "$METERING_NAMESPACE" \
     --presto-host "127.0.0.1:9991" \
     --hive-host "127.0.0.1:9992" \
-    --prometheus-host "${METERING_PROMETHEUS_SCHEME}://127.0.0.1:9993" \
+    --prometheus-host "${METERING_PROMETHEUS_SCHEME}://${METERING_PROMETHEUS_HOST}" \
     "${ARGS[@]}" &
 
 wait

--- a/hack/run-local-with-port-forward.sh
+++ b/hack/run-local-with-port-forward.sh
@@ -10,6 +10,8 @@ source "${ROOT_DIR}/hack/common.sh"
 : "${METERING_PROMETHEUS_SVC:=prometheus-k8s}"
 : "${METERING_PROMETHEUS_SVC_PORT:=9091}"
 : "${METERING_PROMETHEUS_SCHEME:=https}"
+: "${METERING_PROMETHEUS_HOST:=127.0.0.1:9993}"
+: "${METERING_PROMETHEUS_PORT_FORWARD:=true}"
 
 set -e -o pipefail
 trap 'jobs -p | xargs kill' EXIT
@@ -23,14 +25,13 @@ echo Starting hive port-forward
 kubectl -n "$METERING_NAMESPACE" \
     port-forward "svc/hive-server" 9992:10000 &
 
-if [[ -v METERING_PROMETHEUS_HOST ]]; then
-    echo Skipping Prometheus port-forward
-else
+if [ "$METERING_PROMETHEUS_PORT_FORWARD" == "true" ]; then
     echo Starting Prometheus port-forward
-    : "${METERING_PROMETHEUS_HOST:=127.0.0.1:9993}"
     kubectl -n "$METERING_PROMETHEUS_NAMESPACE" \
         port-forward "svc/${METERING_PROMETHEUS_SVC}" \
         9993:"${METERING_PROMETHEUS_SVC_PORT}" &
+else
+    echo Skipping Prometheus port-forward
 fi
 
 sleep 6


### PR DESCRIPTION
lets you do things like connecting to the telemeter integration script's telemeter prometheus:

Run a telemeter prometheus instance (from within the openshift/telemeter repo):

```
make
./test/integration.sh http://localhost:9005
```

Create the resources:


```
apiVersion: metering.openshift.io/v1alpha1
kind: ReportPrometheusQuery
metadata:
  name: "time"
  labels:
    operator-metering: "true"
spec:
  query: |
    time()
---
apiVersion: metering.openshift.io/v1alpha1
kind: ReportDataSource
metadata:
  labels:
    operator-metering: "true"
  name: time
spec:
  awsBilling: null
  promsum:
    query: time
---
apiVersion: metering.openshift.io/v1alpha1
kind: ReportGenerationQuery
metadata:
  name: "time"
  labels:
    operator-metering: "true"
spec:
  reportDataSources:
  - "time"
  reportQueries:
  - "time"
  columns: []
  query: ""
```

In another window, from within operator-metering:

```
METERING_PROMETHEUS_SCHEME=http METERING_PROMETHEUS_HOST=127.0.0.1:9005 \
METERING_NAMESPACE=my_namespace \
make run-reporting-operator-local
```

In another window connect to presto:

```
k port-forward presto-coordinator-5b97f44bc5-whjb5 8081:8080
```

Verify in web console that data is being inserted into database:

```
INSERT INTO datasource_metering_tschuy_time VALUES (1551295200.000000,timestamp '2019-02-27 19:20:00.000'...
```