### PR TITLE
Improve validation of Report data dependency checks and fix runImmediately

### DIFF
--- a/Documentation/report.md
+++ b/Documentation/report.md
@@ -223,8 +223,8 @@ spec:
 
 ### runImmediately
 
-Set `runImmediately` to `true` to run the report immediately with all available data, regardless of the `reportingEnd` setting.
-For reports with a schedule set, it will not wait for each period's reportingEnd to elapse before processing.
+Set `runImmediately` to `true` to run the report immediately with all available data, regardless of the `reportingStart` or `reportingEnd` values, and without checking if there is any data for the report period.
+For reports with a schedule set, it will not wait for each period's reportingEnd to elapse before processing and all reportPeriods between `reportingStart` and `reportingEnd`.
 
 ### Inputs
 

--- a/Documentation/report.md
+++ b/Documentation/report.md
@@ -7,7 +7,9 @@ Metering produces reports derived from usage data sources which can be used in f
 
 A single `Report` resource represents a report which is updated with new information according to a schedule.
 Reports with a `spec.schedule` field set are always running, and will track what time periods it has collected data for, ensuring that if Metering is shutdown or unavailable for an extended period of time, it will backfill the data starting where it left off.
-If it's unset, then the Report will run once for the time specified by the reportingStart and reportingEnd.
+If the schedule is unset, then the Report will run once for the time specified by the reportingStart and reportingEnd.
+By default, reports will wait for ReportDataSources to have the progressed in their import process to cover the report period being processed.
+If the report has a schedule, it will wait until the period currently being processed has been covered by the import process.
 
 ## Example Report with a Schedule
 

--- a/manifests/custom-resource-definitions/reportdatasource.crd.yaml
+++ b/manifests/custom-resource-definitions/reportdatasource.crd.yaml
@@ -27,6 +27,12 @@ spec:
   - name: Newest Metric
     type: string
     JSONPath: .status.prometheusMetricImportStatus.newestImportedMetricTime
+  - name: Import Start
+    type: string
+    JSONPath: .status.prometheusMetricImportStatus.importDataStartTime
+  - name: Import End
+    type: string
+    JSONPath: .status.prometheusMetricImportStatus.importDataEndTime
   - name: Last Import Time
     type: string
     JSONPath: .status.prometheusMetricImportStatus.lastImportTime

--- a/pkg/apis/metering/v1alpha1/report_datasource.go
+++ b/pkg/apis/metering/v1alpha1/report_datasource.go
@@ -67,6 +67,8 @@ type PrometheusMetricImportStatus struct {
 	// LastImportTime is the time the import last import was ran.
 	LastImportTime *meta.Time `json:"lastImportTime,omitempty"`
 
+	// ImportDataStartTime is the start of the time first time range queried.
+	ImportDataStartTime *meta.Time `json:"importDataStartTime,omitempty"`
 	// ImportDataEndTime is the end of the time last time range queried.
 	ImportDataEndTime *meta.Time `json:"importDataEndTime,omitempty"`
 

--- a/pkg/apis/metering/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/metering/v1alpha1/zz_generated.deepcopy.go
@@ -179,6 +179,10 @@ func (in *PrometheusMetricImportStatus) DeepCopyInto(out *PrometheusMetricImport
 		in, out := &in.LastImportTime, &out.LastImportTime
 		*out = (*in).DeepCopy()
 	}
+	if in.ImportDataStartTime != nil {
+		in, out := &in.ImportDataStartTime, &out.ImportDataStartTime
+		*out = (*in).DeepCopy()
+	}
 	if in.ImportDataEndTime != nil {
 		in, out := &in.ImportDataEndTime, &out.ImportDataEndTime
 		*out = (*in).DeepCopy()

--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -185,96 +185,94 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 		return err
 	}
 
-	importTime := op.clock.Now().UTC()
+	if dataSource.Status.PrometheusMetricImportStatus == nil {
+		dataSource.Status.PrometheusMetricImportStatus = &cbTypes.PrometheusMetricImportStatus{}
+	}
+
+	// record the lastImportTime
+	dataSource.Status.PrometheusMetricImportStatus.LastImportTime = &metav1.Time{op.clock.Now().UTC()}
+
+	// run the import
 	results, err := importer.ImportFromLastTimestamp(context.Background(), allowIncompleteChunks)
 	if err != nil {
 		return fmt.Errorf("ImportFromLastTimestamp errored: %v", err)
 	}
-	numResultsImported := len(results.Metrics)
 
-	// default to importing at the configured import interval
+	// Default to importing at the configured import interval.
 	importDelay := op.getQueryIntervalForReportDataSource(dataSource)
 
-	var (
-		earliestImportedMetricTime,
-		newestImportedMetricTime,
-		importDataEndTime *metav1.Time
-	)
-	if dataSource.Status.PrometheusMetricImportStatus != nil {
-		if dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime != nil {
-			earliestImportedMetricTime = dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime
-		}
-		if dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime != nil {
-			newestImportedMetricTime = dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime
-		}
-		if dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime != nil {
-			importDataEndTime = dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime
-		}
-	}
-
-	// determine if we need to adjust our next import and update the status
-	// information if we've imported new metrics.
-	if numResultsImported != 0 {
+	if len(results.ProcessedTimeRanges) == 0 {
+		logger.Warnf("no time ranges processed for ReportDataSource %s", dataSource.Name)
+	} else {
 		// This is the last timeRange we processed, and we use the End time on
 		// this to determine what time range the importer attempted to import
 		// up until, for tracking our process
+		firstTimeRange := results.ProcessedTimeRanges[0]
 		lastTimeRange := results.ProcessedTimeRanges[len(results.ProcessedTimeRanges)-1]
 
-		// These are the first and last metric from the import, which we use to
-		// determine the data we've actually imported, versus what we've asked
-		// for.
-		firstMetric := results.Metrics[0]
-		lastMetric := results.Metrics[len(results.Metrics)-1]
-
-		// if there is no existing timestamp then this must be the first import
-		// and we should set the earliestImportedMetricTime
-		if earliestImportedMetricTime == nil {
-			earliestImportedMetricTime = &metav1.Time{firstMetric.Timestamp}
-		} else if earliestImportedMetricTime.After(firstMetric.Timestamp) {
-			dataSourceLogger.Errorf("detected time new metric import has older data than previously imported, data is likely duplicated.")
-			// TODO(chance): Look at adding an error to the status.
-			return nil // strop processing this ReportDataSource
+		// Update the timestamp which records the first timestamp we attempted
+		// to query from.
+		if dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime == nil || firstTimeRange.Start.Before(dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime.Time) {
+			dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime = &metav1.Time{firstTimeRange.Start}
 		}
-
-		if newestImportedMetricTime == nil || newestImportedMetricTime.Time.Before(lastMetric.Timestamp) {
-			newestImportedMetricTime = &metav1.Time{lastMetric.Timestamp}
-		}
-
 		// Update the timestamp which records the latest we've attempted to query
 		// up until.
-		if importDataEndTime == nil || importDataEndTime.Time.Before(lastTimeRange.End) {
-			importDataEndTime = &metav1.Time{lastTimeRange.End}
+		if dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime == nil || dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime.Time.Before(lastTimeRange.End) {
+			dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime = &metav1.Time{lastTimeRange.End}
 		}
-		// the data we collected is farther back than 1.5 their chunkSize, so requeue sooner
+
+		// The data we collected is farther back than 1.5 their chunkSize, so requeue sooner
 		// since we're backlogged. We use 1.5 because being behind 1 full chunk
-		// is typical, but we shouldn't be 2 full chunks after catching up
+		// is typical, but we shouldn't be 2 full chunks after catching up.
 		backlogDetectionDuration := time.Duration(1.5*importerCfg.ChunkSize.Seconds()) * time.Second
-		backlogDuration := op.clock.Now().Sub(newestImportedMetricTime.Time)
+		backlogDuration := op.clock.Now().Sub(dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime.Time)
 		if backlogDuration > backlogDetectionDuration {
 			// import delay has jitter so that processing backlogged
 			// ReportDataSources happens in a more randomized order to allow
 			// all of them to get processed when the queue is blocked.
 			importDelay = wait.Jitter(5*time.Second, 2)
-			logger.Warnf("Prometheus metrics import backlog detected: imported data for Prometheus ReportDataSource %s newest imported metric timestamp %s is %s away, queuing to reprocess in %s", dataSource.Name, newestImportedMetricTime.Time, backlogDuration, importDelay)
+			logger.Warnf("Prometheus metrics import backlog detected: imported data for Prometheus ReportDataSource %s newest imported metric timestamp %s is %s away, queuing to reprocess in %s", dataSource.Name, dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime.Time, backlogDuration, importDelay)
 		}
-	}
 
-	// Update the status to indicate where we are in the metric import process
-	dataSource.Status.PrometheusMetricImportStatus = &cbTypes.PrometheusMetricImportStatus{
-		EarliestImportedMetricTime: earliestImportedMetricTime,
-		NewestImportedMetricTime:   newestImportedMetricTime,
-		ImportDataEndTime:          importDataEndTime,
-		LastImportTime:             &metav1.Time{importTime},
-	}
-	dataSource, err = op.meteringClient.MeteringV1alpha1().ReportDataSources(dataSource.Namespace).Update(dataSource)
-	if err != nil {
-		return fmt.Errorf("unable to update ReportDataSource %s PrometheusMetricImportStatus: %v", dataSource.Name, err)
+		if len(results.Metrics) != 0 {
+			// These are the first and last metric from the import, which we use to
+			// determine the data we've actually imported, versus what we've asked
+			// for.
+			firstMetric := results.Metrics[0]
+			lastMetric := results.Metrics[len(results.Metrics)-1]
+
+			// if there is no existing timestamp then this must be the first import
+			// and we should set the earliestImportedMetricTime
+			if dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime == nil {
+				dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime = &metav1.Time{firstMetric.Timestamp}
+			} else if dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime.After(firstMetric.Timestamp) {
+				dataSourceLogger.Errorf("detected time new metric import has older data than previously imported, data is likely duplicated.")
+				// TODO(chance): Look at adding an error to the status.
+				return nil // strop processing this ReportDataSource
+			}
+
+			if dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime == nil || lastMetric.Timestamp.After(dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime.Time) {
+				dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime = &metav1.Time{lastMetric.Timestamp}
+			}
+
+			if err := op.queueDependentReportGenerationQueriesForDataSource(dataSource); err != nil {
+				logger.WithError(err).Errorf("error queuing ReportGenerationQuery dependents of ReportDataSource %s", dataSource.Name)
+			}
+			if err := op.queueDependentReportsForDataSource(dataSource); err != nil {
+				logger.WithError(err).Errorf("error queuing Report dependents of ReportDataSource %s", dataSource.Name)
+			}
+		}
+
+		// Update the status to indicate where we are in the metric import process
+		dataSource, err = op.meteringClient.MeteringV1alpha1().ReportDataSources(dataSource.Namespace).Update(dataSource)
+		if err != nil {
+			return fmt.Errorf("unable to update ReportDataSource %s PrometheusMetricImportStatus: %v", dataSource.Name, err)
+		}
 	}
 
 	nextImport := op.clock.Now().Add(importDelay).UTC()
 	logger.Infof("queuing Prometheus ReportDataSource %s to import data again in %s at %s", dataSource.Name, importDelay, nextImport)
 	op.enqueueReportDataSourceAfter(dataSource, importDelay)
-	op.queueDependentsOfDataSource(dataSource)
 	return nil
 }
 
@@ -342,7 +340,12 @@ func (op *Reporting) handleAWSBillingDataSource(logger log.FieldLogger, dataSour
 	logger.Infof("queuing AWSBilling ReportDataSource %s to update partitions again in %s at %s", dataSource.Name, partitionUpdateInterval, nextUpdate)
 	op.enqueueReportDataSourceAfter(dataSource, partitionUpdateInterval)
 
-	op.queueDependentsOfDataSource(dataSource)
+	if err := op.queueDependentReportGenerationQueriesForDataSource(dataSource); err != nil {
+		logger.WithError(err).Errorf("error queuing ReportGenerationQuery dependents of ReportDataSource %s", dataSource.Name)
+	}
+	if err := op.queueDependentReportsForDataSource(dataSource); err != nil {
+		logger.WithError(err).Errorf("error queuing Report dependents of ReportDataSource %s", dataSource.Name)
+	}
 	return nil
 }
 
@@ -591,14 +594,4 @@ func (op *Reporting) queueDependentReportsForDataSource(dataSource *cbTypes.Repo
 
 	}
 	return nil
-}
-
-func (op *Reporting) queueDependentsOfDataSource(dataSource *cbTypes.ReportDataSource) {
-	logger := op.logger.WithFields(log.Fields{"reportDataSource": dataSource.Name, "namespace": dataSource.Namespace})
-	if err := op.queueDependentReportGenerationQueriesForDataSource(dataSource); err != nil {
-		logger.WithError(err).Errorf("error queuing ReportGenerationQuery dependents of ReportDataSource %s", dataSource.Name)
-	}
-	if err := op.queueDependentReportsForDataSource(dataSource); err != nil {
-		logger.WithError(err).Errorf("error queuing Report dependents of ReportDataSource %s", dataSource.Name)
-	}
 }

--- a/pkg/operator/prestostore/query.go
+++ b/pkg/operator/prestostore/query.go
@@ -53,7 +53,7 @@ func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn 
 
 	var importResults PrometheusImportResults
 	if len(timeRanges) == 0 {
-		logger.Infof("no time ranges to query yet for table %s", cfg.PrestoTableName)
+		logger.Debugf("no time ranges to query yet for table %s", cfg.PrestoTableName)
 		return importResults, nil
 	}
 

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -320,13 +320,10 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 		"overwriteExisting": report.Spec.OverwriteExistingData,
 	})
 
+	var runningMsg, runningReason string
 	if report.Spec.RunImmediately {
-		runningMsg := "Report configured to run immediately"
-		logger.Infof(runningMsg)
-		report, err = op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionTrue, cbutil.RunImmediatelyReason, runningMsg))
-		if err != nil {
-			return err
-		}
+		runningReason = cbutil.RunImmediatelyReason
+		runningMsg = fmt.Sprintf("Report %s scheduled: runImmediately=true bypassing reporting period [%s to %s].", report.Name, reportPeriod.periodStart, reportPeriod.periodEnd)
 	} else {
 		// Check if it's time to generate the report
 		if reportPeriod.periodEnd.After(now) {
@@ -350,59 +347,83 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 			op.enqueueReportAfter(report, waitTime)
 			return nil
 		}
-	}
 
-	var unmetDataSourceDependendencies []string
-	// validate all ReportDataSources that the Report depends on have indicated
-	// they have data available that covers the current reportingPeriod
-	for _, dataSource := range queryDependencies.ReportDataSources {
-		if dataSource.Spec.Promsum != nil {
-			if dataSource.Status.PrometheusMetricImportStatus == nil || dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime == nil || dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime.Time.Before(reportPeriod.periodEnd) {
-				// queue the dataSource and store the list of reports so we can
-				// add information to the Report's status on what's currently
-				// not ready
-				op.enqueueReportDataSource(dataSource)
-				unmetDataSourceDependendencies = append(unmetDataSourceDependendencies, dataSource.Name)
+		var unmetDataStartDataSourceDependendencies, unmetDataEndDataSourceDependendencies []string
+		// Validate all ReportDataSources that the Report depends on have indicated
+		// they have data available that covers the current reportPeriod.
+		for _, dataSource := range queryDependencies.ReportDataSources {
+			if dataSource.Spec.Promsum != nil {
+				if dataSource.Status.PrometheusMetricImportStatus != nil {
+					// queue the dataSource and store the list of reports so we can
+					// add information to the Report's status on what's currently
+					// not ready
+					queue := false
+					// reportPeriod lower bound not covered
+					if dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime == nil || reportPeriod.periodStart.Before(dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime.Time) {
+						queue = true
+						unmetDataStartDataSourceDependendencies = append(unmetDataStartDataSourceDependendencies, dataSource.Name)
+					}
+					// reportPeriod upper bound is not covered
+					if dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime == nil || reportPeriod.periodEnd.After(dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime.Time) {
+						queue = true
+						unmetDataEndDataSourceDependendencies = append(unmetDataEndDataSourceDependendencies, dataSource.Name)
+					}
+					if queue {
+						op.enqueueReportDataSource(dataSource)
+					}
+				}
 			}
 		}
+
+		// Validate all sub-reports that the Report depends on have reported on the
+		// current reportPeriod
+		var unmetReportDependendencies []string
+		for _, subReport := range queryDependencies.Reports {
+			if subReport.Status.LastReportTime != nil || subReport.Status.LastReportTime.Time.Before(reportPeriod.periodEnd) {
+				op.enqueueReport(subReport)
+				unmetReportDependendencies = append(unmetReportDependendencies, subReport.Name)
+			}
+		}
+
+		if len(unmetDataStartDataSourceDependendencies) != 0 || len(unmetDataEndDataSourceDependendencies) != 0 || len(unmetReportDependendencies) != 0 {
+			unmetMsg := "The following Report dependencies do not have data currently available for the current reportPeriod being processed:"
+			if len(unmetDataStartDataSourceDependendencies) != 0 || len(unmetDataEndDataSourceDependendencies) != 0 {
+				var msgs []string
+				if len(unmetDataStartDataSourceDependendencies) != 0 {
+					// sort so the message is reproducible
+					sort.Strings(unmetDataStartDataSourceDependendencies)
+					msgs = append(msgs, fmt.Sprintf("periodStart %s is before importDataStartTime of [%s]", reportPeriod.periodStart, strings.Join(unmetDataStartDataSourceDependendencies, ", ")))
+				}
+				if len(unmetDataEndDataSourceDependendencies) != 0 {
+					// sort so the message is reproducible
+					sort.Strings(unmetDataEndDataSourceDependendencies)
+					msgs = append(msgs, fmt.Sprintf("periodEnd %s is after importDataEndTime of [%s]", reportPeriod.periodEnd, strings.Join(unmetDataEndDataSourceDependendencies, ", ")))
+				}
+				unmetMsg += fmt.Sprintf(" ReportDataSources: %s", strings.Join(msgs, ", "))
+			}
+			if len(unmetReportDependendencies) != 0 {
+				// sort so the message is reproducible
+				sort.Strings(unmetReportDependendencies)
+				unmetMsg += fmt.Sprintf(" Reports: lastReportTime not prior to periodEnd %s: [%s]", reportPeriod.periodEnd, strings.Join(unmetReportDependendencies, ", "))
+			}
+
+			// If the previous condition is unmet dependencies, check if the
+			// message changes, and only update if it does
+			if runningCond != nil && runningCond.Status == v1.ConditionFalse && runningCond.Reason == cbutil.ReportingPeriodUnmetDependenciesReason && runningCond.Message == unmetMsg {
+				logger.Debugf("Report %s already has Running condition=false with reason=%s and unchanged message, skipping update", report.Name, cbutil.ReportingPeriodUnmetDependenciesReason)
+				return nil
+			}
+			logger.Warnf(unmetMsg)
+			_, err := op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionFalse, cbutil.ReportingPeriodUnmetDependenciesReason, unmetMsg))
+			return err
+		}
+
+		runningReason = cbutil.ScheduledReason
+		runningMsg = fmt.Sprintf("Report %s scheduled: reached end of reporting period [%s to %s].", report.Name, reportPeriod.periodStart, reportPeriod.periodEnd)
 	}
-
-	var unmetReportDependendencies []string
-	for _, subReport := range queryDependencies.Reports {
-		if subReport.Status.LastReportTime != nil || subReport.Status.LastReportTime.Time.Before(reportPeriod.periodEnd) {
-			op.enqueueReport(subReport)
-			unmetReportDependendencies = append(unmetReportDependendencies, subReport.Name)
-		}
-	}
-
-	if len(unmetDataSourceDependendencies) != 0 || len(unmetReportDependendencies) != 0 {
-		unmetMsg := "The following Report dependencies do not have data currently available for the reportPeriod being processed: "
-		if len(unmetDataSourceDependendencies) != 0 {
-			// sort so the message is reproducible
-			sort.Strings(unmetDataSourceDependendencies)
-			unmetMsg += fmt.Sprintf("ReportDataSources: %s.", strings.Join(unmetDataSourceDependendencies, ", "))
-		}
-		if len(unmetReportDependendencies) != 0 {
-			// sort so the message is reproducible
-			sort.Strings(unmetReportDependendencies)
-			unmetMsg += fmt.Sprintf(" Reports: %s.", strings.Join(unmetReportDependendencies, ", "))
-		}
-
-		// If the previous condition is unmet dependencies, check if the
-		// message changes, and only update if it does
-		if runningCond != nil && runningCond.Status == v1.ConditionFalse && runningCond.Reason == cbutil.ReportingPeriodUnmetDependenciesReason && runningCond.Message == unmetMsg {
-			logger.Debugf("Report %s already has Running condition=false with reason=%s and unchanged message, skipping update", report.Name, cbutil.ReportingPeriodUnmetDependenciesReason)
-			return nil
-		}
-		logger.Warnf(unmetMsg)
-		_, err := op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionFalse, cbutil.ReportingPeriodUnmetDependenciesReason, unmetMsg))
-		return err
-	}
-
-	runningMsg := fmt.Sprintf("Report Scheduled: reached end of reporting period [%s to %s].", reportPeriod.periodStart, reportPeriod.periodEnd)
 	logger.Infof(runningMsg + " Running now.")
 
-	report, err = op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionTrue, cbutil.ScheduledReason, runningMsg))
+	report, err = op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionTrue, runningReason, runningMsg))
 	if err != nil {
 		return err
 	}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -290,8 +290,8 @@ func TestReportingProducesCorrectDataForInput(t *testing.T) {
 				reportStartStr := reportStart.UTC().Format(time.RFC3339)
 				nowStr := time.Now().UTC().Format(time.RFC3339)
 				jsonPatch := []byte(fmt.Sprintf(
-					`[{ "op": "add", "path": "/status/prometheusMetricImportStatus", "value": { "importDataEndTime": "%s", "earliestImportedMetricTime": "%s", "newestImportedMetricTime": "%s", "lastImportTime": "%s" } } ]`,
-					reportEndStr, reportStartStr, reportEndStr, nowStr))
+					`[{ "op": "add", "path": "/status/prometheusMetricImportStatus", "value": { "importDataStartTime": "%s", "importDataEndTime": "%s", "earliestImportedMetricTime": "%s", "newestImportedMetricTime": "%s", "lastImportTime": "%s" } } ]`,
+					reportStartStr, reportEndStr, reportStartStr, reportEndStr, nowStr))
 				_, err = testFramework.MeteringClient.ReportDataSources(testFramework.Namespace).Patch(dataSource.DatasourceName, types.JSONPatchType, jsonPatch)
 				require.NoError(t, err)
 


### PR DESCRIPTION
When spec.runImmediately is true, it should cause the report to run, regardless of data collected.
Additionally, the status message now provides more details on why a dependency isn't met.