### PR TITLE
metering-operator: Grant access to openshift authorization apis

### DIFF
--- a/charts/metering-helm-operator/values.yaml
+++ b/charts/metering-helm-operator/values.yaml
@@ -149,6 +149,7 @@ operator:
       verbs: ["*"]
     - apiGroups:
       - rbac.authorization.k8s.io
+      - authorization.openshift.io
       resources:
       - rolebindings
       - roles

--- a/manifests/deploy/openshift/metering-helm-operator/metering-operator-role.yaml
+++ b/manifests/deploy/openshift/metering-helm-operator/metering-operator-role.yaml
@@ -96,6 +96,7 @@ rules:
     - '*'
   - apiGroups:
     - rbac.authorization.k8s.io
+    - authorization.openshift.io
     resources:
     - rolebindings
     - roles

--- a/manifests/deploy/openshift/olm/bundle/4.1/meteringoperator.v4.1.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.1/meteringoperator.v4.1.0.clusterserviceversion.yaml
@@ -395,6 +395,7 @@ spec:
             - '*'
           - apiGroups:
             - rbac.authorization.k8s.io
+            - authorization.openshift.io
             resources:
             - rolebindings
             - roles


### PR DESCRIPTION
Since we use `oc` aliased to `kubectl` in the metering-operator image,
it defaults to querying using the authorization.openshift.io API group
instead of rbac.authorization.k8s.io so we should grant permissions to
both groups so metering-operator can manage RBAC without having to fully
qualify RBAC resources with an apiGroup.