### PR TITLE
Use `namespace` label if `exported_namespace` metric label is missing in PVC queries

### DIFF
--- a/charts/openshift-reporting/templates/report-queries/persistentvolumeclaim-capacity.yaml
+++ b/charts/openshift-reporting/templates/report-queries/persistentvolumeclaim-capacity.yaml
@@ -33,7 +33,7 @@ spec:
     type: string
   query: |
     SELECT
-        element_at(labels, 'exported_namespace') as namespace,
+        coalesce(element_at(labels, 'exported_namespace'), element_at(labels, 'namespace')) as namespace,
         labels['persistentvolumeclaim'] as persistentvolumeclaim,
         labels,
         amount as persistentvolumeclaim_capacity_bytes,

--- a/charts/openshift-reporting/templates/report-queries/persistentvolumeclaim-usage.yaml
+++ b/charts/openshift-reporting/templates/report-queries/persistentvolumeclaim-usage.yaml
@@ -78,7 +78,7 @@ spec:
     type: string
   query: |
     SELECT
-        element_at(labels, 'exported_namespace') as namespace,
+        coalesce(element_at(labels, 'exported_namespace'), element_at(labels, 'namespace')) as namespace,
         labels['persistentvolumeclaim'] as persistentvolumeclaim,
         labels,
         amount as persistentvolumeclaim_usage_bytes,


### PR DESCRIPTION
Be compatible with newer versions of kube/prometheus which uses
"namespace" instead of "exported_namespace" in it's
kubelet_volume_stats_* metrics.