### PR TITLE
charts/*: Fix invalid configurations in helm charts.

### DIFF
--- a/charts/hdfs/templates/datanode-statefulset.yaml
+++ b/charts/hdfs/templates/datanode-statefulset.yaml
@@ -198,7 +198,7 @@ spec:
       - name: namenode-empty
         emptyDir: {}
       - name: hadoop-logs
-        mountPath: /opt/hadoop/logs
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: "hdfs-datanode-data"

--- a/charts/hdfs/templates/service-account.yaml
+++ b/charts/hdfs/templates/service-account.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hdfs

--- a/charts/presto/templates/hive-metastore-statefulset.yaml
+++ b/charts/presto/templates/hive-metastore-statefulset.yaml
@@ -72,7 +72,6 @@ spec:
           value: {{ upper .Values.spec.hive.metastore.config.logLevel | quote}}
         - name: JAVA_MAX_MEM_RATIO
           value: "{{ .Values.spec.hive.metastore.config.jvm.percentMemoryLimitAsHeap }}"
-          optional: true
 {{ include "hive-env" . | indent 8 }}
         - name: MY_MEM_REQUEST
           valueFrom:

--- a/charts/presto/templates/hive-server-statefulset.yaml
+++ b/charts/presto/templates/hive-server-statefulset.yaml
@@ -76,7 +76,6 @@ spec:
           value: {{ upper .Values.spec.hive.server.config.logLevel | quote}}
         - name: JAVA_MAX_MEM_RATIO
           value: "{{ .Values.spec.hive.server.config.percentMemoryLimitAsHeap }}"
-          optional: true
 {{ include "hive-env" . | indent 8 }}
         - name: MY_MEM_REQUEST
           valueFrom:

--- a/charts/presto/templates/hive-serviceaccount.yaml
+++ b/charts/presto/templates/hive-serviceaccount.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hive

--- a/charts/presto/templates/presto-coordinator-deployment.yaml
+++ b/charts/presto/templates/presto-coordinator-deployment.yaml
@@ -78,7 +78,6 @@ spec:
         env:
         - name: JAVA_MAX_MEM_RATIO
           value: "{{ .Values.spec.presto.coordinator.config.jvm.percentMemoryLimitAsHeap }}"
-          optional: true
 {{- include "presto-common-env" . | indent 8 }}
         ports:
         - name: http

--- a/charts/presto/templates/presto-serviceaccount.yaml
+++ b/charts/presto/templates/presto-serviceaccount.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: presto

--- a/charts/presto/templates/presto-worker-deployment.yaml
+++ b/charts/presto/templates/presto-worker-deployment.yaml
@@ -78,7 +78,6 @@ spec:
         env:
         - name: JAVA_MAX_MEM_RATIO
           value: "{{ .Values.spec.presto.worker.config.jvm.percentMemoryLimitAsHeap }}"
-          optional: true
 {{- include "presto-common-env" . | indent 8 }}
         ports:
         - name: http


### PR DESCRIPTION
Found by templating the charts out and running everything through
kubectl apply --dry-run.