### PR TITLE
hack/deploy.sh: Fix jq cannot iterate over null errors

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -36,7 +36,7 @@ while true; do
         echo "Namespace is active"
         break
     elif [ "$PHASE" == "Terminating" ]; then
-        echo "Waiting for namespace $METERING_NAMESPACE termination to complete before continuing"
+        echo "Waiting for namespace "$METERING_NAMESPACE" termination to complete before continuing"
     else
         echo "Namespace phase is $PHASE, unsure how to handle, exiting"
         exit 2
@@ -60,20 +60,12 @@ fi
 if [ "$INSTALL_METERING" == "true" ]; then
     echo "Installing metering"
     install_metering "${INSTALL_METHOD}"
-
-    echo
-    echo "Waiting for metering-operator pod to start termination"
-    # we just check until there's a non-ready container then the loop below this will check for readiness
-    until [ "$(kubectl -n $METERING_NAMESPACE get pods -l app=metering-operator -o json | "$FAQ_BIN" -f json -o json -M -c -r '.items | map(.status.containerStatuses[].ready) | all')" == "false" ]; do
-        echo 'waiting for metering-operator pods to terminate'
-        sleep 5
-    done
 else
     echo "Skipping install"
 fi
 
 echo "Waiting for metering-operator pods to be ready"
-until [ "$(kubectl -n $METERING_NAMESPACE get pods -l app=metering-operator -o json | "$FAQ_BIN" -f json -o json -M -c -r '.items | map(.status.containerStatuses[].ready) | all')" == "true" ]; do
+until [ "$(kubectl -n "$METERING_NAMESPACE" get pods -l app=metering-operator -o json | "$FAQ_BIN" -f json -o json -M -c -r '.items | map(try .status.containerStatuses[].ready catch false) | all')" == "true" ]; do
     echo 'waiting for metering-operator pods to be ready'
     sleep 5
 done
@@ -83,25 +75,19 @@ echo
 echo "Waiting a for pods to be recreated"
 
 EXPECTED_POD_COUNT=7
-# wait for the count to not equal the expected count so we know pods are restarting
-until [ "$(kubectl -n $METERING_NAMESPACE get pods -o json | "$FAQ_BIN" -f json -o json -M -c -r '.items | length')" != "$EXPECTED_POD_COUNT" ]; do
-    echo 'waiting for metering pods to be recreated'
-    kubectl -n $METERING_NAMESPACE get pods --no-headers -o wide
-    sleep 10
-done
 
 # now wait for the pods to reach our expected count
 echo "checking for pod statuses"
-until [ "$(kubectl -n $METERING_NAMESPACE get pods -o json | "$FAQ_BIN" -f json -o json -M -c -r '.items | length')" == "$EXPECTED_POD_COUNT" ]; do
+until [ "$(kubectl -n "$METERING_NAMESPACE" get pods -o json | "$FAQ_BIN" -f json -o json -M -c -r '.items | length')" == "$EXPECTED_POD_COUNT" ]; do
     echo 'waiting for metering pods to be created'
-    kubectl -n $METERING_NAMESPACE get pods --no-headers -o wide
+    kubectl -n "$METERING_NAMESPACE" get pods --no-headers -o wide
     sleep 10
 done
 echo "all of the metering pods have been started"
 
-until [ "$(kubectl -n $METERING_NAMESPACE get pods  -o json | "$FAQ_BIN" -f json -o json -M -c -r '.items | map(.status.containerStatuses[].ready) | all')" == "true" ]; do
+until [ "$(kubectl -n "$METERING_NAMESPACE" get pods  -o json | "$FAQ_BIN" -f json -o json -M -c -r '.items | map(try .status.containerStatuses[].ready catch false) | all')" == "true" ]; do
     echo 'waiting for all pods to be ready'
-    kubectl -n $METERING_NAMESPACE get pods --no-headers -o wide
+    kubectl -n "$METERING_NAMESPACE" get pods --no-headers -o wide
     sleep 10
 done
 echo "metering pods are all ready"


### PR DESCRIPTION
Fix the ` Cannot iterate over null (null)` that occur in the deploy script.