### PR TITLE
pkg/operator: Fix metrics importing tracking

### DIFF
--- a/pkg/operator/prestostore/query.go
+++ b/pkg/operator/prestostore/query.go
@@ -113,6 +113,10 @@ func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn 
 		}
 
 		if numMetrics != 0 {
+			// Ensure the metrics are sorted by timestamp
+			sort.Slice(metrics, func(i, j int) bool {
+				return metrics[i].Timestamp.Before(metrics[j].Timestamp)
+			})
 			metricsBegin := metrics[0].Timestamp
 			metricsEnd := metrics[numMetrics-1].Timestamp
 			logger := promLogger.WithFields(logrus.Fields{
@@ -132,12 +136,8 @@ func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn 
 				return importResults, fmt.Errorf("failed to store Prometheus metrics into table %s for the range %v to %v: %v",
 					cfg.PrestoTableName, promQueryBegin, promQueryEnd, err)
 			}
-			// Ensure the metrics are sorted by timestamp
-			sort.Slice(metrics, func(i, j int) bool {
-				return metrics[i].Timestamp.Before(metrics[j].Timestamp)
-			})
-			importResults.Metrics = metrics
 			logger.Debugf("stored %d metrics for time range %s to %s into Presto table %s (took %s)", numMetrics, promQueryBegin, promQueryEnd, cfg.PrestoTableName, prestoStoreDuration)
+			importResults.Metrics = append(importResults.Metrics, metrics...)
 			metricsCollectors.MetricsImportedCounter.Add(float64(numMetrics))
 			metricsCount += numMetrics
 		}


### PR DESCRIPTION
We were overwriting the metrics slice in importResults rather than appending to it, this fixes that. We also sort sooner to ensure the metricBegin/metricsEnd log message fields are accurate.