### PR TITLE
Fix go vet errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,11 @@ e2e-docker: metering-src-docker-build
 	docker cp metering-e2e-docker:/out bin/e2e-docker-test-output
 	docker rm metering-e2e-docker
 
+vet:
+	go vet $(GO_PKG)/cmd/... $(GO_PKG)/pkg/...
+
 # validates no unstaged changes exist in $(VERIFY_FILE_PATHS)
-verify: verify-codegen all-charts verify-manifests fmt
+verify: verify-codegen all-charts verify-manifests fmt vet
 	@echo Checking for unstaged changes
 	git diff --stat HEAD --ignore-submodules --exit-code -- $(VERIFY_FILE_PATHS)
 

--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -190,7 +190,7 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 	}
 
 	// record the lastImportTime
-	dataSource.Status.PrometheusMetricImportStatus.LastImportTime = &metav1.Time{op.clock.Now().UTC()}
+	dataSource.Status.PrometheusMetricImportStatus.LastImportTime = &metav1.Time{Time: op.clock.Now().UTC()}
 
 	// run the import
 	results, err := importer.ImportFromLastTimestamp(context.Background(), allowIncompleteChunks)
@@ -213,12 +213,12 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 		// Update the timestamp which records the first timestamp we attempted
 		// to query from.
 		if dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime == nil || firstTimeRange.Start.Before(dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime.Time) {
-			dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime = &metav1.Time{firstTimeRange.Start}
+			dataSource.Status.PrometheusMetricImportStatus.ImportDataStartTime = &metav1.Time{Time: firstTimeRange.Start}
 		}
 		// Update the timestamp which records the latest we've attempted to query
 		// up until.
 		if dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime == nil || dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime.Time.Before(lastTimeRange.End) {
-			dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime = &metav1.Time{lastTimeRange.End}
+			dataSource.Status.PrometheusMetricImportStatus.ImportDataEndTime = &metav1.Time{Time: lastTimeRange.End}
 		}
 
 		// The data we collected is farther back than 1.5 their chunkSize, so requeue sooner
@@ -244,7 +244,7 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 			// if there is no existing timestamp then this must be the first import
 			// and we should set the earliestImportedMetricTime
 			if dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime == nil {
-				dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime = &metav1.Time{firstMetric.Timestamp}
+				dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime = &metav1.Time{Time: firstMetric.Timestamp}
 			} else if dataSource.Status.PrometheusMetricImportStatus.EarliestImportedMetricTime.After(firstMetric.Timestamp) {
 				dataSourceLogger.Errorf("detected time new metric import has older data than previously imported, data is likely duplicated.")
 				// TODO(chance): Look at adding an error to the status.
@@ -252,7 +252,7 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 			}
 
 			if dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime == nil || lastMetric.Timestamp.After(dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime.Time) {
-				dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime = &metav1.Time{lastMetric.Timestamp}
+				dataSource.Status.PrometheusMetricImportStatus.NewestImportedMetricTime = &metav1.Time{Time: lastMetric.Timestamp}
 			}
 
 			if err := op.queueDependentReportGenerationQueriesForDataSource(dataSource); err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -532,7 +532,7 @@ func (op *Reporting) Run(ctx context.Context) error {
 			OnStartedLeading: func(ctx context.Context) {
 				op.logger.Infof("became leader")
 				op.logger.Info("starting Metering workers")
-				op.startWorkers(wg, ctx)
+				op.startWorkers(&wg, ctx)
 				op.logger.Infof("Metering workers started, watching for reports...")
 			},
 			OnStoppedLeading: func() {
@@ -641,7 +641,7 @@ func (op *Reporting) newPrometheusConnFromURL(url string) (prom.API, error) {
 	})
 }
 
-func (op *Reporting) startWorkers(wg sync.WaitGroup, ctx context.Context) {
+func (op *Reporting) startWorkers(wg *sync.WaitGroup, ctx context.Context) {
 	stopCh := ctx.Done()
 
 	wg.Add(1)

--- a/pkg/operator/prestostore/prometheusmetric.go
+++ b/pkg/operator/prestostore/prometheusmetric.go
@@ -86,7 +86,7 @@ type PrometheusMetricsRepo interface {
 
 type prometheusMetricRepo struct {
 	queryer         db.Queryer
-	queryBufferPool sync.Pool
+	queryBufferPool *sync.Pool
 }
 
 func NewPrometheusMetricsRepo(queryer db.Queryer, queryBufferPool *sync.Pool) *prometheusMetricRepo {
@@ -95,7 +95,7 @@ func NewPrometheusMetricsRepo(queryer db.Queryer, queryBufferPool *sync.Pool) *p
 	}
 	return &prometheusMetricRepo{
 		queryer:         queryer,
-		queryBufferPool: *queryBufferPool,
+		queryBufferPool: queryBufferPool,
 	}
 }
 

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -298,7 +298,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 				currentPeriod := getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, now)
 				// the next full report period from [nextScheduledTime, nextScheduledTime+1]
 				reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, currentPeriod.periodEnd)
-				report.Status.NextReportTime = &metav1.Time{reportPeriod.periodStart}
+				report.Status.NextReportTime = &metav1.Time{Time: reportPeriod.periodStart}
 			}
 		}
 	} else {


### PR DESCRIPTION
Fixes some errors reported by go vet. The copylock ones could be potentially
cause panics. I added this to our Makefile's verify target to ensure we keep
things correct.