### PR TITLE
update manifests/deploy/openshift/helm-operator/metering.yaml to bypa…

### DIFF
--- a/manifests/deploy/openshift/helm-operator/metering.yaml
+++ b/manifests/deploy/openshift/helm-operator/metering.yaml
@@ -2,4 +2,4 @@ apiVersion: metering.openshift.io/v1alpha1
 kind: Metering
 metadata:
   name: operator-metering
-spec:
+spec: []


### PR DESCRIPTION
…ss error check
having empty `spec:` results in validation error and the metering CRD was not applied.
`error: error validating "/home/pruan/workspace/operator-metering/manifests/deploy/openshift/helm-operator/metering.yaml": error validating data: unknown object type "nil" in Metering.spec; if you choose to ignore these errors, turn validation off with --validate=false
`
 
