### PR TITLE
hack: Just use kubectl to create the namespace instead of `oc project`

### DIFF
--- a/hack/openshift-install.sh
+++ b/hack/openshift-install.sh
@@ -3,9 +3,7 @@
 ROOT_DIR=$(dirname "${BASH_SOURCE}")/..
 source "${ROOT_DIR}/hack/common.sh"
 
-if command -v oc; then
-    oc new-project "${METERING_NAMESPACE}" || oc project "${METERING_NAMESPACE}"
-fi
+kubectl create namespace "${METERING_NAMESPACE}" || true
 
 echo "Labeling namespace ${METERING_NAMESPACE} with 'openshift.io/cluster-monitoring=true'"
 kubectl label \


### PR DESCRIPTION
oc fails with openshift- namespaces when using oc project, and also
mutates your kubeconfig which isn't great.