### PR TITLE
charts/presto: Make HIVE_HOME /opt/hive and set /opt/hive/conf to emptyDir

### DIFF
--- a/charts/presto/templates/_helpers.tpl
+++ b/charts/presto/templates/_helpers.tpl
@@ -82,4 +82,6 @@ connector.name=jmx
       name: "{{ .Values.spec.config.awsCredentialsSecretName }}"
       key: aws-secret-access-key
       optional: true
+- name: HIVE_HOME
+  value: /opt/hive
 {{- end }}

--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -93,6 +93,8 @@ spec:
         - name: hdfs-config
           mountPath: /hadoop-config
 {{- end }}
+        - name: hive-home-conf
+          mountPath: /opt/hive/conf
         - name: hive-metastore-db-data
           mountPath: /var/lib/hive
         # openshift requires volumeMounts for VOLUMEs in a Dockerfile
@@ -131,6 +133,8 @@ spec:
         configMap:
           name: {{ .Values.spec.hive.config.hdfsConfigMapName }}
 {{- end }}
+      - name: hive-home-conf
+        emptyDir: {}
       # these emptyDir volumes are necessary because Openshift requires VOLUMEs
       # in a Dockerfile have a corresponding volumeMount
       - name: hive-warehouse-empty

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -97,6 +97,8 @@ spec:
         - name: hdfs-config
           mountPath: /hadoop-config
 {{- end}}
+        - name: hive-home-conf
+          mountPath: /opt/hive/conf
         # openshift requires volumeMounts for VOLUMEs in a Dockerfile
         - name: hive-metastore-db-data
           mountPath: /var/lib/hive
@@ -135,6 +137,8 @@ spec:
         configMap:
           name: {{ .Values.spec.hive.config.hdfsConfigMapName }}
 {{- end }}
+      - name: hive-home-conf
+        emptyDir: {}
       # these emptyDir volumes are necessary because Openshift requires VOLUMEs
       # in a Dockerfile have a corresponding volumeMount
       - name: hive-warehouse-empty


### PR DESCRIPTION
Ensures that we have a writable tmpfs for our configfiles which get
symlinked in at runtime. This ensures that even with a read only rootfs,
we can symlink the config files to the correct location.