### PR TITLE
charts/openshift-metering: Update the reporting-operator and Presto StatefulSets to use TLS when specified

### DIFF
--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -3,6 +3,17 @@ kind: ConfigMap
 metadata:
   name: presto-common-config
 data:
+  initialize_presto.sh: |
+    #!/bin/bash
+    set -e
+
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+    openssl pkcs12 -export -inkey $PRESTO_KEYFILE -in $PRESTO_CRTFILE -out $PRESTO_KEYSTORE_PKCS12 -password pass:$PRESTO_KEYSTORE_PASSWORD
+    keytool -importkeystore -noprompt -srckeystore $PRESTO_KEYSTORE_PKCS12 -srcstoretype pkcs12 -destkeystore $PRESTO_KEYSTORE_JKS -storepass $PRESTO_KEYSTORE_PASSWORD -srcstorepass $PRESTO_KEYSTORE_PASSWORD
+{{- end }}
+
+    cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/
+
   entrypoint.sh: |
     #!/bin/bash
     set -e

--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -13,13 +13,29 @@ data:
     node.environment=production
 
   config.properties: |
+    coordinator=true
+    node-scheduler.include-coordinator={{ .Values.presto.spec.presto.config.nodeSchedulerIncludeCoordinator }}
+    discovery-server.enabled=true
+
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+    http-server.http.enabled=false
+    http-server.https.enabled=true
+    http-server.https.port=8080
+    http-server.https.keystore.path=/opt/presto/tls/keystore.jks
+    http-server.https.keystore.key=password
+    node.internal-address-source=FQDN
+    discovery.uri=https://presto:8080
+    internal-communication.https.required=true
+    internal-communication.https.keystore.path=/opt/presto/tls/keystore.jks
+    internal-communication.https.keystore.key=password
+{{- else }}
     http-server.http.port=8080
+    discovery.uri=http://presto:8080
+{{- end }}
+
     jmx.rmiserver.port=8081
     jmx.rmiregistry.port=8081
-    coordinator=true
-    discovery-server.enabled=true
-    discovery.uri={{ .Values.presto.spec.presto.config.discoveryURI }}
-    node-scheduler.include-coordinator={{ .Values.presto.spec.presto.config.nodeSchedulerIncludeCoordinator }}
+
 {{- if .Values.presto.spec.presto.config.maxQueryLength }}
     query.max-length={{ .Values.presto.spec.presto.config.maxQueryLength }}
 {{- end }}

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: presto-worker
+  name: presto-coordinator
   labels:
     app: presto
-    presto: worker
+    presto: coordinator
 spec:
-  replicas: {{ .Values.presto.spec.presto.worker.replicas }}
+  replicas: 1
   serviceName: presto-nodes
   selector:
     matchLabels:
       app: presto
-      presto: worker
+      presto: coordinator
 {{- if .Values.presto.spec.presto.labels }}
 {{ toYaml .Values.presto.spec.presto.labels | indent 6 }}
 {{- end }}
@@ -19,12 +19,12 @@ spec:
     metadata:
       labels:
         app: presto
-        presto: worker
+        presto: coordinator
 {{- if .Values.presto.spec.presto.labels }}
 {{ toYaml .Values.presto.spec.presto.labels | indent 8 }}
 {{- end }}
       annotations:
-        presto-worker-config-hash: {{ include (print $.Template.BasePath "/presto/presto-worker-config.yaml") . | sha256sum }}
+        presto-coordinator-config-hash: {{ include (print $.Template.BasePath "/presto/presto-coordinator-config.yaml") . | sha256sum }}
         presto-common-config-hash: {{ include (print $.Template.BasePath "/presto/presto-common-config.yaml") . | sha256sum }}
         presto-catalog-config-hash: {{ include (print $.Template.BasePath "/presto/presto-catalog-config-secret.yaml") . | sha256sum }}
         presto-jmx-config-hash: {{ include (print $.Template.BasePath "/presto/presto-jmx-config.yaml") . | sha256sum }}
@@ -36,38 +36,57 @@ spec:
       securityContext:
 {{ toYaml .Values.presto.spec.presto.securityContext | indent 8 }}
 {{- end }}
-{{- if .Values.presto.spec.presto.worker.affinity }}
+{{- if .Values.presto.spec.presto.coordinator.affinity }}
       affinity:
-{{ toYaml .Values.presto.spec.presto.worker.affinity | indent 8 }}
+{{ toYaml .Values.presto.spec.presto.coordinator.affinity | indent 8 }}
 {{- end }}
-{{- if .Values.presto.spec.presto.worker.nodeSelector }}
+{{- if .Values.presto.spec.presto.coordinator.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.presto.spec.presto.worker.nodeSelector | indent 8 }}
+{{ toYaml .Values.presto.spec.presto.coordinator.nodeSelector | indent 8 }}
 {{- end }}
-{{- if .Values.presto.spec.presto.worker.tolerations }}
+{{- if .Values.presto.spec.presto.coordinator.tolerations }}
       tolerations:
-{{ toYaml .Values.presto.spec.presto.worker.tolerations | indent 8 }}
+{{ toYaml .Values.presto.spec.presto.coordinator.tolerations | indent 8 }}
 {{- end }}
       initContainers:
       - name: copy-presto-config
         image: "{{ .Values.presto.spec.presto.image.repository }}:{{ .Values.presto.spec.presto.image.tag }}"
         imagePullPolicy: {{ .Values.presto.spec.presto.image.pullPolicy }}
-        command: ['bash', '-c']
+        command: ['/presto-common/initialize_presto.sh']
         # Copy the mounted configuration data into the presto-etc emptyDir volume so we can write to the config files
-        args: ['cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/']
         env:
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+        - name: PRESTO_KEYFILE
+          value: /presto/tls.key
+        - name: PRESTO_CRTFILE
+          value: /presto/tls.crt
+        - name: PRESTO_KEYSTORE_PKCS12
+          value: /opt/presto/tls/keystore.pkcs12
+        - name: PRESTO_KEYSTORE_JKS
+          value: /opt/presto/tls/keystore.jks
+        - name: PRESTO_KEYSTORE_PASSWORD
+          value: password
+{{- end }}
 {{- include "presto-common-env" . | indent 8 }}
         volumeMounts:
         - name: presto-etc
           mountPath: /opt/presto/presto-server/etc
-        - name: presto-worker-config
+        - name: presto-coordinator-config
           mountPath: /presto-etc
         - name: presto-catalog-config
           mountPath: /presto-etc/catalog
         - name: presto-data
           mountPath: /var/presto/data
+        - name: presto-common-config
+          mountPath: /presto-common
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+        - name: presto-tls
+          mountPath: /opt/presto/tls
+        - name: presto-pem-files
+          mountPath: /presto
+{{- end }}
         resources:
-{{ toYaml .Values.presto.spec.presto.worker.resources | indent 10 }}
+{{ toYaml .Values.presto.spec.presto.coordinator.resources | indent 10 }}
       containers:
       - name: presto
         image: "{{ .Values.presto.spec.presto.image.repository }}:{{ .Values.presto.spec.presto.image.tag }}"
@@ -76,7 +95,7 @@ spec:
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
         env:
         - name: JAVA_MAX_MEM_RATIO
-          value: "{{ .Values.presto.spec.presto.worker.config.jvm.percentMemoryLimitAsHeap }}"
+          value: "{{ .Values.presto.spec.presto.coordinator.config.jvm.percentMemoryLimitAsHeap }}"
 {{- include "presto-common-env" . | indent 8 }}
         ports:
         - name: http
@@ -96,16 +115,20 @@ spec:
           mountPath: /var/presto/data
         - name: presto-logs
           mountPath: /var/presto/logs
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+        - name: presto-tls
+          mountPath: /opt/presto/tls
+{{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
         - name: hive-warehouse-data
           mountPath: {{ .Values.presto.spec.config.sharedVolume.mountPath }}
 {{- end }}
         resources:
-{{ toYaml .Values.presto.spec.presto.worker.resources | indent 10 }}
+{{ toYaml .Values.presto.spec.presto.coordinator.resources | indent 10 }}
       volumes:
-      - name: presto-worker-config
+      - name: presto-coordinator-config
         configMap:
-          name: presto-worker-config
+          name: presto-coordinator-config
       - name: presto-common-config
         configMap:
           name: presto-common-config
@@ -122,6 +145,13 @@ spec:
         emptyDir: {}
       - name: presto-logs
         emptyDir: {}
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+      - name: presto-tls
+        emptyDir: {}
+      - name: presto-pem-files
+        secret:
+          secretName: {{ .Values.presto.spec.presto.config.tls.secretName }}
+{{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
@@ -134,4 +164,4 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.presto.spec.imagePullSecrets | indent 8 }}
 {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.presto.spec.presto.worker.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.presto.spec.presto.coordinator.terminationGracePeriodSeconds }}

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -13,12 +13,28 @@ data:
     node.environment=production
 
   config.properties: |
+    coordinator=false
+    node-scheduler.include-coordinator={{ .Values.presto.spec.presto.config.nodeSchedulerIncludeCoordinator }}
+
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+    http-server.http.enabled=false
+    http-server.https.enabled=true
+    http-server.https.port=8080
+    http-server.https.keystore.path=/opt/presto/tls/keystore.jks
+    http-server.https.keystore.key=password
+    node.internal-address-source=FQDN
+    discovery.uri=https://presto:8080
+    internal-communication.https.required=true
+    internal-communication.https.keystore.path=/opt/presto/tls/keystore.jks
+    internal-communication.https.keystore.key=password
+{{- else }}
     http-server.http.port=8080
+    discovery.uri=http://presto:8080
+{{- end }}
+
     jmx.rmiserver.port=8081
     jmx.rmiregistry.port=8081
-    coordinator=false
-    discovery.uri={{ .Values.presto.spec.presto.config.discoveryURI }}
-    node-scheduler.include-coordinator={{ .Values.presto.spec.presto.config.nodeSchedulerIncludeCoordinator }}
+
 {{- if .Values.presto.spec.presto.config.maxQueryLength }}
     query.max-length={{ .Values.presto.spec.presto.config.maxQueryLength }}
 {{- end }}

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: presto-coordinator
+  name: presto-worker
   labels:
     app: presto
-    presto: coordinator
+    presto: worker
 spec:
-  replicas: 1
+  replicas: {{ .Values.presto.spec.presto.worker.replicas }}
   serviceName: presto-nodes
   selector:
     matchLabels:
       app: presto
-      presto: coordinator
+      presto: worker
 {{- if .Values.presto.spec.presto.labels }}
 {{ toYaml .Values.presto.spec.presto.labels | indent 6 }}
 {{- end }}
@@ -19,12 +19,12 @@ spec:
     metadata:
       labels:
         app: presto
-        presto: coordinator
+        presto: worker
 {{- if .Values.presto.spec.presto.labels }}
 {{ toYaml .Values.presto.spec.presto.labels | indent 8 }}
 {{- end }}
       annotations:
-        presto-coordinator-config-hash: {{ include (print $.Template.BasePath "/presto/presto-coordinator-config.yaml") . | sha256sum }}
+        presto-worker-config-hash: {{ include (print $.Template.BasePath "/presto/presto-worker-config.yaml") . | sha256sum }}
         presto-common-config-hash: {{ include (print $.Template.BasePath "/presto/presto-common-config.yaml") . | sha256sum }}
         presto-catalog-config-hash: {{ include (print $.Template.BasePath "/presto/presto-catalog-config-secret.yaml") . | sha256sum }}
         presto-jmx-config-hash: {{ include (print $.Template.BasePath "/presto/presto-jmx-config.yaml") . | sha256sum }}
@@ -36,38 +36,57 @@ spec:
       securityContext:
 {{ toYaml .Values.presto.spec.presto.securityContext | indent 8 }}
 {{- end }}
-{{- if .Values.presto.spec.presto.coordinator.affinity }}
+{{- if .Values.presto.spec.presto.worker.affinity }}
       affinity:
-{{ toYaml .Values.presto.spec.presto.coordinator.affinity | indent 8 }}
+{{ toYaml .Values.presto.spec.presto.worker.affinity | indent 8 }}
 {{- end }}
-{{- if .Values.presto.spec.presto.coordinator.nodeSelector }}
+{{- if .Values.presto.spec.presto.worker.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.presto.spec.presto.coordinator.nodeSelector | indent 8 }}
+{{ toYaml .Values.presto.spec.presto.worker.nodeSelector | indent 8 }}
 {{- end }}
-{{- if .Values.presto.spec.presto.coordinator.tolerations }}
+{{- if .Values.presto.spec.presto.worker.tolerations }}
       tolerations:
-{{ toYaml .Values.presto.spec.presto.coordinator.tolerations | indent 8 }}
+{{ toYaml .Values.presto.spec.presto.worker.tolerations | indent 8 }}
 {{- end }}
       initContainers:
       - name: copy-presto-config
         image: "{{ .Values.presto.spec.presto.image.repository }}:{{ .Values.presto.spec.presto.image.tag }}"
         imagePullPolicy: {{ .Values.presto.spec.presto.image.pullPolicy }}
-        command: ['bash', '-c']
+        command: ['/presto-common/initialize_presto.sh']
         # Copy the mounted configuration data into the presto-etc emptyDir volume so we can write to the config files
-        args: ['cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/']
         env:
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+        - name: PRESTO_KEYFILE
+          value: /presto/tls.key
+        - name: PRESTO_CRTFILE
+          value: /presto/tls.crt
+        - name: PRESTO_KEYSTORE_PKCS12
+          value: /opt/presto/tls/keystore.pkcs12
+        - name: PRESTO_KEYSTORE_JKS
+          value: /opt/presto/tls/keystore.jks
+        - name: PRESTO_KEYSTORE_PASSWORD
+          value: password
+{{- end }}
 {{- include "presto-common-env" . | indent 8 }}
         volumeMounts:
         - name: presto-etc
           mountPath: /opt/presto/presto-server/etc
-        - name: presto-coordinator-config
+        - name: presto-worker-config
           mountPath: /presto-etc
         - name: presto-catalog-config
           mountPath: /presto-etc/catalog
         - name: presto-data
           mountPath: /var/presto/data
+        - name: presto-common-config
+          mountPath: /presto-common
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+        - name: presto-tls
+          mountPath: /opt/presto/tls
+        - name: presto-pem-files
+          mountPath: /presto
+{{- end }}
         resources:
-{{ toYaml .Values.presto.spec.presto.coordinator.resources | indent 10 }}
+{{ toYaml .Values.presto.spec.presto.worker.resources | indent 10 }}
       containers:
       - name: presto
         image: "{{ .Values.presto.spec.presto.image.repository }}:{{ .Values.presto.spec.presto.image.tag }}"
@@ -76,7 +95,7 @@ spec:
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
         env:
         - name: JAVA_MAX_MEM_RATIO
-          value: "{{ .Values.presto.spec.presto.coordinator.config.jvm.percentMemoryLimitAsHeap }}"
+          value: "{{ .Values.presto.spec.presto.worker.config.jvm.percentMemoryLimitAsHeap }}"
 {{- include "presto-common-env" . | indent 8 }}
         ports:
         - name: http
@@ -96,16 +115,20 @@ spec:
           mountPath: /var/presto/data
         - name: presto-logs
           mountPath: /var/presto/logs
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+        - name: presto-tls
+          mountPath: /opt/presto/tls
+{{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
         - name: hive-warehouse-data
           mountPath: {{ .Values.presto.spec.config.sharedVolume.mountPath }}
 {{- end }}
         resources:
-{{ toYaml .Values.presto.spec.presto.coordinator.resources | indent 10 }}
+{{ toYaml .Values.presto.spec.presto.worker.resources | indent 10 }}
       volumes:
-      - name: presto-coordinator-config
+      - name: presto-worker-config
         configMap:
-          name: presto-coordinator-config
+          name: presto-worker-config
       - name: presto-common-config
         configMap:
           name: presto-common-config
@@ -122,6 +145,13 @@ spec:
         emptyDir: {}
       - name: presto-logs
         emptyDir: {}
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+      - name: presto-tls
+        emptyDir: {}
+      - name: presto-pem-files
+        secret:
+          secretName: {{ .Values.presto.spec.presto.config.tls.secretName }}
+{{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
@@ -134,4 +164,4 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.presto.spec.imagePullSecrets | indent 8 }}
 {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.presto.spec.presto.coordinator.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.presto.spec.presto.worker.terminationGracePeriodSeconds }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -15,6 +15,9 @@ data:
   prometheus-url: {{ required "a valid reporting-operator.spec.config.prometheusURL must be set" $operatorValues.spec.config.prometheusURL | quote}}
   disable-prometheus-metrics-importer: {{ $operatorValues.spec.config.disablePrometheusMetricsImporter | quote}}
   enable-finalizers: {{ $operatorValues.spec.config.enableFinalizers | quote}}
+{{- if $operatorValues.spec.config.prestoTLS.enabled }}
+  presto-ca-file: "/var/run/secrets/presto-tls/tls.crt"
+{{- end }}
 {{- if $operatorValues.spec.config.prometheusMetricsImporterPollInterval }}
   prometheus-metrics-importer-poll-interval: {{ $operatorValues.spec.config.prometheusMetricsImporterPollInterval | quote}}
 {{- end }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -186,6 +186,18 @@ spec:
             configMapKeyRef:
               name: reporting-operator-config
               key: presto-host
+{{- if $operatorValues.spec.config.prestoTLS.enabled}}
+        - name: REPORTING_OPERATOR_PRESTO_USE_TLS
+          value: "true"
+        - name: REPORTING_OPERATOR_PRESTO_CA_FILE
+          valueFrom:
+            configMapKeyRef:
+              name: reporting-operator-config
+              key: presto-ca-file
+{{- else }}
+        - name: REPORTING_OPERATOR_PRESTO_USE_TLS
+          value: "false"
+{{- end }}
         - name: REPORTING_OPERATOR_HIVE_HOST
           valueFrom:
             configMapKeyRef:
@@ -257,6 +269,10 @@ spec:
 {{ toYaml $operatorValues.spec.livenessProbe | indent 10 }}
 {{- end }}
         volumeMounts:
+{{- if $operatorValues.spec.config.prestoTLS.enabled }}
+        - name: presto-tls
+          mountPath: /var/run/secrets/presto-tls/
+{{- end }}
 {{- if $operatorValues.spec.config.tls.enabled }}
         - name: api-tls
           mountPath: /tls
@@ -333,6 +349,11 @@ spec:
 {{- end }}
 {{- end }}
       volumes:
+{{- if $operatorValues.spec.config.prestoTLS.enabled }}
+      - name: presto-tls
+        secret:
+          secretName: {{ $operatorValues.spec.config.prestoTLS.secretName }}
+{{- end }}
 {{- if $operatorValues.spec.config.tls.enabled }}
       - name: api-tls
         secret:

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -229,6 +229,9 @@ reporting-operator:
         secretName: reporting-operator-metrics-tls-secrets
       prestoHost: presto:8080
       prestoMaxQueryLength: null
+      prestoTLS:
+        enabled: false
+        secretName: ""
       prometheusCertificateAuthority:
         configMap:
           create: false
@@ -418,9 +421,11 @@ presto:
     presto:
       annotations: {}
       config:
+        tls:
+          enabled: false
+          secretName: ""
         connectors:
           extraConnectorFiles: []
-        discoveryURI: http://presto:8080
         environment: production
         hiveMetastoreURI: thrift://hive-metastore:9083
         maxQueryLength: "10000000"

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -78,6 +78,9 @@ func init() {
 	startCmd.Flags().StringVar(&cfg.HiveCAFile, "hive-ca-file", "", "The path to the certificate authority to use to connect to Hive. If empty, defaults to system CAs")
 
 	startCmd.Flags().StringVar(&cfg.PrestoHost, "presto-host", defaultPrestoHost, "the hostname:port for connecting to Presto")
+	startCmd.Flags().BoolVar(&cfg.PrestoUseTLS, "presto-use-tls", false, "If true, enables TLS when connecting to Presto")
+	startCmd.Flags().StringVar(&cfg.PrestoCAFile, "presto-ca-file", "", "The path to the certificate authority to use to connect to Presto.")
+
 	startCmd.Flags().StringVar(&cfg.PrometheusConfig.Address, "prometheus-host", defaultPromHost, "the URL string for connecting to Prometheus")
 	startCmd.Flags().BoolVar(&cfg.PrometheusConfig.SkipTLSVerify, "prometheus-skip-tls-verify", false, "Skip TLS verification")
 	startCmd.Flags().StringVar(&cfg.PrometheusConfig.BearerToken, "prometheus-bearer-token", "", "Bearer token to authenticate against Prometheus.")

--- a/images/helm-operator/deploy-resources.sh
+++ b/images/helm-operator/deploy-resources.sh
@@ -329,8 +329,8 @@ installPrestoResources() {
     helmTemplateAndApply templates/presto/presto-service.yaml presto-service true false
     helmTemplateAndApply templates/presto/presto-worker-config.yaml presto-worker-config true false
 
-    helmTemplateAndApply templates/presto/presto-coordinator-deployment.yaml presto-coordinator-deployment true false
-    helmTemplateAndApply templates/presto/presto-worker-deployment.yaml presto-worker-deployment true false
+    helmTemplateAndApply templates/presto/presto-coordinator-statefulset.yaml presto-coordinator-statefulset true false
+    helmTemplateAndApply templates/presto/presto-worker-statefulset.yaml presto-worker-statefulset true false
 }
 
 installReportingOperatorResources() {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/workqueue"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/db"
 	cbClientset "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned"
 	factory "github.com/operator-framework/operator-metering/pkg/generated/informers/externalversions"
@@ -113,7 +113,7 @@ type Config struct {
 	LogDMLQueries bool
 	LogDDLQueries bool
 
-	PrometheusQueryConfig                         cbTypes.PrometheusQueryConfig
+	PrometheusQueryConfig                         metering.PrometheusQueryConfig
 	PrometheusDataSourceMaxQueryRangeDuration     time.Duration
 	PrometheusDataSourceMaxBackfillImportDuration time.Duration
 	PrometheusDataSourceGlobalImportFromTime      *time.Time
@@ -729,5 +729,5 @@ func (op *Reporting) newPrometheusConn(promConfig promapi.Config) (prom.API, err
 }
 
 type DependencyResolver interface {
-	ResolveDependencies(namespace string, inputDefs []cbTypes.ReportQueryInputDefinition, inputVals []cbTypes.ReportQueryInputValue) (*reporting.DependencyResolutionResult, error)
+	ResolveDependencies(namespace string, inputDefs []metering.ReportQueryInputDefinition, inputVals []metering.ReportQueryInputValue) (*reporting.DependencyResolutionResult, error)
 }


### PR DESCRIPTION
### Overview:
Currently, the presto coordinator and worker pods communicate using http. With this change, the presto components can communicate using https when specified in the configurations, or by default, http.

You would need to specify key/cert pem files, which are then used to create a java keystore file and provided to presto.