### PR TITLE
test/e2e: Check ReportDataSources for EarliestImportedMetricTime to determine reportStart

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
@@ -117,10 +116,5 @@ func TestReportingProducesData(t *testing.T) {
 		reportsProduceDataTestCases = append(reportsProduceDataTestCases, reportcronTestCase, reportRunOnceTestCase)
 	}
 
-	// Align to the nearest minute
-	periodEnd := time.Now().UTC().Truncate(time.Minute)
-	// start the report 5 minutes ago
-	periodStart := periodEnd.Add(-5 * time.Minute)
-
-	testReportsProduceData(t, testFramework, periodStart, periodEnd, reportsProduceDataTestCases)
+	testReportsProduceData(t, testFramework, reportsProduceDataTestCases)
 }

--- a/test/e2e/report_test.go
+++ b/test/e2e/report_test.go
@@ -5,8 +5,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	meteringv1alpha1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	"github.com/operator-framework/operator-metering/pkg/operator/reporting"
 	"github.com/operator-framework/operator-metering/test/framework"
 )
 
@@ -19,8 +21,7 @@ type reportProducesDataTestCase struct {
 	parallel      bool
 }
 
-func testReportsProduceData(t *testing.T, testFramework *framework.Framework, reportStart, reportEnd time.Time, testCases []reportProducesDataTestCase) {
-	t.Logf("reportStart: %s, reportEnd: %s", reportStart, reportEnd)
+func testReportsProduceData(t *testing.T, testFramework *framework.Framework, testCases []reportProducesDataTestCase) {
 	for _, test := range testCases {
 		name := test.name
 		// Fix closure captures
@@ -33,6 +34,51 @@ func testReportsProduceData(t *testing.T, testFramework *framework.Framework, re
 			if test.parallel {
 				t.Parallel()
 			}
+
+			genQuery, err := testFramework.GetMeteringReportGenerationQuery(test.queryName)
+			require.NoError(t, err, "generation query for report should exist")
+
+			dsGetter := reporting.NewReportDataSourceClientGetter(testFramework.MeteringClient)
+			queryGetter := reporting.NewReportGenerationQueryClientGetter(testFramework.MeteringClient)
+			reportGetter := reporting.NewReportClientGetter(testFramework.MeteringClient)
+
+			// get all the datasources for the query used in our report
+			dependencies, err := reporting.GetGenerationQueryDependencies(queryGetter, dsGetter, reportGetter, genQuery)
+			require.NoError(t, err, "datasources for query should exist")
+
+			require.NotEqual(t, 0, len(dependencies.ReportDataSources), "Report should have at least 1 datasource dependency")
+
+			var reportStart time.Time
+
+			// for each datasource, wait until it's EarliestImportedMetricTime is set
+			for _, ds := range dependencies.ReportDataSources {
+				_, err := testFramework.WaitForMeteringReportDataSource(t, ds.Name, 5*time.Second, 5*time.Minute, func(dataSource *meteringv1alpha1.ReportDataSource) (bool, error) {
+					if dataSource.Spec.Promsum == nil {
+						return true, nil
+					}
+					if dataSource.Status.PrometheusMetricImportStatus != nil && dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime != nil {
+						// keep the EarliestImportedMetricTime that is the
+						// least far back, so that we ensure the reportStart is
+						// a time that all datasources have metrics for.
+						if reportStart.IsZero() || dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime.Time.After(reportStart) {
+							reportStart = dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime.Time
+						}
+						return true, nil
+					}
+					return false, nil
+				})
+				require.NoError(t, err, "expected ReportDataSource %s to have an earliestImportedMetricTime", ds.Name)
+			}
+
+			if reportStart.IsZero() {
+				t.Errorf("reportStart is zero")
+			}
+
+			reportStart = reportStart.UTC()
+			// The report spans 5 minutes
+			reportEnd := reportStart.Add(5 * time.Minute).UTC()
+
+			t.Logf("reportStart: %s, reportEnd: %s", reportStart, reportEnd)
 
 			report := test.newReportFunc(test.name, test.queryName, test.schedule, &reportStart, &reportEnd)
 			reportRunTimeout := 10 * time.Minute


### PR DESCRIPTION
Improves e2e reliability by looking at the datasources for each Report, and finding a time that all reportDataSources for the Report have in common, and uses that as the reportingStart, and sets reportingEnd to 5 minutes after that. This ensures e2e always runs using a period of time that is covered by the ReportDataSources.