### PR TITLE
reporting-operator: use secret for token config

### DIFF
--- a/Documentation/configuring-reporting-operator.md
+++ b/Documentation/configuring-reporting-operator.md
@@ -3,7 +3,7 @@
 reporting-operator is responsible for collecting data from Prometheus, storing the metrics in Presto, running report queries against Presto, and exposing their results via an HTTP API.
 Configuring the operator is done primarily within a `Metering` CR's `spec.reporting-operator.spec` section.
 
-## Prometheus URL
+## Prometheus connection
 
 Depending on how you installed Metering, the default Prometheus URL varies.
 If you installed for Openshift then the default assumes Prometheus is available at `https://prometheus-k8s.openshift-monitoring.svc:9091/`.
@@ -20,7 +20,33 @@ spec:
         prometheusURL: "http://prometheus.cluster-monitoring.svc:9090"
 ```
 
-> Note: currently we do not support https connections or authentication to Prometheus except for in Openshift, but support for it is being developed.
+To secure the connection to Prometheus, the default Metering installation uses the Openshift certificate authority. If your Prometheus instance uses a different CA, the path to the CA file can be referenced with the `prometheusCAFile` option:
+
+```
+spec:
+  reporting-operator:
+    spec:
+      config:
+        prometheusCAFile: "/path/to/my/ca.crt"
+```
+
+Alternatively, to use the system certificate authorities for publicly valid certificates, it can be set to `""`.
+
+Reporting-operator can also be configured to use a specified bearer token to auth with Prometheus:
+
+```
+spec:
+  reporting-operator:
+    spec:
+      config:
+        prometheusImporter:
+          auth:
+            useServiceAccountToken: false
+            tokenSecret:
+              enabled: true
+              create: true
+              value: "abc-123"
+```
 
 ## Exposing the reporting API
 

--- a/Documentation/metering-config.md
+++ b/Documentation/metering-config.md
@@ -11,7 +11,7 @@ For details on different types of configuration read the relevant document:
   - [node selectors](common-configuration.md#node-selectors)
   - [image repositories and tags](common-configuration.md#image-repositories-and-tags)
 - [configuring reporting-operator](configuring-reporting-operator.md)
-  - [set the Prometheus URL](configuring-reporting-operator.md#prometheus-url)
+  - [set Prometheus connection configuration](configuring-reporting-operator.md#prometheus-connection)
   - [exposing the reporting API](configuring-reporting-operator.md#exposing-the-reporting-api)
   - [configuring Authentication on Openshift](configuring-reporting-operator.md#openshift-authentication)
 - [configuring storage](configuring-storage.md)

--- a/charts/reporting-operator/templates/reporting-operator-config.yaml
+++ b/charts/reporting-operator/templates/reporting-operator-config.yaml
@@ -40,8 +40,10 @@ data:
 {{- if .Values.spec.config.prometheusDatasourceImportFrom }}
   prometheus-datasource-import-from: {{ .Values.spec.config.prometheusDatasourceImportFrom | quote }}
 {{- end }}
-{{- if .Values.spec.config.prometheusBearerTokenFile }}
-  prometheus-bearer-token-file: "{{ .Values.spec.config.prometheusBearerTokenFile }}"
+{{- if .Values.spec.config.prometheusImporter.auth.useServiceAccountToken }}
+  prometheus-bearer-token-file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+{{- else }}
+  prometheus-bearer-token-file: "/var/run/reporting-operator/token"
 {{- end }}
 {{- if .Values.spec.config.allNamespaces }}
   all-namespaces: {{ .Values.spec.config.allNamespaces | quote }}

--- a/charts/reporting-operator/templates/reporting-operator-deployment.yaml
+++ b/charts/reporting-operator/templates/reporting-operator-deployment.yaml
@@ -156,6 +156,10 @@ spec:
               name: reporting-operator-config
               key: prometheus-datasource-import-from
               optional: true
+{{- /* neither specified = no auth used; both specified = error; either = correct & authenticated */ -}}
+{{- if and .Values.spec.config.prometheusImporter.auth.tokenSecret.enabled .Values.spec.config.prometheusImporter.auth.useServiceAccountToken  }}
+  {{ fail "cannot use both token from secret and token from service account" }}
+{{- end }}
         - name: REPORTING_OPERATOR_PROMETHEUS_BEARER_TOKEN_FILE
           valueFrom:
             configMapKeyRef:
@@ -289,6 +293,11 @@ spec:
         - mountPath: /etc/proxy/authenticated-emails
           name: authenticated-emails-secret
 {{- end }}
+{{- if .Values.spec.config.tokenSecret.enabled }}
+        - mountPath: /var/run/reporting-operator/token
+          name: prometheus-bearer-token
+          subPath: token
+{{- end }}
 {{- end }}
       volumes:
 {{- if .Values.spec.config.tls.enabled }}
@@ -312,6 +321,11 @@ spec:
       - name: authenticated-emails-secret
         secret:
           secretName: {{ .Values.spec.authProxy.authenticatedEmailsSecretName }}
+{{- end }}
+{{- if .Values.spec.config.tokenSecret.enabled }}
+      - name: prometheus-bearer-token
+        secret:
+          secretName: {{ .Values.spec.config.tokenSecret.name }}
 {{- end }}
 {{- end }}
       restartPolicy: Always

--- a/charts/reporting-operator/templates/reporting-operator-prometheus-bearer-token-secrets.yaml
+++ b/charts/reporting-operator/templates/reporting-operator-prometheus-bearer-token-secrets.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.spec.config.prometheusImporter.auth.tokenSecret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.spec.config.prometheusImporter.auth.tokenSecret.name }}
+  labels:
+    app: reporting-operator
+{{- block "extraMetadata" . }}
+{{- end }}
+data:
+  token: {{ .Values.spec.config.prometheusImporter.auth.tokenSecret.value | b64enc | quote }}
+{{- end -}}

--- a/charts/reporting-operator/values.yaml
+++ b/charts/reporting-operator/values.yaml
@@ -24,7 +24,15 @@ spec:
     prometheusDatasourceMaxImportBackfillDuration: null
     prometheusDatasourceImportFrom: null
     prometheusCAFile: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
-    prometheusBearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    prometheusImporter:
+      auth:
+        useServiceAccountToken: true
+        tokenSecret:
+          enabled: false
+          create: false
+          name: reporting-operator-prometheus-bearer-secrets
+          value: ""
 
     logLevel: "info"
     logReports: "false"


### PR DESCRIPTION
I'm not particularly happy with the configuration structure for bearer tokens now that we have three options, two intertwined, for bearer config. 

Would it be better perhaps to refactor into something more like the TLS config:

```
prometheusBearer:
    # use either tokenFile or token; file takes precedence
    tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token" 
    token: null # "my_token_here"
    createSecret: false
    tokenSecretName: reporting-operator-prometheus-bearer-secrets
```
?

I'm also not particularly happy with that, since it still leads to awkward-feeling options between the tokenFile and the rest of the options that are specifically about the secret.

Thoughts?