### PR TITLE
WIP Improve ability to run e2e/integration tests in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ _tmp
 bin/*
 coverage.out
 junit-metering.xml
+e2e-docker
+test-output

--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -40,10 +40,12 @@ RUN curl \
 
 RUN helm init --client-only --skip-refresh && helm repo remove stable || true
 
-COPY . /go/src/github.com/operator-framework/operator-metering
-WORKDIR /go/src/github.com/operator-framework/operator-metering
+COPY gotools /go/src/gotools
 
-RUN make bin/test2json
+ENV TEST2JSON_BIN /go/bin/test2json
+RUN go build -o $TEST2JSON_BIN /go/src/gotools/test2json/main.go \
+        && chmod +x $TEST2JSON_BIN
+
 RUN go get -u github.com/jstemmer/go-junit-report
 
 CMD ["/bin/bash"]

--- a/hack/e2e-test-runner.sh
+++ b/hack/e2e-test-runner.sh
@@ -5,6 +5,7 @@ set -e
 : "${METERING_NAMESPACE:?}"
 
 : "${TEST_SCRIPT:?}"
+: "${TEST2JSON_BIN:="$ROOT_DIR/bin/test2json"}"
 
 : "${TEST_TAP_FILE:=tests.tap}"
 : "${TEST_LOG_FILE:=tests.txt}"
@@ -45,10 +46,12 @@ DEPLOY_LOG_FILE_PATH="${DEPLOY_LOG_FILE_PATH:-$LOG_DIR/$DEPLOY_LOG_FILE}"
 DEPLOY_POD_LOGS_LOG_FILE_PATH="${DEPLOY_POD_LOGS_LOG_FILE_PATH:-$LOG_DIR/$DEPLOY_POD_LOGS_LOG_FILE}"
 
 mkdir -p "$TEST_OUTPUT_DIR" "$LOG_DIR" "$REPORTS_DIR"
-touch "$TEST_LOG_FILE_PATH"
-touch "$TEST_TAP_FILE_PATH"
-touch "$DEPLOY_LOG_FILE_PATH"
-touch "$DEPLOY_POD_LOGS_LOG_FILE_PATH"
+
+OUTPUT_FILES=( "$TEST_LOG_FILE_PATH" "$TEST_TAP_FILE_PATH" "$DEPLOY_LOG_FILE_PATH" "$DEPLOY_POD_LOGS_LOG_FILE_PATH" )
+
+# delete any existing output between runs
+rm -f "${OUTPUT_FILES[@]}"
+touch "${OUTPUT_FILES[@]}"
 
 # fail with the last non-zero exit code (preserves test fail exit code)
 set -o pipefail
@@ -134,7 +137,7 @@ if [ "$TEST_METERING" == "true" ]; then
 
     "$TEST_SCRIPT" 2>&1 \
         | tee -a "$TEST_LOG_FILE_PATH" \
-        | "$ROOT_DIR/bin/test2json" \
+        | "$TEST2JSON_BIN" \
         | tee -a "${TEST_LOG_FILE_PATH}.json" \
         | "$FAQ_BIN" -f json -o json -M -c -r -s -F "$ROOT_DIR/hack/tap-output.jq" \
         | tee -a "$TEST_TAP_FILE_PATH"

--- a/jenkins/vars/testRunner.groovy
+++ b/jenkins/vars/testRunner.groovy
@@ -54,7 +54,6 @@ spec:
             timestamps()
             overrideIndexTriggers(false)
             disableConcurrentBuilds()
-            skipDefaultCheckout()
             buildDiscarder(logRotator(
                 artifactDaysToKeepStr: '14',
                 artifactNumToKeepStr: '30',
@@ -64,8 +63,8 @@ spec:
         }
 
         environment {
-            GOPATH                      = "/go"
-            METERING_SRC_DIR            = "/go/src/github.com/operator-framework/operator-metering"
+            GOPATH            = "${env.WORKSPACE}/go"
+            METERING_SRC_DIR  = "${env.WORKSPACE}/go/src/github.com/operator-framework/operator-metering"
             METERING_OPERATOR_DEPLOY_TAG = "${params.DEPLOY_TAG ?: env.BRANCH_NAME}"
             REPORTING_OPERATOR_DEPLOY_TAG = "${params.DEPLOY_TAG ?: env.BRANCH_NAME}"
             OUTPUT_DEPLOY_LOG_STDOUT    = "true"
@@ -82,6 +81,19 @@ spec:
         }
 
         stages {
+            stage('Prepare') {
+                steps {
+                    container('metering-test-runner') {
+                        checkout([
+                            $class: 'GitSCM',
+                            branches: scm.branches,
+                            extensions: scm.extensions + [[$class: 'RelativeTargetDirectory', relativeTargetDir: env.METERING_SRC_DIR]],
+                            userRemoteConfigs: scm.userRemoteConfigs
+                        ])
+                    }
+                }
+            }
+
             stage('Run Tests') {
                 environment {
                     KUBECONFIG                        = credentials("${pipelineParams.kubeconfigCredentialsID}")


### PR DESCRIPTION
First commit updates e2e and integration scripts to work in docker more easily, and removes the source code from the `src` image. 

The 2nd image updates jenkins to handle the code being removed from the src image. Since in origin CI we expect the source to be copied into the container by the CI system. In jenkins we'll clone it directly from inside the container.