### PR TITLE
pkg/operator: Reduces template rendering use of report query fields.

### DIFF
--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -478,9 +478,11 @@ func (op *Reporting) handleReportQueryViewDataSource(logger log.FieldLogger, dat
 			return err
 		}
 
+		requiredInputs := reportingutil.ConvertInputDefinitionsIntoInputList(query.Spec.Inputs)
 		queryCtx := &reporting.ReportQueryTemplateContext{
 			Namespace:         dataSource.Namespace,
-			ReportQuery:       query,
+			Query:             query.Spec.Query,
+			RequiredInputs:    requiredInputs,
 			Reports:           dependencyResult.Dependencies.Reports,
 			ReportQueries:     dependencyResult.Dependencies.ReportQueries,
 			ReportDataSources: dependencyResult.Dependencies.ReportDataSources,

--- a/pkg/operator/reportingutil/util.go
+++ b/pkg/operator/reportingutil/util.go
@@ -238,3 +238,12 @@ func PrestoColumnToHiveColumn(column presto.Column) (hive.Column, error) {
 	}
 	return hive.Column{}, fmt.Errorf("unsupported hive type: %q", column.Type)
 }
+
+func ConvertInputDefinitionsIntoInputList(defs []cbTypes.ReportQueryInputDefinition) (required []string) {
+	for _, def := range defs {
+		if def.Required {
+			required = append(required, def.Name)
+		}
+	}
+	return required
+}

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -609,9 +609,11 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 		return err
 	}
 
+	requiredInputs := reportingutil.ConvertInputDefinitionsIntoInputList(reportQuery.Spec.Inputs)
 	queryCtx := &reporting.ReportQueryTemplateContext{
 		Namespace:         report.Namespace,
-		ReportQuery:       reportQuery,
+		Query:             reportQuery.Spec.Query,
+		RequiredInputs:    requiredInputs,
 		Reports:           reports,
 		ReportQueries:     queries,
 		ReportDataSources: datasources,


### PR DESCRIPTION
This aims to make the API surface of the templating code simpler by removing some struct fields we only use certain parts of, primarily the ReportQuery.