### PR TITLE
pkg/operator: Fix panic when there are no metrics imported

### DIFF
--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -190,7 +190,7 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 	if err != nil {
 		return fmt.Errorf("ImportFromLastTimestamp errored: %v", err)
 	}
-	numResultsImported := len(results.ProcessedTimeRanges)
+	numResultsImported := len(results.Metrics)
 
 	// default to importing at the configured import interval
 	importDelay := op.getQueryIntervalForReportDataSource(dataSource)


### PR DESCRIPTION
Correctly take length of metrics, not processedTimeRanges to get number
of results imported.

This is because line 628 `firstMetric := results.Metrics[0]` panics when metrics is empty. In PR #610 we changed from using `results.ProcessedTimeRanges` to `results.Metrics` but forgot to change what slice numResultsImported used.
