### PR TITLE
hack/ocp-util,Makefile: Update utilities/files for local ocp image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ REPORTING_OPERATOR_PKG := $(GO_PKG)/cmd/reporting-operator
 # gofmt
 VERIFY_FILE_PATHS := cmd pkg test manifests Gopkg.lock
 
+DOCKER_BUILD_CMD = docker build
+OCP_BUILD = false
+REPO_FILE = $(ROOT_DIR)/hack/ocp-util/redhat.repo
+SUB_MGR_FILE = $(ROOT_DIR)/hack/ocp-util/subscription-manager.conf
+
 IMAGE_REPOSITORY = quay.io
 IMAGE_ORG = openshift
 DOCKER_BASE_URL = $(IMAGE_REPOSITORY)/$(IMAGE_ORG)
@@ -27,6 +32,14 @@ METERING_ANSIBLE_OPERATOR_IMAGE_TAG=4.1
 REPORTING_OPERATOR_DOCKERFILE=Dockerfile.reporting-operator
 METERING_OPERATOR_DOCKERFILE=Dockerfile.metering-operator
 METERING_ANSIBLE_OPERATOR_DOCKERFILE=Dockerfile.metering-ansible-operator
+
+
+ifeq ($(OCP_BUILD), true)
+	DOCKER_BUILD_CMD=imagebuilder -mount $(REPO_FILE):/etc/yum.repos.d/redhat.repo -mount $(SUB_MGR_FILE):/etc/yum/pluginconf.d/subscription-manager.conf
+	REPORTING_OPERATOR_DOCKERFILE=Dockerfile.reporting-operator.rhel
+	METERING_ANSIBLE_OPERATOR_DOCKERFILE=Dockerfile.metering-ansible-operator.rhel
+endif
+
 
 GO_BUILD_ARGS := -ldflags '-extldflags "-static"'
 GOOS = "linux"
@@ -63,16 +76,16 @@ all: fmt unit metering-manifests docker-build-all
 docker-build-all: reporting-operator-docker-build metering-operator-docker-build
 
 reporting-operator-docker-build: $(REPORTING_OPERATOR_DOCKERFILE)
-	docker build -f $< -t $(REPORTING_OPERATOR_IMAGE_REPO):$(REPORTING_OPERATOR_IMAGE_TAG) $(ROOT_DIR)
+	$(DOCKER_BUILD_CMD) -f $< -t $(REPORTING_OPERATOR_IMAGE_REPO):$(REPORTING_OPERATOR_IMAGE_TAG) $(ROOT_DIR)
 
 metering-src-docker-build: Dockerfile.src
-	docker build -f $< -t $(METERING_SRC_IMAGE_REPO):$(METERING_SRC_IMAGE_TAG) $(ROOT_DIR)
+	$(DOCKER_BUILD_CMD) -f $< -t $(METERING_SRC_IMAGE_REPO):$(METERING_SRC_IMAGE_TAG) $(ROOT_DIR)
 
 metering-operator-docker-build: $(METERING_OPERATOR_DOCKERFILE)
 	docker build -f $< -t $(METERING_OPERATOR_IMAGE_REPO):$(METERING_OPERATOR_IMAGE_TAG) $(ROOT_DIR)
 
 metering-ansible-operator-docker-build: $(METERING_ANSIBLE_OPERATOR_DOCKERFILE)
-	docker build -f $< -t $(METERING_ANSIBLE_OPERATOR_IMAGE_REPO):$(METERING_ANSIBLE_OPERATOR_IMAGE_TAG) $(ROOT_DIR)
+	$(DOCKER_BUILD_CMD) -f $< -t $(METERING_ANSIBLE_OPERATOR_IMAGE_REPO):$(METERING_ANSIBLE_OPERATOR_IMAGE_TAG) $(ROOT_DIR)
 
 # Runs gofmt on all files in project except vendored source and Hive Thrift definitions
 fmt:

--- a/hack/ocp-util/ocp-build-vars.sh
+++ b/hack/ocp-util/ocp-build-vars.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+DIR=$(dirname "${BASH_SOURCE}")/
+
+
+_readlink() {
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        readlink "$@"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        greadlink "$@"
+    fi
+}
+
+SUB_MGR_FILE="$(_readlink -f "$DIR/subscription-manager.conf")"
+REPO_FILE="$(_readlink -f "$DIR/redhat.repo")"
+
+export SUB_MGR_FILE REPO_FILE

--- a/hack/ocp-util/ocp-image-pull-and-rename.sh
+++ b/hack/ocp-util/ocp-image-pull-and-rename.sh
@@ -19,6 +19,10 @@ docker tag 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/golan
 docker pull 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/ose-base:latest'
 docker tag 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/ose-base:latest' openshift/ose-base:latest
 
+# openshift cli
+docker pull 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/ose-cli:latest'
+docker tag 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/ose-cli:latest' openshift/ose-cli:latest
+
 # helm is pulled for building metering-operator
 if [ "$PULL_OSE_METERING_HELM" == "true" ]; then
     docker pull 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/ose-metering-helm:latest'

--- a/hack/ocp-util/redhat.repo
+++ b/hack/ocp-util/redhat.repo
@@ -18,8 +18,8 @@ baseurl=http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Se
 gpgcheck=0
 enabled=1
 
-[rhel-7-server-ose-4.0-rpms]
-name=Red Hat OCP 4.0
+[rhel-7-server-ose-4.1-rpms]
+name=Red Hat OCP 4.1
 enabled=1
 gpgcheck=0
-baseurl=http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/4.0/building/x86_64/os/
+baseurl=http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/4.1/building/x86_64/os/


### PR DESCRIPTION
Support using imagebuilder for docker image builds via Makefile, and
update scripts to handle pulling latest bases.

For example, this allows building OCP images locally (must be on RH network and your docker daemon trust the brew-pulp docker registry):

```
./hack/ocp-util/ocp-image-pull-and-rename.sh
make docker-build-all OCP_BUILD=true
```