### PR TITLE
pkg/operator: Refactor the checks/validations in runReport into individual functions and add their unit tests.

### DIFF
--- a/pkg/operator/http_test.go
+++ b/pkg/operator/http_test.go
@@ -115,7 +115,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 	}{
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
 					Name: "timestamp",
@@ -143,7 +143,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
 					Name: "timestamp",
@@ -184,7 +184,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
 					Name: "timestamp",
@@ -229,7 +229,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
 					Name: "timestamp",
@@ -385,7 +385,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 	}{
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
@@ -435,7 +435,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
@@ -466,7 +466,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
@@ -515,7 +515,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-format-not-specified": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:               apiReportV2URLFull(namespace, testReportName),
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: format",
@@ -524,7 +524,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-format-non-existent": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:               apiReportV2URLFull(namespace, testReportName) + "?format=doesntexist",
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "format must be one of: csv, json or tabular",
@@ -533,7 +533,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
@@ -667,7 +667,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 	}{
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
@@ -719,7 +719,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
@@ -750,7 +750,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{
@@ -799,7 +799,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-format-not-specified": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:               apiReportV2URLTable(namespace, testReportName),
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: format",
@@ -808,7 +808,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-format-non-existent": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:               apiReportV2URLTable(namespace, testReportName) + "?format=doesntexist",
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "format must be one of: csv, json or tabular",
@@ -817,7 +817,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportGenerationQuery(testQueryName, namespace, []v1alpha1.ReportGenerationQueryColumn{
 				{

--- a/pkg/operator/reporting/validate_test.go
+++ b/pkg/operator/reporting/validate_test.go
@@ -23,10 +23,10 @@ func TestValidateGenerationQueryDependencies(t *testing.T) {
 	dataSourceTableSet := testhelpers.NewReportDataSource("initialized-datasource", "default")
 	dataSourceTableSet.Status.TableName = reportingutil.DataSourceTableName("test-ns", "initialized-datasource")
 
-	reportTableUnset := testhelpers.NewReport("uninitialized-report", "default", "some-query", nil, nil, metering.ReportStatus{})
+	reportTableUnset := testhelpers.NewReport("uninitialized-report", "default", "some-query", nil, nil, metering.ReportStatus{}, nil, false)
 	reportTableSet := testhelpers.NewReport("initialized-report", "default", "some-query", nil, nil, metering.ReportStatus{
 		TableName: reportingutil.ReportTableName("test-ns", "initialized-report"),
-	})
+	}, nil, false)
 
 	// we keep a set of our test objects here since we re-use them in different
 	// combinations in the test cases

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -207,11 +208,8 @@ type reportPeriod struct {
 	periodStart time.Time
 }
 
-// runReport takes a report, and generates reporting data
-// according the report's schedule. If the next scheduled reporting period
-// hasn't elapsed, runReport will requeue the resource for a time when
-// the period has elapsed.
-func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) error {
+// isReportFinished checks the running condition of the report parameter and returns true if the report has previously run
+func isReportFinished(logger log.FieldLogger, report *cbTypes.Report) bool {
 	// check if this report was previously finished
 	runningCond := cbutil.GetReportCondition(report.Status, cbTypes.ReportRunning)
 
@@ -222,7 +220,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 		// re-processing runOnce reports after they're previously finished
 		if report.Spec.Schedule == nil {
 			logger.Infof("Report %s is a previously finished run-once report, not re-processing", report.Name)
-			return nil
+			return true
 		}
 		// log some messages to indicate we're processing what was a previously finished report
 
@@ -236,43 +234,77 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 		} else {
 			// return without processing because the report is complete
 			logger.Infof("Report %s is already finished: %s", report.Name, runningCond.Message)
-			return nil
+			return true
 		}
 	}
 
+	return false
+}
+
+// validateReport takes a Report structure and checks if it contains valid fields
+func validateReport(
+	report *cbTypes.Report,
+	queryGetter reporting.ReportGenerationQueryGetter,
+	reportDataSourceGetter reporting.ReportDataSourceGetter,
+	reportGetter reporting.ReportGetter, handler *reporting.UninitialiedDependendenciesHandler,
+) (*cbTypes.ReportGenerationQuery, *reporting.ReportGenerationQueryDependencies, error) {
 	// Validate the ReportGenerationQuery is set
 	if report.Spec.GenerationQueryName == "" {
-		return op.setReportStatusInvalidReport(report, "must set spec.generationQuery")
-	}
-	// Validate the reportingStart and reportingEnd make sense and are set when
-	// required.
-	if report.Spec.ReportingStart != nil && report.Spec.ReportingEnd != nil && (report.Spec.ReportingStart.Time.After(report.Spec.ReportingEnd.Time) || report.Spec.ReportingStart.Time.Equal(report.Spec.ReportingEnd.Time)) {
-		return op.setReportStatusInvalidReport(report, fmt.Sprintf("spec.reportingEnd (%s) must be after spec.reportingStart (%s)", report.Spec.ReportingEnd.Time, report.Spec.ReportingStart.Time))
-	}
-	if report.Spec.ReportingEnd == nil && report.Spec.RunImmediately {
-		return op.setReportStatusInvalidReport(report, "spec.reportingEnd must be set if report.spec.runImmediately is true")
+		return nil, nil, errors.New("must set spec.generationQuery")
 	}
 
-	// Validate the ReportGenerationQuery used exists
-	genQuery, err := op.getReportGenerationQueryForReport(report)
+	// Validate the reportingStart and reportingEnd make sense and are set when
+	// required
+	if report.Spec.ReportingStart != nil && report.Spec.ReportingEnd != nil && (report.Spec.ReportingStart.Time.After(report.Spec.ReportingEnd.Time) || report.Spec.ReportingStart.Time.Equal(report.Spec.ReportingEnd.Time)) {
+		return nil, nil, fmt.Errorf("spec.reportingEnd (%s) must be after spec.reportingStart (%s)", report.Spec.ReportingEnd.Time, report.Spec.ReportingStart.Time)
+	}
+	if report.Spec.ReportingEnd == nil && report.Spec.RunImmediately {
+		return nil, nil, errors.New("spec.reportingEnd must be set if report.spec.runImmediately is true")
+	}
+
+	// Validate the ReportGenerationQuery that the Report used exists
+	genQuery, err := GetReportGenerationQueryForReport(report, queryGetter)
 	if err != nil {
-		logger.WithError(err).Errorf("failed to get report generation query")
 		if apierrors.IsNotFound(err) {
-			return op.setReportStatusInvalidReport(report, fmt.Sprintf("ReportGenerationQuery %s does not exist", report.Spec.GenerationQueryName))
+			return nil, nil, fmt.Errorf("ReportGenerationQuery (%s) does not exist", report.Spec.GenerationQueryName)
 		}
-		return err
+		return nil, nil, fmt.Errorf("failed to get report generation query")
 	}
 
 	// Validate the dependencies of this Report's query exist
 	queryDependencies, err := reporting.GetAndValidateGenerationQueryDependencies(
-		reporting.NewReportGenerationQueryListerGetter(op.reportGenerationQueryLister),
-		reporting.NewReportDataSourceListerGetter(op.reportDataSourceLister),
-		reporting.NewReportListerGetter(op.reportLister),
+		queryGetter,
+		reportDataSourceGetter,
+		reportGetter,
 		genQuery,
-		op.uninitialiedDependendenciesHandler(),
+		handler,
 	)
 	if err != nil {
-		return op.setReportStatusInvalidReport(report, fmt.Sprintf("failed to validate ReportGenerationQuery dependencies %s: %v", genQuery.Name, err))
+		return nil, nil, fmt.Errorf("failed to validate ReportGenerationQuery dependencies %s: %v", genQuery.Name, err)
+	}
+
+	return genQuery, queryDependencies, nil
+}
+
+// runReport takes a report, and generates reporting data
+// according the report's schedule. If the next scheduled reporting period
+// hasn't elapsed, runReport will requeue the resource for a time when
+// the period has elapsed.
+func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) error {
+	// check if the report was previously finished; store result in bool
+	if reportFinished := isReportFinished(logger, report); reportFinished {
+		return nil
+	}
+
+	runningCond := cbutil.GetReportCondition(report.Status, cbTypes.ReportRunning)
+	queryGetter := reporting.NewReportGenerationQueryListerGetter(op.reportGenerationQueryLister)
+	reportDataSourceGetter := reporting.NewReportDataSourceListerGetter(op.reportDataSourceLister)
+	reportGetter := reporting.NewReportListerGetter(op.reportLister)
+
+	// validate that Report contains valid Spec fields
+	genQuery, queryDependencies, err := validateReport(report, queryGetter, reportDataSourceGetter, reportGetter, op.uninitialiedDependendenciesHandler())
+	if err != nil {
+		return op.setReportStatusInvalidReport(report, err.Error())
 	}
 
 	now := op.clock.Now().UTC()
@@ -672,17 +704,20 @@ func (op *Reporting) setReportStatusInvalidReport(report *cbTypes.Report, msg st
 	return err
 }
 
-func (op *Reporting) getReportGenerationQueryForReport(report *cbTypes.Report) (*cbTypes.ReportGenerationQuery, error) {
-	return op.reportGenerationQueryLister.ReportGenerationQueries(report.Namespace).Get(report.Spec.GenerationQueryName)
+// GetReportGenerationQueryForReport returns the ReportGenerationQuery that was used in the Report parameter
+func GetReportGenerationQueryForReport(report *cbTypes.Report, queryGetter reporting.ReportGenerationQueryGetter) (*cbTypes.ReportGenerationQuery, error) {
+	return queryGetter.GetReportGenerationQuery(report.Namespace, report.Spec.GenerationQueryName)
 }
 
 func (op *Reporting) getReportDependencies(report *cbTypes.Report) (*reporting.ReportGenerationQueryDependencies, error) {
-	genQuery, err := op.getReportGenerationQueryForReport(report)
+	queryGetter := reporting.NewReportGenerationQueryListerGetter(op.reportGenerationQueryLister)
+
+	genQuery, err := GetReportGenerationQueryForReport(report, queryGetter)
 	if err != nil {
 		return nil, err
 	}
 	return reporting.GetGenerationQueryDependencies(
-		reporting.NewReportGenerationQueryListerGetter(op.reportGenerationQueryLister),
+		queryGetter,
 		reporting.NewReportDataSourceListerGetter(op.reportDataSourceLister),
 		reporting.NewReportListerGetter(op.reportLister),
 		genQuery,

--- a/pkg/operator/reports_test.go
+++ b/pkg/operator/reports_test.go
@@ -1,23 +1,33 @@
 package operator
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/operator-framework/operator-metering/pkg/operator/reporting"
+	"github.com/operator-framework/operator-metering/pkg/operator/reportingutil"
+
 	"github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	"github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
+	"github.com/operator-framework/operator-metering/test/testhelpers"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetNextReportPeriod(t *testing.T) {
 	baseTime := time.Date(2018, time.July, 1, 0, 0, 0, 0, time.UTC)
 	tests := map[string]struct {
-		period              v1alpha1.ReportPeriod
+		period              metering.ReportPeriod
 		expectError         bool
 		expectReportPeriods []reportPeriod
 	}{
 		"hourly": {
-			period: v1alpha1.ReportPeriodHourly,
+			period: metering.ReportPeriodHourly,
 			expectReportPeriods: []reportPeriod{
 				{
 					periodStart: baseTime,
@@ -30,7 +40,7 @@ func TestGetNextReportPeriod(t *testing.T) {
 			},
 		},
 		"daily": {
-			period: v1alpha1.ReportPeriodDaily,
+			period: metering.ReportPeriodDaily,
 			expectReportPeriods: []reportPeriod{
 				{
 					periodStart: baseTime,
@@ -43,7 +53,7 @@ func TestGetNextReportPeriod(t *testing.T) {
 			},
 		},
 		"weekly": {
-			period: v1alpha1.ReportPeriodWeekly,
+			period: metering.ReportPeriodWeekly,
 			expectReportPeriods: []reportPeriod{
 				{
 					periodStart: baseTime,
@@ -56,7 +66,7 @@ func TestGetNextReportPeriod(t *testing.T) {
 			},
 		},
 		"monthly": {
-			period: v1alpha1.ReportPeriodMonthly,
+			period: metering.ReportPeriodMonthly,
 			expectReportPeriods: []reportPeriod{
 				{
 					periodStart: baseTime,
@@ -68,14 +78,14 @@ func TestGetNextReportPeriod(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			apiSched := &v1alpha1.ReportSchedule{
+			apiSched := &metering.ReportSchedule{
 				Period: test.period,
 				// Normally only one is set, but we simply use a zero value
 				// for each to make it easier in tests.
-				Hourly:  &v1alpha1.ReportScheduleHourly{},
-				Daily:   &v1alpha1.ReportScheduleDaily{},
-				Weekly:  &v1alpha1.ReportScheduleWeekly{},
-				Monthly: &v1alpha1.ReportScheduleMonthly{},
+				Hourly:  &metering.ReportScheduleHourly{},
+				Daily:   &metering.ReportScheduleDaily{},
+				Weekly:  &metering.ReportScheduleWeekly{},
+				Monthly: &metering.ReportScheduleMonthly{},
 			}
 
 			schedule, err := getSchedule(apiSched)
@@ -89,6 +99,239 @@ func TestGetNextReportPeriod(t *testing.T) {
 				lastScheduled = expectedReportPeriod.periodEnd
 			}
 
+		})
+	}
+}
+
+func TestIsReportFinished(t *testing.T) {
+	const (
+		testNamespace     = "default"
+		testReportName    = "test-report"
+		testQueryName     = "test-query"
+		testReportMessage = "test-message"
+	)
+
+	schedule := &metering.ReportSchedule{
+		Period: metering.ReportPeriodCron,
+		Cron:   &metering.ReportScheduleCron{Expression: "5 4 * * *"},
+	}
+
+	reportStart := &time.Time{}
+	reportEndTmp := reportStart.AddDate(0, 1, 0)
+	reportEnd := &reportEndTmp
+
+	testTable := []struct {
+		name           string
+		report         *metering.Report
+		expectFinished bool
+	}{
+		{
+			name:           "new report returns false",
+			report:         testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			expectFinished: false,
+		},
+		{
+			name: "finished status on run-once report returns true",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ReportFinishedReason, testReportMessage),
+				},
+			}, nil, false),
+			expectFinished: true,
+		},
+		{
+			name: "unset reportingEnd returns false",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, nil, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ReportFinishedReason, testReportMessage),
+				},
+			}, schedule, false),
+			expectFinished: false,
+		},
+		{
+			name: "reportingEnd > lastReportTime returns false",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ReportFinishedReason, testReportMessage),
+				},
+				LastReportTime: &metav1.Time{Time: reportStart.AddDate(0, 0, 0)},
+			}, schedule, false),
+			expectFinished: false,
+		},
+		{
+			name: "reportingEnd < lastReportTime returns true",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ReportFinishedReason, testReportMessage),
+				},
+				LastReportTime: &metav1.Time{Time: reportStart.AddDate(0, 2, 0)},
+			}, schedule, false),
+			expectFinished: true,
+		},
+		{
+			name: "when status running is false and reason is Scheduled return false",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ScheduledReason, testReportMessage),
+				},
+			}, schedule, false),
+			expectFinished: false,
+		},
+		{
+			name: "when status running is true and reason is Scheduled return false",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, util.ScheduledReason, testReportMessage),
+				},
+			}, schedule, false),
+			expectFinished: false,
+		},
+		{
+			name: "when status running is false and reason is InvalidReport return false",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.InvalidReportReason, testReportMessage),
+				},
+			}, schedule, false),
+			expectFinished: false,
+		},
+		{
+			name: "when status running is true and reason is InvalidReport return false",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, util.InvalidReportReason, testReportMessage),
+				},
+			}, schedule, false),
+			expectFinished: false,
+		},
+		{
+			name: "when status running is false and reason is RunImmediately return false",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.RunImmediatelyReason, testReportMessage),
+				},
+			}, schedule, false),
+			expectFinished: false,
+		},
+		{
+			name: "when status running is true and reason is RunImmediately return false",
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+				Conditions: []metering.ReportCondition{
+					*util.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, util.RunImmediatelyReason, testReportMessage),
+				},
+			}, schedule, false),
+			expectFinished: false,
+		},
+	}
+
+	for _, testCase := range testTable {
+		var mockLogger = logrus.New()
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			runningCond := isReportFinished(mockLogger, testCase.report)
+			assert.Equalf(t, runningCond, testCase.expectFinished, "expected the report would return '%t', but got '%t'", testCase.expectFinished, runningCond)
+		})
+	}
+}
+
+func TestValidateReport(t *testing.T) {
+	const (
+		testNamespace            = "default"
+		testReportName           = "test-report"
+		testQueryName            = "test-query"
+		testInvalidQueryName     = "invalid-query"
+		testNonExistentQueryName = "does-not-exist"
+	)
+
+	ds1 := testhelpers.NewReportDataSource("datasource1", testNamespace)
+	ds1.Status.TableName = reportingutil.DataSourceTableName("test-ns", "initialized-datasource")
+
+	testValidQuery := &metering.ReportGenerationQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testQueryName,
+			Namespace: testNamespace,
+		},
+		Spec: metering.ReportGenerationQuerySpec{
+			DataSources: []string{
+				ds1.Name,
+			},
+		},
+	}
+
+	testInvalidQuery := &metering.ReportGenerationQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testInvalidQueryName,
+			Namespace: testNamespace,
+		},
+		Spec: metering.ReportGenerationQuerySpec{
+			DataSources: []string{"this-does-not-exist"},
+		},
+	}
+
+	dataSourceGetter := testhelpers.NewReportDataSourceStore([]*metering.ReportDataSource{ds1})
+	queryGetter := testhelpers.NewReportGenerationQueryStore([]*metering.ReportGenerationQuery{testValidQuery, testInvalidQuery})
+	reportGetter := testhelpers.NewReportStore(nil)
+
+	reportStart := &time.Time{}
+	reportEndTmp := reportStart.AddDate(0, 1, 0)
+	reportEnd := &reportEndTmp
+
+	testTable := []struct {
+		name         string
+		report       *metering.Report
+		expectErr    bool
+		expectErrMsg string
+	}{
+		{
+			name:         "empty spec.generationQuery returns err",
+			report:       testhelpers.NewReport(testReportName, testNamespace, "", reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			expectErr:    true,
+			expectErrMsg: "must set spec.generationQuery",
+		},
+		{
+			name:         "spec.ReportingStart > spec.ReportingEnd returns err",
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportEnd, reportStart, v1alpha1.ReportStatus{}, nil, false),
+			expectErr:    true,
+			expectErrMsg: fmt.Sprintf("spec.reportingEnd (%s) must be after spec.reportingStart (%s)", reportStart.String(), reportEnd.String()),
+		},
+		{
+			name:         "spec.ReportingEnd is unset and spec.RunImmediately is set returns err",
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, nil, v1alpha1.ReportStatus{}, nil, true),
+			expectErr:    true,
+			expectErrMsg: "spec.reportingEnd must be set if report.spec.runImmediately is true",
+		},
+		{
+			name:         "spec.GenerationQueryName does not exist returns err",
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			expectErr:    true,
+			expectErrMsg: fmt.Sprintf("ReportGenerationQuery (%s) does not exist", testNonExistentQueryName),
+		},
+		{
+			name:         "valid report with invalid DataSource returns error",
+			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, true),
+			expectErr:    true,
+			expectErrMsg: fmt.Sprintf("failed to validate ReportGenerationQuery dependencies %s: %s", testInvalidQueryName, "ReportDataSource.metering.openshift.io \"this-does-not-exist\" not found"),
+		},
+		{
+			name:         "valid report with valid DataSource returns nil",
+			report:       testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, true),
+			expectErr:    false,
+			expectErrMsg: "",
+		},
+	}
+
+	for _, testCase := range testTable {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			_, _, err := validateReport(testCase.report, queryGetter, dataSourceGetter, reportGetter, &reporting.UninitialiedDependendenciesHandler{})
+
+			if testCase.expectErr {
+				assert.EqualErrorf(t, err, testCase.expectErrMsg, "expected that validateReport would return the correct error message")
+			} else {
+				assert.NoErrorf(t, err, "expected the report would return no error, but got '%v'", err)
+			}
 		})
 	}
 }

--- a/test/testhelpers/helpers.go
+++ b/test/testhelpers/helpers.go
@@ -11,7 +11,8 @@ import (
 	"github.com/operator-framework/operator-metering/pkg/operator/reportingutil"
 )
 
-func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *time.Time, status v1alpha1.ReportStatus) *v1alpha1.Report {
+// NewReport creates a mock report used for testing purposes.
+func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *time.Time, status v1alpha1.ReportStatus, schedule *v1alpha1.ReportSchedule, runImmediately bool) *v1alpha1.Report {
 	var start, end *meta.Time
 	if reportStart != nil {
 		start = &meta.Time{*reportStart}
@@ -28,6 +29,8 @@ func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *ti
 			GenerationQueryName: testQueryName,
 			ReportingStart:      start,
 			ReportingEnd:        end,
+			Schedule:            schedule,
+			RunImmediately:      runImmediately,
 		},
 		Status: status,
 	}


### PR DESCRIPTION
Currently, in the `runReport(..)` function in pkg/operator/reports.go, we check the report parameter's running condition. This change would move those checks into a separate function and adds unit tests to verify that the function works as intended.