### PR TITLE
Dockerfile.src,jenkins: Move checkout of code to happen via jenkins in the container

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -40,10 +40,13 @@ RUN curl \
 
 RUN helm init --client-only --skip-refresh && helm repo remove stable || true
 
-COPY . /go/src/github.com/operator-framework/operator-metering
-WORKDIR /go/src/github.com/operator-framework/operator-metering
+COPY gotools /go/src/gotools
 
-RUN make bin/test2json
+ENV TEST2JSON_BIN /go/bin/test2json
+
+RUN go build -o $TEST2JSON_BIN /go/src/gotools/test2json/main.go \
+        && chmod +x $TEST2JSON_BIN
+
 RUN go get -u github.com/jstemmer/go-junit-report
 
 CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,13 @@ unit:
 	hack/unit.sh
 
 unit-docker: metering-src-docker-build
-	docker run -i $(METERING_SRC_IMAGE_REPO):$(IMAGE_TAG) bash -c 'make unit'
+	docker run \
+		--rm \
+		-t \
+		-w /go/src/github.com/operator-framework/operator-metering \
+		-v $(PWD):/go/src/github.com/operator-framework/operator-metering \
+		$(METERING_SRC_IMAGE_REPO):$(IMAGE_TAG) \
+		make unit
 
 integration:
 	hack/integration.sh
@@ -273,7 +279,13 @@ verify: verify-codegen all-charts metering-manifests fmt
 	git diff --stat HEAD --ignore-submodules --exit-code -- $(VERIFY_FILE_PATHS)
 
 verify-docker: metering-src-docker-build
-	docker run -i $(METERING_SRC_IMAGE_REPO):$(IMAGE_TAG) bash -c 'make verify'
+	docker run \
+		--rm \
+		-t \
+		-w /go/src/github.com/operator-framework/operator-metering \
+		-v $(PWD):/go/src/github.com/operator-framework/operator-metering \
+		$(METERING_SRC_IMAGE_REPO):$(IMAGE_TAG) \
+		make verify
 
 .PHONY: run-metering-operator-local
 run-metering-operator-local: metering-operator-docker-build

--- a/jenkins/vars/testRunner.groovy
+++ b/jenkins/vars/testRunner.groovy
@@ -54,7 +54,6 @@ spec:
             timestamps()
             overrideIndexTriggers(false)
             disableConcurrentBuilds()
-            skipDefaultCheckout()
             buildDiscarder(logRotator(
                 artifactDaysToKeepStr: '14',
                 artifactNumToKeepStr: '30',
@@ -64,8 +63,8 @@ spec:
         }
 
         environment {
-            GOPATH                      = "/go"
-            METERING_SRC_DIR            = "/go/src/github.com/operator-framework/operator-metering"
+            GOPATH            = "${env.WORKSPACE}/go"
+            METERING_SRC_DIR  = "${env.WORKSPACE}/go/src/github.com/operator-framework/operator-metering"
             METERING_OPERATOR_DEPLOY_TAG = "${params.DEPLOY_TAG ?: env.BRANCH_NAME}"
             REPORTING_OPERATOR_DEPLOY_TAG = "${params.DEPLOY_TAG ?: env.BRANCH_NAME}"
             OUTPUT_DEPLOY_LOG_STDOUT    = "true"
@@ -84,6 +83,19 @@ spec:
         }
 
         stages {
+            stage('Prepare') {
+                steps {
+                    container('metering-test-runner') {
+                        checkout([
+                            $class: 'GitSCM',
+                            branches: scm.branches,
+                            extensions: scm.extensions + [[$class: 'RelativeTargetDirectory', relativeTargetDir: env.METERING_SRC_DIR]],
+                            userRemoteConfigs: scm.userRemoteConfigs
+                        ])
+                    }
+                }
+            }
+
             stage('Run Tests') {
                 environment {
                     KUBECONFIG                        = credentials("${pipelineParams.kubeconfigCredentialsID}")


### PR DESCRIPTION
Remove source from Dockerfile.src, so we mount/check it out in builds and tests as needed.