### PR TITLE
charts/openshift-metering: Configure Presto blackhole, memory, tpcds, and tpch connectors

### DIFF
--- a/charts/openshift-metering/templates/presto/_presto_helpers.tpl
+++ b/charts/openshift-metering/templates/presto/_presto_helpers.tpl
@@ -16,6 +16,23 @@ hive.metastore-timeout={{ .Values.presto.spec.presto.config.metastoreTimeout }}
 connector.name=jmx
 {{ end }}
 
+{{- define "presto-blackhole-catalog-properties" -}}
+connector.name=blackhole
+{{ end }}
+
+{{- define "presto-memory-catalog-properties" -}}
+connector.name=memory
+{{ end }}
+
+{{- define "presto-tpcds-catalog-properties" -}}
+connector.name=tpcds
+{{ end }}
+
+{{- define "presto-tpch-catalog-properties" -}}
+connector.name=tpch
+{{ end }}
+
+
 {{- define "presto-common-env" }}
 - name: MY_NODE_ID
   valueFrom:

--- a/charts/openshift-metering/templates/presto/presto-catalog-config-secret.yaml
+++ b/charts/openshift-metering/templates/presto/presto-catalog-config-secret.yaml
@@ -8,6 +8,10 @@ type: Opaque
 data:
   hive.properties: "{{ include "presto-hive-catalog-properties" . | b64enc }}"
   jmx.properties: "{{ include "presto-jmx-catalog-properties" . | b64enc }}"
+  blackhole.properties: "{{ include "presto-blackhole-catalog-properties" . | b64enc }}"
+  memory.properties: "{{ include "presto-memory-catalog-properties" . | b64enc }}"
+  tpcds.properties: "{{ include "presto-tpcds-catalog-properties" . | b64enc }}"
+  tpch.properties: "{{ include "presto-tpch-catalog-properties" . | b64enc }}"
 {{- range $_, $connector := .Values.presto.spec.presto.config.connectors.extraConnectorFiles }}
   {{ $connector.name }}: "{{ $connector.content | b64enc }}"
 {{- end }}


### PR DESCRIPTION
These connectors are useful for testing and debugging have little extra cost to enable by default.