### PR TITLE
pkg/operator: Allow triggering ReportDataSource collection for individual ReportDataSource

### DIFF
--- a/pkg/operator/http.go
+++ b/pkg/operator/http.go
@@ -93,6 +93,7 @@ func newRouter(
 	router.HandleFunc(APIV2ReportsEndpointPrefix+"/{namespace}/{name}/table", srv.getReportV2TableHandler)
 	router.HandleFunc(APIV1ReportsGetEndpoint, srv.getReportV1Handler)
 	router.HandleFunc("/api/v1/datasources/prometheus/collect/{namespace}", srv.collectPromsumDataHandler)
+	router.HandleFunc("/api/v1/datasources/prometheus/collect/{namespace}/{datasourceName}", srv.collectPromsumDataHandler)
 	router.HandleFunc("/api/v1/datasources/prometheus/store/{namespace}/{datasourceName}", srv.storePromsumDataHandler)
 	router.HandleFunc("/api/v1/datasources/prometheus/fetch/{namespace}/{datasourceName}", srv.fetchPromsumDataHandler)
 
@@ -493,6 +494,7 @@ func (srv *server) collectPromsumDataHandler(w http.ResponseWriter, r *http.Requ
 	logger := newRequestLogger(srv.logger, r, srv.rand)
 
 	namespace := chi.URLParam(r, "namespace")
+	dsName := chi.URLParam(r, "datasource")
 
 	decoder := json.NewDecoder(r.Body)
 	var req CollectPromsumDataRequest
@@ -507,7 +509,7 @@ func (srv *server) collectPromsumDataHandler(w http.ResponseWriter, r *http.Requ
 
 	logger.Debugf("collecting promsum data for ReportDataSources in namespace %s between %s and %s", namespace, start.Format(time.RFC3339), end.Format(time.RFC3339))
 
-	results, err := srv.collectorFunc(context.Background(), namespace, start, end)
+	results, err := srv.collectorFunc(context.Background(), namespace, dsName, start, end)
 	if err != nil {
 		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to collect prometheus data: %v", err)
 		return

--- a/pkg/operator/http_test.go
+++ b/pkg/operator/http_test.go
@@ -31,7 +31,7 @@ import (
 var (
 	testRandSeed               = rand.NewSource(0)
 	testRand                   = rand.New(testRandSeed)
-	noopPrometheusImporterFunc = func(ctx context.Context, namespace string, start, end time.Time) ([]*prometheusImportResults, error) {
+	noopPrometheusImporterFunc = func(ctx context.Context, namespace, dsName string, start, end time.Time) ([]*prometheusImportResults, error) {
 		return nil, nil
 	}
 	testLogger = logrus.New()

--- a/pkg/operator/promsum.go
+++ b/pkg/operator/promsum.go
@@ -153,7 +153,7 @@ func init() {
 	prometheus.MustRegister(prometheusReportDatasourceRunningImportsGauge)
 }
 
-type prometheusImporterFunc func(ctx context.Context, namespace string, start, end time.Time) ([]*prometheusImportResults, error)
+type prometheusImporterFunc func(ctx context.Context, namespace, dsName string, start, end time.Time) ([]*prometheusImportResults, error)
 
 type prometheusImportResults struct {
 	ReportDataSource     string `json:"reportDataSource"`
@@ -161,7 +161,7 @@ type prometheusImportResults struct {
 	MetricsImportedCount int    `json:"metricsImportedCount"`
 }
 
-func (op *Reporting) importPrometheusForTimeRange(ctx context.Context, namespace string, start, end time.Time) ([]*prometheusImportResults, error) {
+func (op *Reporting) importPrometheusForTimeRange(ctx context.Context, namespace, dsName string, start, end time.Time) ([]*prometheusImportResults, error) {
 	reportDataSources, err := op.meteringClient.MeteringV1alpha1().ReportDataSources(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -179,6 +179,10 @@ func (op *Reporting) importPrometheusForTimeRange(ctx context.Context, namespace
 	for _, reportDataSource := range reportDataSources.Items {
 		reportDataSource := reportDataSource
 		if reportDataSource.Spec.Promsum == nil {
+			continue
+		}
+
+		if dsName != "" && dsName != reportDataSource.Name {
 			continue
 		}
 


### PR DESCRIPTION
This is an initial step to make it easier to backfill historical data after installation. This allows manually triggering data collect for a single ReportDataSource. Currently we only have an API for triggering a  collection for all reportDataSources.