### PR TITLE
pkg/operator: Refactor getting a report's reportPeriod into its own function and add unit tests.

### DIFF
--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -286,6 +286,57 @@ func validateReport(
 	return genQuery, queryDependencies, nil
 }
 
+// getReportPeriod determines a Report's reporting period based off the report parameter's fields.
+// Returns a pointer to a reportPeriod structure if no error was encountered, else panic or return an error.
+func getReportPeriod(now time.Time, logger log.FieldLogger, report *cbTypes.Report) (*reportPeriod, error) {
+	var reportPeriod *reportPeriod
+
+	// check if the report's schedule spec is set
+	if report.Spec.Schedule != nil {
+		reportSchedule, err := getSchedule(report.Spec.Schedule)
+		if err != nil {
+			return nil, err
+		}
+
+		if report.Status.LastReportTime != nil {
+			reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, report.Status.LastReportTime.Time)
+		} else {
+			if report.Spec.ReportingStart != nil {
+				logger.Infof("no last report time for report, using spec.reportingStart %s as starting point", report.Spec.ReportingStart.Time)
+				reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, report.Spec.ReportingStart.Time)
+			} else if report.Status.NextReportTime != nil {
+				logger.Infof("no last report time for report, using status.nextReportTime %s as starting point", report.Status.NextReportTime.Time)
+				reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, report.Status.NextReportTime.Time)
+			} else {
+				// the current period, [now, nextScheduledTime]
+				currentPeriod := getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, now)
+				// the next full report period from [nextScheduledTime, nextScheduledTime+1]
+				reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, currentPeriod.periodEnd)
+				report.Status.NextReportTime = &metav1.Time{Time: reportPeriod.periodStart}
+			}
+		}
+	} else {
+		var err error
+		// if there's the Spec.Schedule field is unset, then the report must be a run-once report
+		reportPeriod, err = getRunOnceReportPeriod(report)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if reportPeriod.periodStart.After(reportPeriod.periodEnd) {
+		panic("periodStart should never come after periodEnd")
+	}
+
+	if report.Spec.ReportingEnd != nil && reportPeriod.periodEnd.After(report.Spec.ReportingEnd.Time) {
+		logger.Debugf("calculated Report periodEnd %s goes beyond spec.reportingEnd %s, setting periodEnd to reportingEnd", reportPeriod.periodEnd, report.Spec.ReportingEnd.Time)
+		// we need to truncate the reportPeriod to align with the reportingEnd
+		reportPeriod.periodEnd = report.Spec.ReportingEnd.Time
+	}
+
+	return reportPeriod, nil
+}
+
 // runReport takes a report, and generates reporting data
 // according the report's schedule. If the next scheduled reporting period
 // hasn't elapsed, runReport will requeue the resource for a time when
@@ -309,45 +360,10 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 
 	now := op.clock.Now().UTC()
 
-	var reportPeriod *reportPeriod
-	if report.Spec.Schedule != nil {
-		reportSchedule, err := getSchedule(report.Spec.Schedule)
-		if err != nil {
-			return err
-		}
-
-		if report.Status.LastReportTime != nil {
-			reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, report.Status.LastReportTime.Time)
-		} else {
-			if report.Spec.ReportingStart != nil {
-				logger.Infof("no last report time for report, using spec.reportingStart %s as starting point", report.Spec.ReportingStart.Time)
-				reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, report.Spec.ReportingStart.Time)
-			} else if report.Status.NextReportTime != nil {
-				logger.Infof("no last report time for report, using status.nextReportTime %s as starting point", report.Status.NextReportTime.Time)
-				reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, report.Status.NextReportTime.Time)
-			} else {
-				// the current period, [now, nextScheduledTime]
-				currentPeriod := getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, now)
-				// the next full report period from [nextScheduledTime, nextScheduledTime+1]
-				reportPeriod = getNextReportPeriod(reportSchedule, report.Spec.Schedule.Period, currentPeriod.periodEnd)
-				report.Status.NextReportTime = &metav1.Time{Time: reportPeriod.periodStart}
-			}
-		}
-	} else {
-		reportPeriod, err = getRunOnceReportPeriod(report)
-		if err != nil {
-			return err
-		}
-	}
-
-	if reportPeriod.periodStart.After(reportPeriod.periodEnd) {
-		panic("periodStart should never come after periodEnd")
-	}
-
-	if report.Spec.ReportingEnd != nil && reportPeriod.periodEnd.After(report.Spec.ReportingEnd.Time) {
-		logger.Debugf("calculated Report periodEnd %s goes beyond spec.reportingEnd %s, setting periodEnd to reportingEnd", reportPeriod.periodEnd, report.Spec.ReportingEnd.Time)
-		// we need to truncate the reportPeriod to align with the reportingEnd
-		reportPeriod.periodEnd = report.Spec.ReportingEnd.Time
+	// get the report's reporting period
+	reportPeriod, err := getReportPeriod(now, logger, report)
+	if err != nil {
+		return err
 	}
 
 	logger = logger.WithFields(log.Fields{

--- a/pkg/operator/reports_test.go
+++ b/pkg/operator/reports_test.go
@@ -335,3 +335,99 @@ func TestValidateReport(t *testing.T) {
 		})
 	}
 }
+
+func TestGetReportPeriod(t *testing.T) {
+	const (
+		testNamespace  = "default"
+		testReportName = "test-report"
+		testQueryName  = "test-query"
+	)
+
+	invalidSchedule := &metering.ReportSchedule{
+		Period: metering.ReportPeriodCron,
+		Cron:   nil,
+	}
+
+	validSchedule := &metering.ReportSchedule{
+		Period: metering.ReportPeriodCron,
+		Cron:   &metering.ReportScheduleCron{Expression: "5 4 * * *"},
+	}
+
+	reportStart := &time.Time{}
+	reportEndTmp := reportStart.AddDate(0, 1, 0)
+	reportEnd := &reportEndTmp
+	lastReportTime := &metav1.Time{Time: reportStart.AddDate(0, 0, 0)}
+	nextReportTime := &metav1.Time{Time: reportStart.AddDate(0, 1, 0)}
+
+	testTable := []struct {
+		name        string
+		report      *metering.Report
+		expectErr   bool
+		expectPanic bool
+	}{
+		{
+			name:      "invalid report with an unset spec.Schedule field returns an error",
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, v1alpha1.ReportStatus{}, nil, false),
+			expectErr: true,
+		},
+		{
+			name:      "valid report with an unset spec.Schedule field returns nil",
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			expectErr: false,
+		},
+		{
+			name:      "invalid schedule with a set spec.Schedule field returns error",
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, invalidSchedule, false),
+			expectErr: true,
+		},
+		{
+			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime returns nil",
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, validSchedule, false),
+			expectErr: false,
+		},
+		{
+			name:      "valid schedule with a set spec.Schedule field and a set Spec.Status.LastReportTime returns nil",
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{LastReportTime: lastReportTime}, validSchedule, false),
+			expectErr: false,
+		},
+		{
+			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and a set Spec.ReportingStart returns nil",
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, validSchedule, false),
+			expectErr: false,
+		},
+		{
+			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and an unset Spec.ReportingStart returns nil",
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, v1alpha1.ReportStatus{}, validSchedule, false),
+			expectErr: false,
+		},
+		{
+			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and a set Spec.NextReportTime returns nil",
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, v1alpha1.ReportStatus{NextReportTime: nextReportTime}, validSchedule, false),
+			expectErr: false,
+		},
+		{
+			name:        "unset Spec.Schedule with reportPeriod.periodStart > reportPeriod.periodEnd returns panic",
+			report:      testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportEnd, reportStart, v1alpha1.ReportStatus{NextReportTime: nextReportTime}, nil, false),
+			expectErr:   false,
+			expectPanic: true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		var mockLogger = logrus.New()
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.expectPanic {
+				assert.Panics(t, func() { getReportPeriod(time.Now(), mockLogger, testCase.report) }, "expected the test case would panic, but it did not")
+			} else {
+				_, err := getReportPeriod(time.Now(), mockLogger, testCase.report)
+				if testCase.expectErr {
+					assert.Error(t, err, "expected that getting the report period  would return a non-nil error")
+				} else {
+					assert.Nil(t, err, "expected that getting the report period would return a nil error")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently based off of #697. Same idea as that PR - refactor portions of `runReport` into their own function with the intent of being able to unit tests those functions.

There's a `panic` call when the built-up `reportPeriod` struct contains an invalid start and end period, so I used `assert.Panics()` to test this, but there may be better way to achieve this.