### PR TITLE
Add support for configuring TLS authentication for Presto components by providing pre-existing secrets containing server, client, and CA resources.

### DIFF
--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -8,8 +8,14 @@ data:
     set -e
 
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
-    openssl pkcs12 -export -inkey $PRESTO_KEYFILE -in $PRESTO_CRTFILE -out $PRESTO_KEYSTORE_PKCS12 -password pass:$PRESTO_KEYSTORE_PASSWORD
-    keytool -importkeystore -noprompt -srckeystore $PRESTO_KEYSTORE_PKCS12 -srcstoretype pkcs12 -destkeystore $PRESTO_KEYSTORE_JKS -storepass $PRESTO_KEYSTORE_PASSWORD -srcstorepass $PRESTO_KEYSTORE_PASSWORD
+    # copy all necessary tls.crt/tls.key from read-only secret volumes
+    cat $PRESTO_SERVER_KEYFILE $PRESTO_SERVER_CRTFILE > $PRESTO_SERVER_PEM
+    cat $PRESTO_SERVER_PEM $PRESTO_CA_CRTFILE > $PRESTO_KEYSTORE_PEM
+    cat $PRESTO_SERVER_PEM $PRESTO_CA_CRTFILE > $PRESTO_TRUSTSTORE_PEM
+{{- end }}
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+    # append the client key/certificate to the beginning of the truststore PEM
+    sed -i -e '1 e cat $PRESTO_CLIENT_KEYFILE $PRESTO_CLIENT_CRTFILE' $PRESTO_TRUSTSTORE_PEM
 {{- end }}
 
     cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/

--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -7,15 +7,14 @@ data:
     #!/bin/bash
     set -e
 
-{{- if .Values.presto.spec.presto.config.tls.enabled }}
-    # copy all necessary tls.crt/tls.key from read-only secret volumes
-    cat $PRESTO_SERVER_KEYFILE $PRESTO_SERVER_CRTFILE > $PRESTO_SERVER_PEM
-    cat $PRESTO_SERVER_PEM $PRESTO_CA_CRTFILE > $PRESTO_KEYSTORE_PEM
-    cat $PRESTO_SERVER_PEM $PRESTO_CA_CRTFILE > $PRESTO_TRUSTSTORE_PEM
-{{- end }}
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
-    # append the client key/certificate to the beginning of the truststore PEM
-    sed -i -e '1 e cat $PRESTO_CLIENT_KEYFILE $PRESTO_CLIENT_CRTFILE' $PRESTO_TRUSTSTORE_PEM
+    cat $PRESTO_CLIENT_KEYFILE $PRESTO_CLIENT_CRTFILE > $PRESTO_TRUSTSTORE_PEM
+
+{{- if .Values.presto.spec.presto.config.tls.enabled }}
+    # copy all necessary tls.crt/tls.key from read-only secret volumes - append server bundle and CA cert to truststore
+    cat $PRESTO_SERVER_KEYFILE $PRESTO_SERVER_CRTFILE $PRESTO_CA_CRTFILE > $PRESTO_KEYSTORE_PEM
+    cat $PRESTO_SERVER_KEYFILE $PRESTO_SERVER_CRTFILE $PRESTO_CA_CRTFILE >> $PRESTO_TRUSTSTORE_PEM
+{{- end }}
 {{- end }}
 
     cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/

--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -21,16 +21,19 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port=8080
-    http-server.https.keystore.path=/opt/presto/tls/keystore.jks
-    http-server.https.keystore.key=password
+    http-server.https.keystore.path=/opt/presto/tls/keystore.pem
+    http-server.https.truststore.path=/opt/presto/tls/truststore.pem
     node.internal-address-source=FQDN
     discovery.uri=https://presto:8080
     internal-communication.https.required=true
-    internal-communication.https.keystore.path=/opt/presto/tls/keystore.jks
-    internal-communication.https.keystore.key=password
+    internal-communication.https.keystore.path=/opt/presto/tls/keystore.pem
+    internal-communication.https.truststore.path=/opt/presto/tls/truststore.pem
 {{- else }}
     http-server.http.port=8080
     discovery.uri=http://presto:8080
+{{- end }}
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+    http-server.authentication.type=CERTIFICATE
 {{- end }}
 
     jmx.rmiserver.port=8081

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -56,16 +56,24 @@ spec:
         # Copy the mounted configuration data into the presto-etc emptyDir volume so we can write to the config files
         env:
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
-        - name: PRESTO_KEYFILE
-          value: /presto/tls.key
-        - name: PRESTO_CRTFILE
-          value: /presto/tls.crt
-        - name: PRESTO_KEYSTORE_PKCS12
-          value: /opt/presto/tls/keystore.pkcs12
-        - name: PRESTO_KEYSTORE_JKS
-          value: /opt/presto/tls/keystore.jks
-        - name: PRESTO_KEYSTORE_PASSWORD
-          value: password
+        - name: PRESTO_SERVER_KEYFILE
+          value: /presto-server/tls.key
+        - name: PRESTO_SERVER_CRTFILE
+          value: /presto-server/tls.crt
+        - name: PRESTO_SERVER_PEM
+          value: /opt/presto/tls/server.pem
+        - name: PRESTO_KEYSTORE_PEM
+          value: /opt/presto/tls/keystore.pem
+        - name: PRESTO_TRUSTSTORE_PEM
+          value: /opt/presto/tls/truststore.pem
+        - name: PRESTO_CA_CRTFILE
+          value: /presto-ca/tls.crt
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+        - name: PRESTO_CLIENT_KEYFILE
+          value: /presto-client/tls.key
+        - name: PRESTO_CLIENT_CRTFILE
+          value: /presto-client/tls.crt
+{{- end }}
 {{- end }}
 {{- include "presto-common-env" . | indent 8 }}
         volumeMounts:
@@ -82,8 +90,14 @@ spec:
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
         - name: presto-tls
           mountPath: /opt/presto/tls
-        - name: presto-pem-files
-          mountPath: /presto
+        - name: presto-server-pem
+          mountPath: /presto-server
+        - name: presto-ca-pem
+          mountPath: /presto-ca
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+        - name: presto-client-pem
+          mountPath: /presto-client
+{{- end }}
 {{- end }}
         resources:
           limits:
@@ -153,9 +167,19 @@ spec:
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
       - name: presto-tls
         emptyDir: {}
-      - name: presto-pem-files
+      - name: presto-server-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.tls.secretName }}
+          secretName: {{ .Values.presto.spec.presto.config.tls.serverSecretName }}
+      - name: presto-ca
+        emptyDir: {}
+      - name: presto-ca-pem
+        secret:
+          secretName: {{ .Values.presto.spec.presto.config.tls.rootCASecretName }}
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+      - name: presto-client-pem
+        secret:
+          secretName: {{ .Values.presto.spec.presto.config.auth.clientSecretName }}
+{{- end }}
 {{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -60,14 +60,12 @@ spec:
           value: /presto-server/tls.key
         - name: PRESTO_SERVER_CRTFILE
           value: /presto-server/tls.crt
-        - name: PRESTO_SERVER_PEM
-          value: /opt/presto/tls/server.pem
+        - name: PRESTO_CA_CRTFILE
+          value: /presto-server/ca.crt
         - name: PRESTO_KEYSTORE_PEM
           value: /opt/presto/tls/keystore.pem
         - name: PRESTO_TRUSTSTORE_PEM
           value: /opt/presto/tls/truststore.pem
-        - name: PRESTO_CA_CRTFILE
-          value: /presto-ca/tls.crt
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
         - name: PRESTO_CLIENT_KEYFILE
           value: /presto-client/tls.key
@@ -92,8 +90,6 @@ spec:
           mountPath: /opt/presto/tls
         - name: presto-server-pem
           mountPath: /presto-server
-        - name: presto-ca-pem
-          mountPath: /presto-ca
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
         - name: presto-client-pem
           mountPath: /presto-client
@@ -169,16 +165,11 @@ spec:
         emptyDir: {}
       - name: presto-server-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.tls.serverSecretName }}
-      - name: presto-ca
-        emptyDir: {}
-      - name: presto-ca-pem
-        secret:
-          secretName: {{ .Values.presto.spec.presto.config.tls.rootCASecretName }}
+          secretName: {{ .Values.presto.spec.presto.config.tls.serverCertificateSecretName }}
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
       - name: presto-client-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.auth.clientSecretName }}
+          secretName: {{ .Values.presto.spec.presto.config.auth.clientCertificateSecretName }}
 {{- end }}
 {{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -20,16 +20,19 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port=8080
-    http-server.https.keystore.path=/opt/presto/tls/keystore.jks
-    http-server.https.keystore.key=password
+    http-server.https.keystore.path=/opt/presto/tls/keystore.pem
+    http-server.https.truststore.path=/opt/presto/tls/truststore.pem
     node.internal-address-source=FQDN
     discovery.uri=https://presto:8080
     internal-communication.https.required=true
-    internal-communication.https.keystore.path=/opt/presto/tls/keystore.jks
-    internal-communication.https.keystore.key=password
+    internal-communication.https.keystore.path=/opt/presto/tls/keystore.pem
+    internal-communication.https.truststore.path=/opt/presto/tls/truststore.pem
 {{- else }}
     http-server.http.port=8080
     discovery.uri=http://presto:8080
+{{- end }}
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+    http-server.authentication.type=CERTIFICATE
 {{- end }}
 
     jmx.rmiserver.port=8081

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -56,16 +56,24 @@ spec:
         # Copy the mounted configuration data into the presto-etc emptyDir volume so we can write to the config files
         env:
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
-        - name: PRESTO_KEYFILE
-          value: /presto/tls.key
-        - name: PRESTO_CRTFILE
-          value: /presto/tls.crt
-        - name: PRESTO_KEYSTORE_PKCS12
-          value: /opt/presto/tls/keystore.pkcs12
-        - name: PRESTO_KEYSTORE_JKS
-          value: /opt/presto/tls/keystore.jks
-        - name: PRESTO_KEYSTORE_PASSWORD
-          value: password
+        - name: PRESTO_SERVER_KEYFILE
+          value: /presto-server/tls.key
+        - name: PRESTO_SERVER_CRTFILE
+          value: /presto-server/tls.crt
+        - name: PRESTO_SERVER_PEM
+          value: /opt/presto/tls/server.pem
+        - name: PRESTO_KEYSTORE_PEM
+          value: /opt/presto/tls/keystore.pem
+        - name: PRESTO_TRUSTSTORE_PEM
+          value: /opt/presto/tls/truststore.pem
+        - name: PRESTO_CA_CRTFILE
+          value: /presto-ca/tls.crt
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+        - name: PRESTO_CLIENT_KEYFILE
+          value: /presto-client/tls.key
+        - name: PRESTO_CLIENT_CRTFILE
+          value: /presto-client/tls.crt
+{{- end }}
 {{- end }}
 {{- include "presto-common-env" . | indent 8 }}
         volumeMounts:
@@ -82,8 +90,14 @@ spec:
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
         - name: presto-tls
           mountPath: /opt/presto/tls
-        - name: presto-pem-files
-          mountPath: /presto
+        - name: presto-server-pem
+          mountPath: /presto-server
+        - name: presto-ca-pem
+          mountPath: /presto-ca
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+        - name: presto-client-pem
+          mountPath: /presto-client
+{{- end }}
 {{- end }}
         resources:
           limits:
@@ -153,9 +167,19 @@ spec:
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
       - name: presto-tls
         emptyDir: {}
-      - name: presto-pem-files
+      - name: presto-server-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.tls.secretName }}
+          secretName: {{ .Values.presto.spec.presto.config.tls.serverSecretName }}
+      - name: presto-ca
+        emptyDir: {}
+      - name: presto-ca-pem
+        secret:
+          secretName: {{ .Values.presto.spec.presto.config.tls.rootCASecretName }}
+{{- if .Values.presto.spec.presto.config.auth.enabled }}
+      - name: presto-client-pem
+        secret:
+          secretName: {{ .Values.presto.spec.presto.config.auth.clientSecretName }}
+{{- end }}
 {{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -60,14 +60,12 @@ spec:
           value: /presto-server/tls.key
         - name: PRESTO_SERVER_CRTFILE
           value: /presto-server/tls.crt
-        - name: PRESTO_SERVER_PEM
-          value: /opt/presto/tls/server.pem
+        - name: PRESTO_CA_CRTFILE
+          value: /presto-server/ca.crt
         - name: PRESTO_KEYSTORE_PEM
           value: /opt/presto/tls/keystore.pem
         - name: PRESTO_TRUSTSTORE_PEM
           value: /opt/presto/tls/truststore.pem
-        - name: PRESTO_CA_CRTFILE
-          value: /presto-ca/tls.crt
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
         - name: PRESTO_CLIENT_KEYFILE
           value: /presto-client/tls.key
@@ -92,8 +90,6 @@ spec:
           mountPath: /opt/presto/tls
         - name: presto-server-pem
           mountPath: /presto-server
-        - name: presto-ca-pem
-          mountPath: /presto-ca
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
         - name: presto-client-pem
           mountPath: /presto-client
@@ -169,16 +165,11 @@ spec:
         emptyDir: {}
       - name: presto-server-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.tls.serverSecretName }}
-      - name: presto-ca
-        emptyDir: {}
-      - name: presto-ca-pem
-        secret:
-          secretName: {{ .Values.presto.spec.presto.config.tls.rootCASecretName }}
+          secretName: {{ .Values.presto.spec.presto.config.tls.serverCertificateSecretName }}
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
       - name: presto-client-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.auth.clientSecretName }}
+          secretName: {{ .Values.presto.spec.presto.config.auth.clientCertificateSecretName }}
 {{- end }}
 {{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -18,7 +18,7 @@ data:
 {{- if $operatorValues.spec.config.prestoTLS.enabled }}
   presto-ca-file: "/var/run/secrets/presto-tls/tls.crt"
 {{- if $operatorValues.spec.config.prestoAuth.enabled }}
-  presto-server-file: "/var/run/secrets/presto-auth/"
+  presto-client-cert-file: "/var/run/secrets/presto-auth/"
 {{- end }}
 {{- end }}
 {{- if $operatorValues.spec.config.prometheusMetricsImporterPollInterval }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -18,7 +18,8 @@ data:
 {{- if $operatorValues.spec.config.prestoTLS.enabled }}
   presto-ca-file: "/var/run/secrets/presto-tls/tls.crt"
 {{- if $operatorValues.spec.config.prestoAuth.enabled }}
-  presto-client-cert-file: "/var/run/secrets/presto-auth/"
+  presto-client-cert-file: "/var/run/secrets/presto-auth/tls.crt"
+  presto-client-key-file: "/var/run/secrets/presto-auth/tls.key"
 {{- end }}
 {{- end }}
 {{- if $operatorValues.spec.config.prometheusMetricsImporterPollInterval }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -17,6 +17,9 @@ data:
   enable-finalizers: {{ $operatorValues.spec.config.enableFinalizers | quote}}
 {{- if $operatorValues.spec.config.prestoTLS.enabled }}
   presto-ca-file: "/var/run/secrets/presto-tls/tls.crt"
+{{- if $operatorValues.spec.config.prestoAuth.enabled }}
+  presto-server-file: "/var/run/secrets/presto-auth/"
+{{- end }}
 {{- end }}
 {{- if $operatorValues.spec.config.prometheusMetricsImporterPollInterval }}
   prometheus-metrics-importer-poll-interval: {{ $operatorValues.spec.config.prometheusMetricsImporterPollInterval | quote}}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -186,7 +186,7 @@ spec:
             configMapKeyRef:
               name: reporting-operator-config
               key: presto-host
-{{- if $operatorValues.spec.config.prestoTLS.enabled}}
+{{- if $operatorValues.spec.config.prestoTLS.enabled }}
         - name: REPORTING_OPERATOR_PRESTO_USE_TLS
           value: "true"
         - name: REPORTING_OPERATOR_PRESTO_CA_FILE
@@ -196,6 +196,18 @@ spec:
               key: presto-ca-file
 {{- else }}
         - name: REPORTING_OPERATOR_PRESTO_USE_TLS
+          value: "false"
+{{- end }}
+{{- if $operatorValues.spec.config.prestoAuth.enabled }}
+        - name: REPORTING_OPERATOR_PRESTO_USE_AUTH
+          value: "true"
+        - name: REPORTING_OPERATOR_PRESTO_SERVER_FILE
+          valueFrom:
+            configMapKeyRef:
+              name: reporting-operator-config
+              key: presto-server-file
+{{- else }}
+        - name: REPORTING_OPERATOR_PRESTO_USE_AUTH
           value: "false"
 {{- end }}
         - name: REPORTING_OPERATOR_HIVE_HOST
@@ -271,7 +283,11 @@ spec:
         volumeMounts:
 {{- if $operatorValues.spec.config.prestoTLS.enabled }}
         - name: presto-tls
-          mountPath: /var/run/secrets/presto-tls/
+          mountPath: /var/run/secrets/presto-tls
+{{- if $operatorValues.spec.config.prestoAuth.enabled }}
+        - name: presto-auth
+          mountPath: /var/run/secrets/presto-auth
+{{- end }}
 {{- end }}
 {{- if $operatorValues.spec.config.tls.enabled }}
         - name: api-tls
@@ -353,6 +369,11 @@ spec:
       - name: presto-tls
         secret:
           secretName: {{ $operatorValues.spec.config.prestoTLS.secretName }}
+{{- if $operatorValues.spec.config.prestoAuth.enabled }}
+      - name: presto-auth
+        secret:
+          secretName: {{ $operatorValues.spec.config.prestoAuth.secretName }}
+{{- end }}
 {{- end }}
 {{- if $operatorValues.spec.config.tls.enabled }}
       - name: api-tls

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -201,11 +201,11 @@ spec:
 {{- if $operatorValues.spec.config.prestoAuth.enabled }}
         - name: REPORTING_OPERATOR_PRESTO_USE_AUTH
           value: "true"
-        - name: REPORTING_OPERATOR_PRESTO_SERVER_FILE
+        - name: REPORTING_OPERATOR_PRESTO_CLIENT_CERT_FILE
           valueFrom:
             configMapKeyRef:
               name: reporting-operator-config
-              key: presto-server-file
+              key: presto-client-cert-file
 {{- else }}
         - name: REPORTING_OPERATOR_PRESTO_USE_AUTH
           value: "false"

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -206,6 +206,11 @@ spec:
             configMapKeyRef:
               name: reporting-operator-config
               key: presto-client-cert-file
+        - name: REPORTING_OPERATOR_PRESTO_CLIENT_KEY_FILE
+          valueFrom:
+            configMapKeyRef:
+              name: reporting-operator-config
+              key: presto-client-key-file
 {{- else }}
         - name: REPORTING_OPERATOR_PRESTO_USE_AUTH
           value: "false"

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -426,11 +426,10 @@ presto:
       config:
         tls:
           enabled: false
-          serverSecretName: ""
-          rootCASecretName: ""
+          serverCertificateSecretName: ""
         auth:
           enabled: false
-          clientSecretName: ""
+          clientCertificateSecretName: ""
         connectors:
           extraConnectorFiles: []
         environment: production

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -232,6 +232,9 @@ reporting-operator:
       prestoTLS:
         enabled: false
         secretName: ""
+      prestoAuth:
+        enabled: false
+        secretName: ""
       prometheusCertificateAuthority:
         configMap:
           create: false
@@ -423,7 +426,11 @@ presto:
       config:
         tls:
           enabled: false
-          secretName: ""
+          serverSecretName: ""
+          rootCASecretName: ""
+        auth:
+          enabled: false
+          clientSecretName: ""
         connectors:
           extraConnectorFiles: []
         environment: production

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -79,7 +79,9 @@ func init() {
 
 	startCmd.Flags().StringVar(&cfg.PrestoHost, "presto-host", defaultPrestoHost, "the hostname:port for connecting to Presto")
 	startCmd.Flags().BoolVar(&cfg.PrestoUseTLS, "presto-use-tls", false, "If true, enables TLS when connecting to Presto")
+	startCmd.Flags().BoolVar(&cfg.PrestoUseAuth, "presto-use-auth", false, "If true, enables TLS authentication when connecting to Presto")
 	startCmd.Flags().StringVar(&cfg.PrestoCAFile, "presto-ca-file", "", "The path to the certificate authority to use to connect to Presto.")
+	startCmd.Flags().StringVar(&cfg.PrestoServerFile, "presto-server-file", "", "The path to the certificate authority to use to connect to Presto.")
 
 	startCmd.Flags().StringVar(&cfg.PrometheusConfig.Address, "prometheus-host", defaultPromHost, "the URL string for connecting to Prometheus")
 	startCmd.Flags().BoolVar(&cfg.PrometheusConfig.SkipTLSVerify, "prometheus-skip-tls-verify", false, "Skip TLS verification")

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -82,6 +82,7 @@ func init() {
 	startCmd.Flags().BoolVar(&cfg.PrestoUseClientCertAuth, "presto-use-auth", false, "If true, enables TLS client certificate authentication when presto-use-tls is also enabled.")
 	startCmd.Flags().StringVar(&cfg.PrestoCAFile, "presto-ca-file", "", "The path to the certificate authority to use to connect to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientCertFile, "presto-client-cert-file", "", "The path to the client certificate to use to connect to Presto.")
+	startCmd.Flags().StringVar(&cfg.PrestoClientKeyFile, "presto-client-key-file", "", "The path to the client private key to use to connect to Presto.")
 
 	startCmd.Flags().StringVar(&cfg.PrometheusConfig.Address, "prometheus-host", defaultPromHost, "the URL string for connecting to Prometheus")
 	startCmd.Flags().BoolVar(&cfg.PrometheusConfig.SkipTLSVerify, "prometheus-skip-tls-verify", false, "Skip TLS verification")

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -77,11 +77,11 @@ func init() {
 	startCmd.Flags().BoolVar(&cfg.HiveUseTLS, "hive-use-tls", false, "If true, enables TLS when connecting to Hive")
 	startCmd.Flags().StringVar(&cfg.HiveCAFile, "hive-ca-file", "", "The path to the certificate authority to use to connect to Hive. If empty, defaults to system CAs")
 
-	startCmd.Flags().StringVar(&cfg.PrestoHost, "presto-host", defaultPrestoHost, "the hostname:port for connecting to Presto")
-	startCmd.Flags().BoolVar(&cfg.PrestoUseTLS, "presto-use-tls", false, "If true, enables TLS when connecting to Presto")
-	startCmd.Flags().BoolVar(&cfg.PrestoUseAuth, "presto-use-auth", false, "If true, enables TLS authentication when connecting to Presto")
+	startCmd.Flags().StringVar(&cfg.PrestoHost, "presto-host", defaultPrestoHost, "the hostname:port for connecting to Presto.")
+	startCmd.Flags().BoolVar(&cfg.PrestoUseTLS, "presto-use-tls", false, "If true, enables TLS when connecting to Presto.")
+	startCmd.Flags().BoolVar(&cfg.PrestoUseClientCertAuth, "presto-use-auth", false, "If true, enables TLS client certificate authentication when presto-use-tls is also enabled.")
 	startCmd.Flags().StringVar(&cfg.PrestoCAFile, "presto-ca-file", "", "The path to the certificate authority to use to connect to Presto.")
-	startCmd.Flags().StringVar(&cfg.PrestoServerFile, "presto-server-file", "", "The path to the certificate authority to use to connect to Presto.")
+	startCmd.Flags().StringVar(&cfg.PrestoClientCertFile, "presto-client-cert-file", "", "The path to the client certificate to use to connect to Presto.")
 
 	startCmd.Flags().StringVar(&cfg.PrometheusConfig.Address, "prometheus-host", defaultPromHost, "the URL string for connecting to Prometheus")
 	startCmd.Flags().BoolVar(&cfg.PrometheusConfig.SkipTLSVerify, "prometheus-skip-tls-verify", false, "Skip TLS verification")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -448,8 +448,6 @@ func (op *Reporting) Run(ctx context.Context) error {
 
 	// check if the PrestoUseTLS flag is set to true
 	if op.cfg.PrestoUseTLS {
-		prestoTLSConfig := &tls.Config{}
-
 		rootCert, err := ioutil.ReadFile(op.cfg.PrestoCAFile)
 		if err != nil {
 			return fmt.Errorf("presto: Error loading SSL Cert File: %v", err)
@@ -458,7 +456,7 @@ func (op *Reporting) Run(ctx context.Context) error {
 		rootCertPool := x509.NewCertPool()
 		rootCertPool.AppendCertsFromPEM(rootCert)
 
-		prestoTLSConfig = &tls.Config{
+		prestoTLSConfig := &tls.Config{
 			RootCAs: rootCertPool,
 		}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -110,6 +110,7 @@ type Config struct {
 	PrestoUseClientCertAuth bool
 	PrestoCAFile            string
 	PrestoClientCertFile    string
+	PrestoClientKeyFile     string
 
 	PrestoMaxQueryLength int
 
@@ -462,7 +463,7 @@ func (op *Reporting) Run(ctx context.Context) error {
 		}
 
 		if op.cfg.PrestoUseClientCertAuth {
-			clientCert, err := tls.LoadX509KeyPair(op.cfg.PrestoClientCertFile+"tls.crt", op.cfg.PrestoClientCertFile+"tls.key")
+			clientCert, err := tls.LoadX509KeyPair(op.cfg.PrestoClientCertFile, op.cfg.PrestoClientKeyFile)
 			if err != nil {
 				return fmt.Errorf("presto: Error loading SSL Client cert/key file: %v", err)
 			}


### PR DESCRIPTION
There are a couple more things that need to be fleshed out - most notably the ordering of the TLS/auth (`.Values.presto.spec.presto.config.*.enabled` in `values.yaml`) and what we want the default behavior to be when TLS is enabled and auth is not, and vice-versa. 

The current state of this PR is was constructed under the assumption that we want to be able to configure authentication only if TLS is also enabled (which is reflected as a nested helm if-conditional  templating). It's also important to note that we recently upgraded our Presto fork to a much newer version. This version allows us to specify PEM formatted certificates/keys to Presto, where before we needed to provide JKS/PKCS files (and had to convert the PEM files in the pre-existing secrets, to JKS keystores/truststores.) 

See: https://gist.github.com/timflannagan1/5b9cd5425eb5c4b85c804f034f7da9ea for help setting up locally.