### PR TITLE
pkg/operator: Fix small linting errors and remove unneeded code.

### DIFF
--- a/pkg/operator/http.go
+++ b/pkg/operator/http.go
@@ -49,9 +49,9 @@ type server struct {
 	prometheusMetricsRepo prestostore.PrometheusMetricsRepo
 	reportResultsGetter   prestostore.ReportResultsGetter
 
-	reportLister                 listers.ReportLister
-	reportGenerationQuerieLister listers.ReportGenerationQueryLister
-	prestoTableLister            listers.PrestoTableLister
+	reportLister                listers.ReportLister
+	reportGenerationQueryLister listers.ReportGenerationQueryLister
+	prestoTableLister           listers.PrestoTableLister
 }
 
 type requestLogger struct {
@@ -69,7 +69,7 @@ func newRouter(
 	reportResultsGetter prestostore.ReportResultsGetter,
 	collectorFunc prometheusImporterFunc,
 	reportLister listers.ReportLister,
-	reportGenerationQuerieLister listers.ReportGenerationQueryLister,
+	reportGenerationQueryLister listers.ReportGenerationQueryLister,
 	prestoTableLister listers.PrestoTableLister,
 ) chi.Router {
 	router := chi.NewRouter()
@@ -79,14 +79,14 @@ func newRouter(
 	router.Use(prometheusMiddleware)
 
 	srv := &server{
-		logger:                       logger,
-		rand:                         rand,
-		collectorFunc:                collectorFunc,
-		prometheusMetricsRepo:        prometheusMetricsRepo,
-		reportResultsGetter:          reportResultsGetter,
-		reportLister:                 reportLister,
-		reportGenerationQuerieLister: reportGenerationQuerieLister,
-		prestoTableLister:            prestoTableLister,
+		logger:                      logger,
+		rand:                        rand,
+		collectorFunc:               collectorFunc,
+		prometheusMetricsRepo:       prometheusMetricsRepo,
+		reportResultsGetter:         reportResultsGetter,
+		reportLister:                reportLister,
+		reportGenerationQueryLister: reportGenerationQueryLister,
+		prestoTableLister:           prestoTableLister,
 	}
 
 	router.HandleFunc(APIV2ReportsEndpointPrefix+"/{namespace}/{name}/full", srv.getReportV2FullHandler)
@@ -194,7 +194,7 @@ func (srv *server) getReport(logger log.FieldLogger, name, namespace, format str
 		}
 	}
 
-	reportQuery, err := srv.reportGenerationQuerieLister.ReportGenerationQueries(report.Namespace).Get(report.Spec.GenerationQueryName)
+	reportQuery, err := srv.reportGenerationQueryLister.ReportGenerationQueries(report.Namespace).Get(report.Spec.GenerationQueryName)
 	if err != nil {
 		logger.WithError(err).Errorf("error getting report: %v", err)
 		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "error getting report: %v", err)
@@ -321,7 +321,7 @@ func writeResultsAsCSV(columns []api.ReportGenerationQueryColumn, results []pres
 func writeResultsResponseAsTabular(logger log.FieldLogger, name string, columns []api.ReportGenerationQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/tab-separated-values")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment;filename=%s.tsv", name))
-	var padding int = 2
+	padding := 2
 	paddingStr := r.FormValue("padding")
 	if paddingStr != "" {
 		var err error

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -109,7 +109,7 @@ func getSchedule(reportSched *cbTypes.ReportSchedule) (reportSchedule, error) {
 	switch reportSched.Period {
 	case cbTypes.ReportPeriodCron:
 		if reportSched.Cron == nil || reportSched.Cron.Expression == "" {
-			return nil, fmt.Errorf("spec.schedule.cron.expression must be specified!")
+			return nil, fmt.Errorf("spec.schedule.cron.expression must be specified")
 		}
 		return cron.ParseStandard(reportSched.Cron.Expression)
 	case cbTypes.ReportPeriodHourly:

--- a/pkg/operator/storage.go
+++ b/pkg/operator/storage.go
@@ -62,6 +62,7 @@ func (op *Reporting) getStorageSpec(logger log.FieldLogger, storage *cbTypes.Sto
 	} else if storage.StorageSpec != nil { // Storage location is inlined in the datastore
 		storageSpec = *storage.StorageSpec
 	}
+
 	return storageSpec, nil
 }
 
@@ -73,7 +74,7 @@ func (op *Reporting) getHiveTableProperties(logger log.FieldLogger, storage *cbT
 	if storageSpec.Hive != nil {
 		props := hive.TableProperties(storageSpec.Hive.TableProperties)
 		return &props, nil
-	} else {
-		return nil, fmt.Errorf("incorrect storage configuration, must configure spec.hive")
 	}
+
+	return nil, fmt.Errorf("incorrect storage configuration, must configure spec.hive")
 }


### PR DESCRIPTION
This would remove an unneeded `else` condition when the accompanied `if` statement returns a value.

Removes any declared type when initializing a variable using the `var` keyword.