### PR TITLE
Update e2e for running against origin CI/4.0 clusters

### DIFF
--- a/charts/metering-ci/templates/metering.yaml
+++ b/charts/metering-ci/templates/metering.yaml
@@ -36,23 +36,21 @@ spec:
         awsAccessKeyID: "{{ .Values.awsAccessKeyId }}"
         awsSecretAccessKey: "{{ .Values.awsSecretAccessKey }}"
 
-        # hard code to 2 hours in tests since tests run hourly scheduled tests
-        # and need more than 1 hours worth of data to ensure we have enough for
-        # the reports to produce results
-        prometheusDatasourceMaxImportBackfillDuration: "2h"
+        # decrease backfill for e2e since we run for a short period of time
+        # and run reports against the last 10 minutes of data
+        prometheusDatasourceMaxImportBackfillDuration: "15m"
 
         # increase the poll interval for tests so that the Reports can run
         # sooner
         promsumPollInterval: "30s"
 
-        # increase the chunk size and prom query size decreases the number of
-        # imports we need to do to catch up
-        prometheusDatasourceMaxQueryRangeDuration: "15m"
-        promsumChunkSize: "15m"
+        # set chunk/query size to a value suitable for the backfill duration
+        prometheusDatasourceMaxQueryRangeDuration: "5m"
+        promsumChunkSize: "5m"
 
-        # for efficiency, we don't need data at the default 60 second
-        # resolution, and we can use a slightly higher resolution for tests
-        promsumStepSize: "5m"
+        # e2e runs a per-minute report so the metric resolution should be 60s
+        # or less
+        promsumStepSize: "60s"
 
   presto:
     spec:

--- a/hack/e2e-test-runner.sh
+++ b/hack/e2e-test-runner.sh
@@ -150,9 +150,9 @@ if [ "$DEPLOY_METERING" == "true" ]; then
     echo "Deploying Metering"
     echo "Storing deploy logs at $DEPLOY_LOG_FILE_PATH"
     if [ "$OUTPUT_DEPLOY_LOG_STDOUT" == "true" ]; then
-        "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" | tee -a "$DEPLOY_LOG_FILE_PATH" 2>&1
+        time "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" | tee -a "$DEPLOY_LOG_FILE_PATH" 2>&1
     else
-        "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" > "$DEPLOY_LOG_FILE_PATH" 2>&1
+        time "$ROOT_DIR/hack/${DEPLOY_SCRIPT}" > "$DEPLOY_LOG_FILE_PATH" 2>&1
     fi
 fi
 
@@ -163,7 +163,7 @@ if [ "$TEST_METERING" == "true" ]; then
     set +o pipefail
     echo "Running tests"
     # Log the results and store in a file
-    "$TEST_SCRIPT" 2>&1 | tee "$TEST_LOG_FILE_PATH"; TEST_EXIT_CODE=${PIPESTATUS[0]}
+    time "$TEST_SCRIPT" 2>&1 | tee "$TEST_LOG_FILE_PATH"; TEST_EXIT_CODE=${PIPESTATUS[0]}
 
     echo "Converting test results"
     # turn the results into json

--- a/jenkins/vars/testRunner.groovy
+++ b/jenkins/vars/testRunner.groovy
@@ -140,7 +140,7 @@ spec:
 private def runScript() {
     container('metering-test-runner') {
         ansiColor('xterm') {
-            timeout(20) {
+            timeout(25) {
                 sh '''#!/bin/bash -ex
                 export METERING_CREATE_PULL_SECRET=true
                 export DOCKER_USERNAME="${DOCKER_CREDS_USR:-}"


### PR DESCRIPTION
Because 4.0 tests are run against brand new clusters, we can't expect there to
be 2 hours with of data already in monitoring. Instead, use less data, and run
a scheduled report with a more frequent schedule using the cron period
configuration.

This is based on #410 as it changes how tests run dramatically and this leverages the new functionality.