### PR TITLE
metering-ansible-operator: Run deploy-resources.sh in meteringconfig role

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -1,4 +1,36 @@
+# need the helm-cli from the helm image
+FROM quay.io/openshift/origin-metering-helm:latest as helm
+# final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
+FROM openshift/origin-cli as cli
+# real base
 FROM quay.io/operator-framework/ansible-operator:v0.6.0
+
+USER root
+# our copy of faq and jq
+COPY hack/faq.repo /etc/yum.repos.d/ecnahc515-faq-epel-7.repo
+# oniguruma-devel comes from epel-release
+RUN INSTALL_PKGS="curl bash jq-1.6-2.el7 faq ca-certificates" \
+    && yum -y install epel-release \
+    && yum install --setopt=skip_missing_names_on_install=False -y \
+        $INSTALL_PKGS  \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=cli /usr/bin/oc /usr/bin/oc
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
+
+USER 1001
 
 COPY images/metering-ansible-operator/roles/ /opt/ansible/roles/
 COPY images/metering-ansible-operator/watches.yaml /opt/ansible/watches.yaml
+COPY images/helm-operator/* /opt/ansible/scripts/
+
+COPY charts/openshift-metering /openshift-metering
+COPY manifests/deploy/openshift/olm/bundle /manifests
+
+LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
+      io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+      io.openshift.tags="openshift" \
+      com.redhat.delivery.appregistry=true \
+      maintainer="Chance Zibolski <sd-operator-metering@redhat.com>"

--- a/images/helm-operator/deploy-resources.sh
+++ b/images/helm-operator/deploy-resources.sh
@@ -7,7 +7,6 @@ set -u
 
 shopt -s extglob
 
-
 : "${ENABLE_DEBUG:=false}"
 
 if [ "$ENABLE_DEBUG" == "true" ]; then
@@ -404,10 +403,15 @@ installReportingOperatorResources() {
     helmTemplateAndApply templates/reporting-operator/reporting-operator-deployment.yaml reporting-operator-deployment true false
 }
 
+echo "Deploying metering resources"
 installMeteringResources
+echo "Deploying reporting resources"
 installReportingResources
+echo "Deploying HDFS resources"
 installHdfsResources
+echo "Deploying Presto resources"
 installPrestoResources
+echo "Deploying reporting-operator resources"
 installReportingOperatorResources
 
 wait

--- a/images/metering-ansible-operator/deploy/clusterrole.yaml
+++ b/images/metering-ansible-operator/deploy/clusterrole.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metering-ansible-operator
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+  - apiGroups:
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    verbs:
+    - create
+  - apiGroups:
+    - authentication.k8s.io
+    resources:
+    - tokenreviews
+    verbs:
+    - create
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - clusterrolebindings
+    - clusterroles
+    verbs:
+    - '*'
+

--- a/images/metering-ansible-operator/deploy/clusterrole.yaml
+++ b/images/metering-ansible-operator/deploy/clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
     - namespaces
     verbs:
     - get
+    - list
   - apiGroups:
     - authorization.k8s.io
     resources:

--- a/images/metering-ansible-operator/deploy/clusterrolebinding.yaml
+++ b/images/metering-ansible-operator/deploy/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metering-ansible-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metering-ansible-operator
+subjects:
+- kind: ServiceAccount
+  name: metering-ansible-operator
+  namespace: placeholder
+

--- a/images/metering-ansible-operator/deploy/role.yaml
+++ b/images/metering-ansible-operator/deploy/role.yaml
@@ -4,51 +4,99 @@ metadata:
   creationTimestamp: null
   name: metering-ansible-operator
 rules:
+# grant access to metering resources
+- apiGroups: ["metering.openshift.io"]
+  resources: ["*"]
+  verbs: ["*"]
+# grant access to monitoring resources for optional monitoring integration
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  verbs: ["*"]
+# access to most core resources that can be created by metering
 - apiGroups:
   - ""
   resources:
   - pods
-  - services
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  verbs: ["*"]
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
   - endpoints
   - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs: ["*"]
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces/status
+  - pods/log
+  - pods/status
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
-  - deployments
   - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
   - replicasets
+  - replicasets/scale
   - statefulsets
-  verbs:
-  - '*'
+  verbs: ["*"]
 - apiGroups:
-  - monitoring.coreos.com
+  - batch
   resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
+  - cronjobs
+  - jobs
+  verbs: ["*"]
 - apiGroups:
-  - apps
-  resourceNames:
-  - metering-ansible-operator
+  - extensions
   resources:
-  - deployments/finalizers
-  verbs:
-  - update
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  verbs: ["*"]
 - apiGroups:
-  - metering.openshift.io
+  - rbac.authorization.k8s.io
+  - authorization.openshift.io
   resources:
-  - '*'
-  verbs:
-  - '*'
+  - rolebindings
+  - roles
+  verbs: ["*"]
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs: ["*"]

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
-- name: start metering
-  debug:
-    msg: "Hello World (non default)"
+
+- name: Extract MeteringConfig spec
+  copy: content="{{ _metering_openshift_io_meteringconfig.spec }}" dest=/tmp/metering-values.yaml
+
+- name: Install Metering
+  shell: |
+    /opt/ansible/scripts/deploy-resources.sh -f /tmp/metering-values.yaml {{ meta.name }} {{ lookup('env','HELM_CHART_PATH') }} {{ meta.namespace }} metering.openshift.io meteringconfig {{ meta.name }} {{ _metering_openshift_io_meteringconfig.metadata.uid }} metering.openshift.io/prune false 2>&1 | tee /tmp/deploy-resources.txt
+  register: install_result
+
+- debug: msg="{{item}}"
+  with_items: "{{install_result.stdout_lines}}"
+  when: install_result.stdout_lines

--- a/images/metering-ansible-operator/watches.yaml
+++ b/images/metering-ansible-operator/watches.yaml
@@ -3,3 +3,5 @@
   group: metering.openshift.io
   kind: MeteringConfig
   role: /opt/ansible/roles/meteringconfig
+  watchDependentResources: false
+  reconcilePeriod: 1m


### PR DESCRIPTION
Manually tested by editing the deployment to use my own custom image of metering-ansible-operator.
This updates metering-ansible-operator to run the deploy-resources.sh script that metering-helm-operator currently uses to deploy the metering stack.

As a follow up, this script can be translated into ansible roles and tasks that accomplish the same logic directly.