### PR TITLE
pkg/operator: Fix ownerReference GVK for ReportQueryView ReportDataSources

### DIFF
--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -497,7 +497,7 @@ func (op *Reporting) handleReportQueryViewDataSource(logger log.FieldLogger, dat
 
 		columns := reportingutil.GeneratePrestoColumns(query)
 		logger.Infof("creating view %s", viewName)
-		prestoTable, err := op.createPrestoTableCR(dataSource, cbTypes.ReportQueryGVK, "hive", hiveStorage.Status.Hive.DatabaseName, viewName, columns, false, true, renderedQuery)
+		prestoTable, err := op.createPrestoTableCR(dataSource, cbTypes.ReportDataSourceGVK, "hive", hiveStorage.Status.Hive.DatabaseName, viewName, columns, false, true, renderedQuery)
 		if err != nil {
 			return fmt.Errorf("error creating view %s for ReportDataSource %s: %v", viewName, dataSource.Name, err)
 		}


### PR DESCRIPTION
Was previously producing an invalid ownerRef because the GCK didn't match the information used for the name/UID of the owning resource. This can cause the kube GC to delete the PrestoTables created due to the invalid owner not existing.