### PR TITLE
charts: Add ReservedCodeCacheSize and jdk.nio.maxCachedBufferSize to presto JVM options

### DIFF
--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -77,6 +77,8 @@ data:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
+    -XX:ReservedCodeCacheSize=512M
+    -Djdk.nio.maxCachedBufferSize=2000000
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
     -Dcom.sun.management.jmxremote
     -Dcom.sun.management.jmxremote.local.only=false

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -76,6 +76,8 @@ data:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
+    -XX:ReservedCodeCacheSize=512M
+    -Djdk.nio.maxCachedBufferSize=2000000
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
     -Dcom.sun.management.jmxremote
     -Dcom.sun.management.jmxremote.local.only=false


### PR DESCRIPTION
As recommended by the presto deployment documentation.