### PR TITLE
hack: improve capturing pod logs in e2e tests

### DIFF
--- a/hack/capture-pod-logs.sh
+++ b/hack/capture-pod-logs.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-ROOT_DIR=$(dirname "${BASH_SOURCE[0]}")/..
-source "${ROOT_DIR}/hack/common.sh"
-
-: "${1:?Must be the namespace which pod\'s logs you want to capture}"
-
-capture_pod_logs "$1"

--- a/hack/e2e-test-runner.sh
+++ b/hack/e2e-test-runner.sh
@@ -10,11 +10,10 @@ set -e
 : "${TEST_LOG_FILE:=tests.txt}"
 : "${DEPLOY_LOG_FILE:=deploy.log}"
 : "${DEPLOY_POD_LOGS_LOG_FILE:=pod-logs.log}"
-: "${FINAL_POD_LOGS_LOG_FILE:=final-pod-descriptions-logs.log}"
 
 : "${DEPLOY_METERING:=true}"
 : "${TEST_METERING:=true}"
-: "${CLEANUP_METERING:=true}"
+: "${CLEANUP_METERING_NAMESPACE:=true}"
 # can be deploy.sh, deploy-custom.sh, deploy-e2e.sh, deploy-integration.sh
 : "${DEPLOY_SCRIPT:=deploy.sh}"
 : "${TEST_OUTPUT_PATH:="$(mktemp -d)"}"
@@ -38,20 +37,18 @@ echo "\$TEST_OUTPUT_PATH=$TEST_OUTPUT_PATH"
 
 REPORTS_DIR=$TEST_OUTPUT_PATH/reports
 LOG_DIR=$TEST_OUTPUT_PATH/logs
-TEST_OUT_DIR=$TEST_OUTPUT_PATH/tests
+TEST_OUTPUT_DIR=$TEST_OUTPUT_PATH/tests
 
-TEST_LOG_FILE_PATH="${TEST_LOG_FILE_PATH:-$TEST_OUT_DIR/$TEST_LOG_FILE}"
-TEST_TAP_FILE_PATH="${TEST_TAP_FILE_PATH:-$TEST_OUT_DIR/$TEST_TAP_FILE}"
+TEST_LOG_FILE_PATH="${TEST_LOG_FILE_PATH:-$TEST_OUTPUT_DIR/$TEST_LOG_FILE}"
+TEST_TAP_FILE_PATH="${TEST_TAP_FILE_PATH:-$TEST_OUTPUT_DIR/$TEST_TAP_FILE}"
 DEPLOY_LOG_FILE_PATH="${DEPLOY_LOG_FILE_PATH:-$LOG_DIR/$DEPLOY_LOG_FILE}"
 DEPLOY_POD_LOGS_LOG_FILE_PATH="${DEPLOY_POD_LOGS_LOG_FILE_PATH:-$LOG_DIR/$DEPLOY_POD_LOGS_LOG_FILE}"
-FINAL_POD_LOGS_LOG_FILE_PATH="${FINAL_POD_LOGS_LOG_FILE_PATH:-$LOG_DIR/$FINAL_POD_LOGS_LOG_FILE}"
 
-mkdir -p $TEST_OUT_DIR $LOG_DIR $REPORTS_DIR
+mkdir -p "$TEST_OUTPUT_DIR" "$LOG_DIR" "$REPORTS_DIR"
 touch "$TEST_LOG_FILE_PATH"
 touch "$TEST_TAP_FILE_PATH"
 touch "$DEPLOY_LOG_FILE_PATH"
 touch "$DEPLOY_POD_LOGS_LOG_FILE_PATH"
-touch "$FINAL_POD_LOGS_LOG_FILE_PATH"
 
 # fail with the last non-zero exit code (preserves test fail exit code)
 set -o pipefail
@@ -61,26 +58,53 @@ export DELETE_PVCS=true
 export TEST_RESULT_REPORT_OUTPUT_DIRECTORY="$REPORTS_DIR"
 
 function cleanup() {
+    exit_status=$?
+
     echo "Performing cleanup"
 
-    if [ -n "$FINAL_POD_LOGS_LOG_FILE" ]; then
-        echo "Capturing final pod logs"
-        capture_pod_logs "$METERING_NAMESPACE" >> "$FINAL_POD_LOGS_LOG_FILE_PATH"
-        echo "Finished capturing final pod logs"
-    fi
+    echo "Storing pod descriptions and logs at $LOG_DIR"
+    echo "Capturing pod descriptions"
+    PODS="$(kubectl get pods --no-headers --namespace "$METERING_NAMESPACE")"
+    echo "$PODS" | awk '{ print $1 }' | while read -r pod; do
+        if [[ -n "$pod" ]]; then
+            echo "Capturing pod $pod description"
+            if ! kubectl describe pod --namespace "$METERING_NAMESPACE" "$pod" >> "$LOG_DIR/${pod}-description.txt"; then
+                echo "Error capturing pod $pod description"
+            fi
+        fi
+    done
 
-    echo "Deleting namespace"
-    kubectl delete ns "$METERING_NAMESPACE" || true
+    echo "Capturing pod logs"
+    echo "$PODS" | awk '{ print $1 }' | while read -r pod; do
+        # There can be multiple containers within a pod. We need to iterate
+        # over each of those
+        containers=$(kubectl get pods -o jsonpath="{.spec.containers[*].name}" --namespace "$METERING_NAMESPACE" "$pod")
+        for container in $containers; do
+            echo "Capturing pod $pod container $container logs"
+            if ! kubectl logs --namespace "$METERING_NAMESPACE" -c "$container" "$pod" >> "$LOG_DIR/${pod}-${container}.log"; then
+                echo "Error capturing pod $pod container $container logs"
+            fi
+        done
+    done
+
+
+    if [ "$CLEANUP_METERING_NAMESPACE" == "true" ]; then
+        echo "Deleting namespace"
+        kubectl delete ns "$METERING_NAMESPACE" || true
+    fi
 
     # kill any background jobs, such as stern
     jobs -p | xargs kill
     # Wait for any jobs
     wait
+
+    exit "$exit_status"
 }
 
 if [ "$DEPLOY_METERING" == "true" ]; then
     if [ -n "$DEPLOY_POD_LOGS_LOG_FILE" ]; then
-        echo "Capturing pod logs"
+        echo "Streaming pod logs"
+        echo "Storing logs at $DEPLOY_POD_LOGS_LOG_FILE_PATH"
         if [ "$OUTPUT_POD_LOG_STDOUT" == "true" ]; then
             stern --timestamps -n "$METERING_NAMESPACE" '.*' | tee -a "$DEPLOY_POD_LOGS_LOG_FILE_PATH" &
         else
@@ -88,11 +112,10 @@ if [ "$DEPLOY_METERING" == "true" ]; then
         fi
     fi
 
-    if [ "$CLEANUP_METERING" == "true" ]; then
-        trap cleanup EXIT SIGINT
-    fi
+    trap cleanup EXIT
 
     echo "Deploying Metering"
+    echo "Storing deploy logs at $DEPLOY_LOG_FILE_PATH"
     if [ "$OUTPUT_DEPLOY_LOG_STDOUT" == "true" ]; then
         "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" | tee -a "$DEPLOY_LOG_FILE_PATH" 2>&1
     else
@@ -103,6 +126,7 @@ fi
 if [ "$TEST_METERING" == "true" ]; then
     echo "Running tests"
 
+    echo "Storing test results at $TEST_OUTPUT_DIR"
 
     if [ "$OUTPUT_TEST_LOG_STDOUT" == "true" ]; then
         tail -f "$TEST_LOG_FILE_PATH" &

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -67,32 +67,3 @@ function uninstall_metering() {
     fi
 }
 
-# Taken and modified slightly from https://github.com/kubernetes/charts/blob/f1711c220988b69e530263dc924eaed0a759e441/test/changed.sh#L42
-capture_pod_logs() {
-    NS="$(sanetize_namespace "$1")"
-    echo "Capturing logs for $NS"
-    # List all logs for all containers in all pods for the namespace which was
-    PODS="$(kubectl get pods --no-headers --namespace "$NS")"
-    echo '===Pods==='
-    echo "$PODS"
-    echo "$PODS" | awk '{ print $1 }' | while read -r pod; do
-        if [[ -n "$pod" ]]; then
-            printf '===Details from pod %s:===\n' "$pod"
-
-            printf '...Description of pod %s:...\n' "$pod"
-            kubectl describe pod --namespace "$NS" "$pod" || true
-            printf '...End of description for pod %s...\n\n' "$pod"
-
-            # There can be multiple containers within a pod. We need to iterate
-            # over each of those
-            containers=$(kubectl get pods -o jsonpath="{.spec.containers[*].name}" --namespace "$NS" "$pod")
-            for container in $containers; do
-                printf -- '---Logs from container %s in pod %s:---\n' "$container" "$pod"
-                kubectl logs --namespace "$METERING_NAMESPACE" -c "$container" "$pod" || true
-                printf -- '---End of logs for container %s in pod %s---\n\n' "$container" "$pod"
-            done
-
-            printf '===End of details for pod %s===\n\n' "$pod"
-        fi
-    done
-}

--- a/jenkins/vars/testRunner.groovy
+++ b/jenkins/vars/testRunner.groovy
@@ -75,10 +75,9 @@ spec:
             // use the OVERRIDE_NAMESPACE if specified, otherwise set namespace to prefix + BRANCH_NAME
             METERING_NAMESPACE          = "${params.OVERRIDE_NAMESPACE ?: defaultNamespace}"
             SCRIPT                      = "${pipelineParams.testScript}"
-            // we set CLEANUP_METERING to false and instead handle cleanup on
-            // our own, so that if there's a test timeout, we can still capture
-            // pod logs
-            CLEANUP_METERING            = "false"
+            // we set CLEANUP_METERING_NAMESPACE to false and instead handle cleanup on
+            // our own
+            CLEANUP_METERING_NAMESPACE            = "false"
             DOCKER_CREDS                = credentials('quay-coreos-jenkins-push')
         }
 
@@ -88,7 +87,6 @@ spec:
                     KUBECONFIG                        = credentials("${pipelineParams.kubeconfigCredentialsID}")
                     TEST_OUTPUT_DIR                   = "${env.OUTPUT_DIR}/${commonPrefix}-tests"
                     TEST_OUTPUT_PATH                  = "${env.WORKSPACE}/${env.TEST_OUTPUT_DIR}"
-                    FINAL_POD_LOGS_LOG_FILE_PATH      = "${env.TEST_OUTPUT_PATH}/logs/final-pod-descriptions-logs.log"
                     DEPLOY_PLATFORM                   = "${pipelineParams.deployPlatform}"
                     METERING_HTTPS_API                = "${pipelineParams.meteringHttpsAPI ?: false}"
                     METERING_CREATE_PULL_SECRET       = "true"
@@ -104,7 +102,6 @@ spec:
                     }
                     cleanup {
                         script {
-                            captureLogs()
                             if (alwaysSkipNamespaceCleanup || params.SKIP_NS_CLEANUP) {
                                 echo 'Skipping namespace cleanup'
                             } else {
@@ -151,13 +148,6 @@ private def runScript() {
                 '''
             }
         }
-    }
-}
-
-private def captureLogs() {
-    container('metering-test-runner') {
-        echo "Capturing pod logs"
-        sh 'set -e; cd $METERING_SRC_DIR && mkdir -p $(dirname $FINAL_POD_LOGS_LOG_FILE_PATH) && ./hack/capture-pod-logs.sh $METERING_NAMESPACE > $FINAL_POD_LOGS_LOG_FILE_PATH'
     }
 }
 


### PR DESCRIPTION
This basically moves the logic into the test runner script and puts each pod description and pod log into a seperate file instead of 1 huge log file which was getting difficult to sift through. I removed the log collection from the jenkins side since it failing without logs due to the script failing is fairly rare, and in origin CI, our script is the only thing which can collect the logs.