### PR TITLE
Write resourceVersion used to Metering CR status

### DIFF
--- a/Dockerfile.metering-operator
+++ b/Dockerfile.metering-operator
@@ -1,5 +1,8 @@
 # build image needs the helm-cli from the helm image
-FROM quay.io/coreos/helm:metering-v2.8.2 as helm
+FROM quay.io/coreos/helm:latest as helm
+
+# final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
+FROM openshift/origin-cli as cli
 
 # build image builds our charts
 FROM openshift/origin-release:golang-1.10 as build
@@ -30,7 +33,7 @@ RUN make \
     bin/metering-override-values.yaml
 
 # metering-helm-operator is below
-FROM quay.io/coreos/helm:metering-v2.8.2
+FROM quay.io/coreos/helm:latest
 
 USER root
 
@@ -38,12 +41,15 @@ USER root
 COPY hack/faq.repo /etc/yum.repos.d/ecnahc515-faq-epel-7.repo
 
 # oniguruma-devel comes from epel-release
-RUN INSTALL_PKGS="curl bash jq-1.6-2.el7 faq ca-certificates socat kubernetes-client" \
+RUN INSTALL_PKGS="curl bash jq-1.6-2.el7 faq ca-certificates socat" \
     && yum -y install epel-release \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \
     && rm -rf /var/cache/yum
+
+COPY --from=cli /usr/bin/oc /usr/bin/oc
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 EXPOSE 44134
 ENV HELM_HOST 127.0.0.1:44134

--- a/Dockerfile.metering-operator.rhel
+++ b/Dockerfile.metering-operator.rhel
@@ -1,6 +1,9 @@
 # build image needs the helm-cli from the helm image
 FROM openshift/ose-metering-helm:v4.0 as helm
 
+# final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
+FROM openshift/ose-cli as cli
+
 # build image builds our charts
 FROM openshift/golang-builder:1.10 AS build
 
@@ -28,11 +31,14 @@ RUN make \
 FROM openshift/ose-metering-helm:v4.0
 
 USER root
-RUN INSTALL_PKGS="curl bash jq-1.6-2.el7 faq ca-certificates socat kubernetes-client" \
+RUN INSTALL_PKGS="curl bash jq-1.6-2.el7 faq ca-certificates socat" \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \
     && rm -rf /var/cache/yum
+
+COPY --from=cli /usr/bin/oc /usr/bin/oc
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 EXPOSE 44134
 ENV HELM_HOST 127.0.0.1:44134

--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -1,3 +1,9 @@
+# need helm CLI for final image
+FROM quay.io/coreos/helm:latest as helm
+
+# image needs kubectl, so we copy `oc` from cli image to use as kubectl.
+FROM openshift/origin-cli as cli
+
 FROM openshift/origin-release:golang-1.10
 
 # our copy of faq and jq
@@ -9,25 +15,10 @@ RUN INSTALL_PKGS="curl jq-1.6-2.el7 faq" && \
     yum clean all && \
     rm -rf /var/cache/yum
 
-RUN mkdir -p /out
+COPY --from=cli /usr/bin/oc /usr/bin/oc
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
-ENV HELM_VERSION 2.8.0
-RUN curl \
-    --silent \
-    --show-error \
-    --location \
-    "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
-    | tar xz --strip-components=1 -C /usr/local/bin linux-amd64/helm \
-    && chmod +x /usr/local/bin/helm
-
-env KUBERNETES_VERSION 1.11.0
-RUN curl \
-    --silent \
-    --show-error \
-    --location \
-    "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl" \
-    -o /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl
+COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 
 ENV STERN_VERSION 1.6.0
 RUN curl \

--- a/charts/helm-operator/templates/deployment.yaml
+++ b/charts/helm-operator/templates/deployment.yaml
@@ -67,12 +67,7 @@ spec:
         - name: RELEASE_HISTORY_LIMIT
           value: "3"
         resources:
-          requests:
-            memory: "25Mi"
-            cpu: "50m"
-          limits:
-            memory: "25Mi"
-            cpu: "50m"
+{{ toYaml .Values.resources | indent 10 }}
       - name: tiller
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args: ["tiller"]

--- a/charts/helm-operator/values.yaml
+++ b/charts/helm-operator/values.yaml
@@ -21,6 +21,7 @@ image:
 
 serviceAccountName: helm-operator
 imagePullSecrets: []
+resources: {}
 
 rbac:
   roleName: helm-operator

--- a/manifests/deploy/common-helm-operator-values.yaml
+++ b/manifests/deploy/common-helm-operator-values.yaml
@@ -25,6 +25,13 @@ image:
   pullPolicy: Always
 
 serviceAccountName: metering-operator
+resources:
+  requests:
+    memory: "100Mi"
+    cpu: "50m"
+  limits:
+    memory: "100Mi"
+    cpu: "50m"
 
 rbac:
   clusterRoleName: metering-operator

--- a/manifests/deploy/openshift/helm-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/openshift/helm-operator/metering-operator-deployment.yaml
@@ -54,12 +54,13 @@ spec:
         - name: RELEASE_HISTORY_LIMIT
           value: "3"
         resources:
-          requests:
-            memory: "25Mi"
-            cpu: "50m"
           limits:
-            memory: "25Mi"
-            cpu: "50m"
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 50m
+            memory: 100Mi
+
       - name: tiller
         image: "quay.io/coreos/metering-helm-operator:0.13.0-latest"
         args: ["tiller"]

--- a/manifests/deploy/openshift/olm/metering.0.13.0-latest.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/metering.0.13.0-latest.clusterserviceversion.yaml
@@ -334,10 +334,10 @@ spec:
                   resources:
                     limits:
                       cpu: 50m
-                      memory: 25Mi
+                      memory: 100Mi
                     requests:
                       cpu: 50m
-                      memory: 25Mi
+                      memory: 100Mi
                 - args:
                   - tiller
                   env:


### PR DESCRIPTION
Also updates Dockerfiles to use a newer kubectl by using the `oc` binary as kubectl. Need a newer version to allow patching CRDs. Currently only kubectl 1.5.2 is available in centos/rhel repos.

The idea is this can be used to determine if a Metering operator has reacted to an update in the spec, as currently you cannot tell without looking at what's been deployed.