### PR TITLE
charts/presto: Add initial support for configuring extra Presto connectors

### DIFF
--- a/charts/presto/templates/presto-catalog-config-secret.yaml
+++ b/charts/presto/templates/presto-catalog-config-secret.yaml
@@ -10,3 +10,6 @@ type: Opaque
 data:
   hive.properties: "{{ include "presto-hive-catalog-properties" . | b64enc }}"
   jmx.properties: "{{ include "presto-jmx-catalog-properties" . | b64enc }}"
+{{- range $_, $connector := .Values.spec.presto.config.connectors.extraConnectorFiles }}
+  {{ $connector.name }}: "{{ $connector.content | b64enc }}"
+{{- end }}

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -16,6 +16,9 @@ spec:
       nodeSchedulerIncludeCoordinator: true
       metastoreTimeout: null
 
+      connectors:
+        extraConnectorFiles: []
+
     coordinator:
       terminationGracePeriodSeconds: 30
       config:


### PR DESCRIPTION
I tested this manually out, and it works. I'm throwing this up @JooyoungJeong can try to access MySQL in Presto/metering. Currently it has no integration with anything, but my WIP rewrite of storage and table CRs will help with that sooner.

The idea is you could specify extra configuration for (Presto connectors)(https://prestodb.github.io/docs/current/connector.html) by providing a metering config like so:

```
apiVersion: metering.openshift.io/v1alpha1
kind: Metering
metadata:
  name: "operator-metering"
spec:
  presto:
    spec:
      presto:
        image:
          tag: pr-650
        config:
          connectors:
            extraConnectorFiles:
            - name: "mysql.properties"
              content: |
                connector.name=mysql
                connection-url=jdbc:mysql://example.net:3306
                connection-user=root
                connection-password=secret

```
