### PR TITLE
pkg/operator: Do not return uppercased column types

### DIFF
--- a/pkg/operator/reportingutil/util.go
+++ b/pkg/operator/reportingutil/util.go
@@ -105,8 +105,7 @@ func PrestoColumnsToHiveColumns(columns []presto.Column) ([]hive.Column, error) 
 }
 
 func SimpleHiveColumnTypeToPrestoColumnType(colType string) string {
-	colType = strings.ToUpper(colType)
-	switch colType {
+	switch strings.ToUpper(colType) {
 	case "TINYINT", "SMALLINT", "INT", "INTEGER", "BIGINT",
 		"FLOAT", "DOUBLE", "BOOLEAN",
 		"VARCHAR", "CHAR",


### PR DESCRIPTION
Only compare to uppercased column types, do not change the original value.

Fixes a warning when the http code compares ReportQuery columns to
Presto columns:
```
time="2019-05-09T18:43:55Z" level=debug msg="mismatched columns, PrestoTable columns: [{period_start TIMESTAMP} {period_end TIMESTAMP} {namespace VARCHAR} {pod_usage_cpu_core_seconds DOUBLE} {pod_request_cpu_core_seconds DOUBLE} {pod_cpu_usage_percent DOUBLE} {pod_cpu_request_percent DOUBLE} {total_cluster_capacity_cpu_core_seconds DOUBLE}], ReportQuery columns: [{period_start timestamp} {period_end timestamp} {namespace varchar} {pod_usage_cpu_core_seconds double} {pod_request_cpu_core_seconds double} {pod_cpu_usage_percent double} {pod_cpu_request_percent double} {total_cluster_capacity_cpu_core_seconds double}]" app=metering component=api logID=GJFpG1L56w method=GET url="/api/v1/reports/get?format=json&name=namespace-cpu-utilization-runonce&namespace=metering-chancez-e2e"
```