### PR TITLE
charts,hack: Set presto resource requests lower and remove limits for CI tests

### DIFF
--- a/charts/metering-ci/templates/metering.yaml
+++ b/charts/metering-ci/templates/metering.yaml
@@ -68,6 +68,18 @@ spec:
   {{- if .Values.terminationGracePeriodSeconds  }}
         terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   {{- end }}
+        {{- if or .Values.prestoMemory .Values.prestoCpu }}
+        coordinator:
+          {{- if or .Values.prestoMemory .Values.prestoCpu }}
+          resources:
+            requests:
+              memory: "{{ .Values.prestoMemory }}"
+              cpu: "{{ .Values.prestoCpu }}"
+            limits:
+              memory: null
+              cpu: null
+          {{- end }}
+        {{- end }}
       hive:
   {{- if .Values.dateAnnotationValue }}
         annotations: { "metering.deploy-custom/deploy-time": "{{ .Values.dateAnnotationValue }}" }

--- a/charts/metering-ci/values.yaml
+++ b/charts/metering-ci/values.yaml
@@ -14,4 +14,6 @@ hdfsNamenodeMemory: null
 hiveMetastoreStorageSize: null
 hiveMetastoreMemory: null
 hiveMetastoreCpu: null
+prestoMemory: null
+prestoCpu: null
 reportingOperatorReplicas: 1

--- a/hack/deploy-e2e.sh
+++ b/hack/deploy-e2e.sh
@@ -39,6 +39,8 @@ export METERING_CREATE_PULL_SECRET
 : "${HIVE_METASTORE_STORAGE_SIZE:=}"
 : "${HIVE_METASTORE_MEMORY:=}"
 : "${HIVE_METASTORE_CPU:=}"
+: "${PRESTO_MEMORY:=1Gi}"
+: "${PRESTO_CPU:=1}"
 : "${CUR_DATE:=$(date +%s)}"
 
 if [ "$DEPLOY_REPORTING_OPERATOR_LOCAL" == "true" ]; then
@@ -65,6 +67,8 @@ HELM_ARGS=(\
     --set "hiveMetastoreStorageSize=${HIVE_METASTORE_STORAGE_SIZE}" \
     --set "hiveMetastoreMemory=${HIVE_METASTORE_MEMORY}" \
     --set "hiveMetastoreCpu=${HIVE_METASTORE_CPU}" \
+    --set "prestoMemory=${PRESTO_MEMORY}" \
+    --set "prestoCpu=${PRESTO_CPU}" \
     --set "dateAnnotationValue=currdate-${CUR_DATE}" \
 )
 


### PR DESCRIPTION
I noticed CI fail once because presto coordinator was stuck pending due to not enough CPU resources. removing limits and lowering request may potentially help.