### PR TITLE
Update and normalize outdated import identifiers for the metering v1alpha package

### DIFF
--- a/pkg/operator/aws_usage_hive.go
+++ b/pkg/operator/aws_usage_hive.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/aws"
 	"github.com/operator-framework/operator-metering/pkg/hive"
 	"github.com/operator-framework/operator-metering/pkg/operator/reportingutil"
@@ -36,7 +36,7 @@ var (
 )
 
 // CreateAWSUsageTable instantiates a new external HiveTable CR for AWS Billing/Usage reports stored in S3.
-func (op *Reporting) createAWSUsageHiveTableCR(logger logrus.FieldLogger, dataSource *cbTypes.ReportDataSource, tableName, bucket, prefix string, manifests []*aws.Manifest) (*cbTypes.HiveTable, error) {
+func (op *Reporting) createAWSUsageHiveTableCR(logger logrus.FieldLogger, dataSource *metering.ReportDataSource, tableName, bucket, prefix string, manifests []*aws.Manifest) (*metering.HiveTable, error) {
 	location, err := hive.S3Location(bucket, prefix)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (op *Reporting) createAWSUsageHiveTableCR(logger logrus.FieldLogger, dataSo
 	}
 
 	logger.Infof("creating Hive table %s", tableName)
-	hiveTable, err := op.createHiveTableCR(dataSource, cbTypes.ReportDataSourceGVK, params, true, nil)
+	hiveTable, err := op.createHiveTableCR(dataSource, metering.ReportDataSourceGVK, params, true, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Hive table for ReportDataSource %s: %s", dataSource.Name, err)
 	}
@@ -112,7 +112,7 @@ func (op *Reporting) createAWSUsageHiveTableCR(logger logrus.FieldLogger, dataSo
 	return hiveTable, nil
 }
 
-func (op *Reporting) updateAWSBillingPartitions(logger log.FieldLogger, dataSource *cbTypes.ReportDataSource, source *cbTypes.S3Bucket, hiveTable *cbTypes.HiveTable, manifests []*aws.Manifest) error {
+func (op *Reporting) updateAWSBillingPartitions(logger log.FieldLogger, dataSource *metering.ReportDataSource, source *metering.S3Bucket, hiveTable *metering.HiveTable, manifests []*aws.Manifest) error {
 	logger.Infof("updating partitions for Hive table %s", hiveTable.Name)
 	// Fetch the billing manifests
 	if len(manifests) == 0 {
@@ -135,8 +135,8 @@ func (op *Reporting) updateAWSBillingPartitions(logger log.FieldLogger, dataSour
 	return nil
 }
 
-func getDesiredPartitions(bucket string, manifests []*aws.Manifest) ([]cbTypes.HiveTablePartition, error) {
-	desiredPartitions := make([]cbTypes.HiveTablePartition, 0)
+func getDesiredPartitions(bucket string, manifests []*aws.Manifest) ([]metering.HiveTablePartition, error) {
+	desiredPartitions := make([]metering.HiveTablePartition, 0)
 	// Manifests have a one-to-one correlation with hive currentPartitions
 	for _, manifest := range manifests {
 		manifestPath := manifest.DataDirectory()
@@ -147,7 +147,7 @@ func getDesiredPartitions(bucket string, manifests []*aws.Manifest) ([]cbTypes.H
 
 		start := reportingutil.AWSBillingPeriodTimestamp(manifest.BillingPeriod.Start.Time)
 		end := reportingutil.AWSBillingPeriodTimestamp(manifest.BillingPeriod.End.Time)
-		p := cbTypes.HiveTablePartition{
+		p := metering.HiveTablePartition{
 			Location: location,
 			PartitionSpec: hive.PartitionSpec{
 				"start": start,

--- a/pkg/operator/hive_test.go
+++ b/pkg/operator/hive_test.go
@@ -5,22 +5,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/hive"
 )
 
 func TestGetPartitionChanges(t *testing.T) {
 	tests := []struct {
 		name             string
-		current          []cbTypes.HiveTablePartition
-		desired          []cbTypes.HiveTablePartition
-		expectedToRemove []cbTypes.HiveTablePartition
-		expectedToAdd    []cbTypes.HiveTablePartition
-		expectedToUpdate []cbTypes.HiveTablePartition
+		current          []metering.HiveTablePartition
+		desired          []metering.HiveTablePartition
+		expectedToRemove []metering.HiveTablePartition
+		expectedToAdd    []metering.HiveTablePartition
+		expectedToUpdate []metering.HiveTablePartition
 	}{
 		{
 			name: "current and desired are same",
-			current: []cbTypes.HiveTablePartition{
+			current: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",
@@ -29,7 +29,7 @@ func TestGetPartitionChanges(t *testing.T) {
 					Location: "foobar",
 				},
 			},
-			desired: []cbTypes.HiveTablePartition{
+			desired: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",
@@ -41,7 +41,7 @@ func TestGetPartitionChanges(t *testing.T) {
 		},
 		{
 			name: "empty current should have desired in to add list",
-			desired: []cbTypes.HiveTablePartition{
+			desired: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",
@@ -50,7 +50,7 @@ func TestGetPartitionChanges(t *testing.T) {
 					Location: "foobar",
 				},
 			},
-			expectedToAdd: []cbTypes.HiveTablePartition{
+			expectedToAdd: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",
@@ -62,7 +62,7 @@ func TestGetPartitionChanges(t *testing.T) {
 		},
 		{
 			name: "desired is empty and current should be removed",
-			current: []cbTypes.HiveTablePartition{
+			current: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",
@@ -71,7 +71,7 @@ func TestGetPartitionChanges(t *testing.T) {
 					Location: "foobar",
 				},
 			},
-			expectedToRemove: []cbTypes.HiveTablePartition{
+			expectedToRemove: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",
@@ -83,7 +83,7 @@ func TestGetPartitionChanges(t *testing.T) {
 		},
 		{
 			name: "desired matches and replaces current",
-			current: []cbTypes.HiveTablePartition{
+			current: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",
@@ -92,7 +92,7 @@ func TestGetPartitionChanges(t *testing.T) {
 					Location: "foobar",
 				},
 			},
-			desired: []cbTypes.HiveTablePartition{
+			desired: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",
@@ -101,7 +101,7 @@ func TestGetPartitionChanges(t *testing.T) {
 					Location: "fizbuzz",
 				},
 			},
-			expectedToUpdate: []cbTypes.HiveTablePartition{
+			expectedToUpdate: []metering.HiveTablePartition{
 				{
 					PartitionSpec: hive.PartitionSpec{
 						"start": "20170101",

--- a/pkg/operator/http.go
+++ b/pkg/operator/http.go
@@ -22,7 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
-	api "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	meteringUtil "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
 	listers "github.com/operator-framework/operator-metering/pkg/generated/listers/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator/prestostore"
@@ -187,7 +187,7 @@ func (srv *server) getReport(logger log.FieldLogger, name, namespace, format str
 	}
 
 	if r.FormValue("ignore_failed") != "true" {
-		if cond := meteringUtil.GetReportCondition(report.Status, api.ReportRunning); cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == meteringUtil.GenerateReportFailedReason {
+		if cond := meteringUtil.GetReportCondition(report.Status, metering.ReportRunning); cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == meteringUtil.GenerateReportFailedReason {
 			logger.Errorf("report is is failed state, reason: %s, message: %s", cond.Reason, cond.Message)
 			writeErrorResponse(logger, w, r, http.StatusInternalServerError, "report is is failed state, reason: %s, message: %s", cond.Reason, cond.Message)
 			return
@@ -253,7 +253,7 @@ func (srv *server) getReport(logger log.FieldLogger, name, namespace, format str
 	}
 }
 
-func writeResultsResponseAsCSV(logger log.FieldLogger, name string, columns []api.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
+func writeResultsResponseAsCSV(logger log.FieldLogger, name string, columns []metering.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/csv")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment;filename=%s.csv", name))
 	err := writeResultsAsCSV(columns, results, w, ',')
@@ -264,7 +264,7 @@ func writeResultsResponseAsCSV(logger log.FieldLogger, name string, columns []ap
 	w.WriteHeader(http.StatusOK)
 }
 
-func writeResultsAsCSV(columns []api.ReportQueryColumn, results []presto.Row, w io.Writer, delimiter rune) error {
+func writeResultsAsCSV(columns []metering.ReportQueryColumn, results []presto.Row, w io.Writer, delimiter rune) error {
 	csvWriter := csv.NewWriter(w)
 	csvWriter.Comma = delimiter
 
@@ -317,7 +317,7 @@ func writeResultsAsCSV(columns []api.ReportQueryColumn, results []presto.Row, w 
 	return csvWriter.Error()
 }
 
-func writeResultsResponseAsTabular(logger log.FieldLogger, name string, columns []api.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
+func writeResultsResponseAsTabular(logger log.FieldLogger, name string, columns []metering.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/tab-separated-values")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment;filename=%s.tsv", name))
 	padding := 2
@@ -344,7 +344,7 @@ func writeResultsResponseAsTabular(logger log.FieldLogger, name string, columns 
 	w.WriteHeader(http.StatusOK)
 }
 
-func writeResultsResponseAsJSON(logger log.FieldLogger, name string, columns []api.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
+func writeResultsResponseAsJSON(logger log.FieldLogger, name string, columns []metering.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment;filename=%s.json", name))
 	newResults := make([]*orderedmap.OrderedMap, len(results))
 	for i, item := range results {
@@ -358,7 +358,7 @@ func writeResultsResponseAsJSON(logger log.FieldLogger, name string, columns []a
 	writeResponseAsJSON(logger, w, http.StatusOK, newResults)
 }
 
-func writeResultsResponse(logger log.FieldLogger, format, name string, columns []api.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
+func writeResultsResponse(logger log.FieldLogger, format, name string, columns []metering.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
 	switch format {
 	case "json":
 		writeResultsResponseAsJSON(logger, name, columns, results, w, r)
@@ -385,9 +385,9 @@ type ReportResultValues struct {
 }
 
 // convertsToGetReportResults converts Rows returned from `presto.ExecuteSelect` into a GetReportResults
-func convertsToGetReportResults(input []presto.Row, columns []api.ReportQueryColumn) GetReportResults {
+func convertsToGetReportResults(input []presto.Row, columns []metering.ReportQueryColumn) GetReportResults {
 	results := GetReportResults{}
-	columnsMap := make(map[string]api.ReportQueryColumn)
+	columnsMap := make(map[string]metering.ReportQueryColumn)
 	for _, column := range columns {
 		columnsMap[column.Name] = column
 	}
@@ -407,9 +407,9 @@ func convertsToGetReportResults(input []presto.Row, columns []api.ReportQueryCol
 	return results
 }
 
-func writeResultsResponseV1(logger log.FieldLogger, format string, name string, columns []api.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
-	columnsMap := make(map[string]api.ReportQueryColumn)
-	var filteredColumns []api.ReportQueryColumn
+func writeResultsResponseV1(logger log.FieldLogger, format string, name string, columns []metering.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
+	columnsMap := make(map[string]metering.ReportQueryColumn)
+	var filteredColumns []metering.ReportQueryColumn
 
 	// remove tableHidden columns and their values if the format is tabular or CSV
 
@@ -434,11 +434,11 @@ func writeResultsResponseV1(logger log.FieldLogger, format string, name string, 
 	writeResultsResponse(logger, format, name, filteredColumns, results, w, r)
 }
 
-func writeResultsResponseV2(logger log.FieldLogger, full bool, format string, name string, columns []api.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
+func writeResultsResponseV2(logger log.FieldLogger, full bool, format string, name string, columns []metering.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {
 	format = strings.ToLower(format)
 	isTableFormat := format == "csv" || format == "tab" || format == "tabular"
-	columnsMap := make(map[string]api.ReportQueryColumn)
-	var filteredColumns []api.ReportQueryColumn
+	columnsMap := make(map[string]metering.ReportQueryColumn)
+	var filteredColumns []metering.ReportQueryColumn
 
 	// Remove columns and their values from `results` if full is false and the
 	// column's TableHidden is true or if TableHidden is true and we're

--- a/pkg/operator/http.go
+++ b/pkg/operator/http.go
@@ -23,7 +23,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	api "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
-	cbutil "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
+	meteringUtil "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
 	listers "github.com/operator-framework/operator-metering/pkg/generated/listers/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator/prestostore"
 	"github.com/operator-framework/operator-metering/pkg/operator/reportingutil"
@@ -187,7 +187,7 @@ func (srv *server) getReport(logger log.FieldLogger, name, namespace, format str
 	}
 
 	if r.FormValue("ignore_failed") != "true" {
-		if cond := cbutil.GetReportCondition(report.Status, api.ReportRunning); cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == cbutil.GenerateReportFailedReason {
+		if cond := meteringUtil.GetReportCondition(report.Status, api.ReportRunning); cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == meteringUtil.GenerateReportFailedReason {
 			logger.Errorf("report is is failed state, reason: %s, message: %s", cond.Reason, cond.Message)
 			writeErrorResponse(logger, w, r, http.StatusInternalServerError, "report is is failed state, reason: %s, message: %s", cond.Reason, cond.Message)
 			return

--- a/pkg/operator/http_test.go
+++ b/pkg/operator/http_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	listers "github.com/operator-framework/operator-metering/pkg/generated/listers/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator/prestostore"
 	"github.com/operator-framework/operator-metering/pkg/presto"
@@ -105,9 +105,9 @@ func TestAPIV1ReportsGet(t *testing.T) {
 	tests := map[string]struct {
 		reportName string
 
-		report      *v1alpha1.Report
-		query       *v1alpha1.ReportQuery
-		prestoTable *v1alpha1.PrestoTable
+		report      *metering.Report
+		query       *metering.ReportQuery
+		prestoTable *metering.PrestoTable
 
 		expectedStatusCode int
 		expectedAPIError   string
@@ -118,8 +118,8 @@ func TestAPIV1ReportsGet(t *testing.T) {
 	}{
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
@@ -146,8 +146,8 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
@@ -187,8 +187,8 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
@@ -232,8 +232,8 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
 					Type: "timestamp",
@@ -374,14 +374,14 @@ func TestAPIV2ReportsFull(t *testing.T) {
 	reportEnd := &reportEndTmp
 
 	tests := map[string]struct {
-		reportStatus v1alpha1.ReportStatus
+		reportStatus metering.ReportStatus
 		reportName   string
 		reportFormat string
 		apiPath      string
 
-		report      *v1alpha1.Report
-		query       *v1alpha1.ReportQuery
-		prestoTable *v1alpha1.PrestoTable
+		report      *metering.Report
+		query       *metering.ReportQuery
+		prestoTable *metering.PrestoTable
 
 		expectedStatusCode int
 		expectedAPIError   string
@@ -392,9 +392,9 @@ func TestAPIV2ReportsFull(t *testing.T) {
 	}{
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name:        "timestamp",
 					Type:        "timestamp",
@@ -442,9 +442,9 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name:        "timestamp",
 					Type:        "timestamp",
@@ -473,9 +473,9 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name:        "timestamp",
 					Type:        "timestamp",
@@ -522,7 +522,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-format-not-specified": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:               apiReportV2URLFull(namespace, testReportName),
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: format",
@@ -531,7 +531,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-format-non-existent": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:               apiReportV2URLFull(namespace, testReportName) + "?format=doesntexist",
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "format must be one of: csv, json or tabular",
@@ -540,9 +540,9 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name:        "timestamp",
 					Type:        "timestamp",
@@ -660,14 +660,14 @@ func TestAPIV2ReportsTable(t *testing.T) {
 	reportEnd := &reportEndTmp
 
 	tests := map[string]struct {
-		reportStatus v1alpha1.ReportStatus
+		reportStatus metering.ReportStatus
 		reportName   string
 		reportFormat string
 		apiPath      string
 
-		report      *v1alpha1.Report
-		query       *v1alpha1.ReportQuery
-		prestoTable *v1alpha1.PrestoTable
+		report      *metering.Report
+		query       *metering.ReportQuery
+		prestoTable *metering.PrestoTable
 
 		expectedStatusCode int
 		expectedAPIError   string
@@ -678,9 +678,9 @@ func TestAPIV2ReportsTable(t *testing.T) {
 	}{
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name:        "timestamp",
 					Type:        "timestamp",
@@ -730,9 +730,9 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name:        "timestamp",
 					Type:        "timestamp",
@@ -761,9 +761,9 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name:        "timestamp",
 					Type:        "timestamp",
@@ -810,7 +810,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-format-not-specified": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:               apiReportV2URLTable(namespace, testReportName),
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: format",
@@ -819,7 +819,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-format-non-existent": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:               apiReportV2URLTable(namespace, testReportName) + "?format=doesntexist",
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "format must be one of: csv, json or tabular",
@@ -828,9 +828,9 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
-			query: testhelpers.NewReportQuery(testQueryName, namespace, []v1alpha1.ReportQueryColumn{
+			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name:        "timestamp",
 					Type:        "timestamp",

--- a/pkg/operator/promsum.go
+++ b/pkg/operator/promsum.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator/prestostore"
 	"github.com/operator-framework/operator-metering/pkg/operator/reportingutil"
 )
@@ -176,7 +176,7 @@ func (op *Reporting) importPrometheusForTimeRange(ctx context.Context, namespace
 	resultsCh := make(chan *prometheusImportResults)
 	g, ctx := errgroup.WithContext(ctx)
 
-	var reportDataSourcesToImport []*cbTypes.ReportDataSource
+	var reportDataSourcesToImport []*metering.ReportDataSource
 
 	for _, reportDataSource := range reportDataSources.Items {
 		if reportDataSource.Spec.PrometheusMetricsImporter == nil {
@@ -262,7 +262,7 @@ func (op *Reporting) importPrometheusForTimeRange(ctx context.Context, namespace
 	return results, g.Wait()
 }
 
-func (op *Reporting) getQueryIntervalForReportDataSource(reportDataSource *cbTypes.ReportDataSource) time.Duration {
+func (op *Reporting) getQueryIntervalForReportDataSource(reportDataSource *metering.ReportDataSource) time.Duration {
 	queryConf := reportDataSource.Spec.PrometheusMetricsImporter.QueryConfig
 	queryInterval := op.cfg.PrometheusQueryConfig.QueryInterval.Duration
 	if queryConf != nil {
@@ -273,7 +273,7 @@ func (op *Reporting) getQueryIntervalForReportDataSource(reportDataSource *cbTyp
 	return queryInterval
 }
 
-func (op *Reporting) newPromImporterCfg(reportDataSource *cbTypes.ReportDataSource, query string, prestoTable *cbTypes.PrestoTable) (prestostore.Config, error) {
+func (op *Reporting) newPromImporterCfg(reportDataSource *metering.ReportDataSource, query string, prestoTable *metering.PrestoTable) (prestostore.Config, error) {
 	chunkSize := op.cfg.PrometheusQueryConfig.ChunkSize.Duration
 	stepSize := op.cfg.PrometheusQueryConfig.StepSize.Duration
 
@@ -321,7 +321,7 @@ func (op *Reporting) newPromImporterCfg(reportDataSource *cbTypes.ReportDataSour
 	}, nil
 }
 
-func (op *Reporting) newPromImporter(logger logrus.FieldLogger, reportDataSource *cbTypes.ReportDataSource, prestoTable *cbTypes.PrestoTable, cfg prestostore.Config) (*prestostore.PrometheusImporter, error) {
+func (op *Reporting) newPromImporter(logger logrus.FieldLogger, reportDataSource *metering.ReportDataSource, prestoTable *metering.PrestoTable, cfg prestostore.Config) (*prestostore.PrometheusImporter, error) {
 	metricsCollectors := op.newPromImporterMetricsCollectors(reportDataSource, prestoTable)
 	var promConn prom.API
 	var err error
@@ -337,7 +337,7 @@ func (op *Reporting) newPromImporter(logger logrus.FieldLogger, reportDataSource
 	return prestostore.NewPrometheusImporter(logger, promConn, op.prometheusMetricsRepo, op.clock, cfg, metricsCollectors), nil
 }
 
-func (op *Reporting) newPromImporterMetricsCollectors(reportDataSource *cbTypes.ReportDataSource, prestoTable *cbTypes.PrestoTable) prestostore.ImporterMetricsCollectors {
+func (op *Reporting) newPromImporterMetricsCollectors(reportDataSource *metering.ReportDataSource, prestoTable *metering.PrestoTable) prestostore.ImporterMetricsCollectors {
 	promLabels := prometheus.Labels{
 		"reportdatasource": reportDataSource.Name,
 		"namespace":        reportDataSource.Namespace,

--- a/pkg/operator/queues.go
+++ b/pkg/operator/queues.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	_ "github.com/operator-framework/operator-metering/pkg/util/reflector/prometheus" // for prometheus metric registration
 	_ "github.com/operator-framework/operator-metering/pkg/util/workqueue/prometheus" // for prometheus metric registration
 )
@@ -23,7 +23,7 @@ func (op *Reporting) shutdownQueues() {
 }
 
 func (op *Reporting) addReport(obj interface{}) {
-	report := obj.(*cbTypes.Report)
+	report := obj.(*metering.Report)
 	if report.DeletionTimestamp != nil {
 		op.deleteReport(report)
 		return
@@ -33,8 +33,8 @@ func (op *Reporting) addReport(obj interface{}) {
 }
 
 func (op *Reporting) updateReport(prev, cur interface{}) {
-	prevReport := prev.(*cbTypes.Report)
-	curReport := cur.(*cbTypes.Report)
+	prevReport := prev.(*metering.Report)
+	curReport := cur.(*metering.Report)
 	if curReport.DeletionTimestamp != nil {
 		op.deleteReport(curReport)
 		return
@@ -58,14 +58,14 @@ func (op *Reporting) updateReport(prev, cur interface{}) {
 }
 
 func (op *Reporting) deleteReport(obj interface{}) {
-	report, ok := obj.(*cbTypes.Report)
+	report, ok := obj.(*metering.Report)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			op.logger.WithFields(log.Fields{"report": report.Name, "namespace": report.Namespace}).Errorf("Couldn't get object from tombstone %#v", obj)
 			return
 		}
-		report, ok = tombstone.Obj.(*cbTypes.Report)
+		report, ok = tombstone.Obj.(*metering.Report)
 		if !ok {
 			op.logger.WithFields(log.Fields{"report": report.Name, "namespace": report.Namespace}).Errorf("Tombstone contained object that is not a Report %#v", obj)
 			return
@@ -79,7 +79,7 @@ func (op *Reporting) deleteReport(obj interface{}) {
 	op.reportQueue.Add(key)
 }
 
-func (op *Reporting) enqueueReport(report *cbTypes.Report) {
+func (op *Reporting) enqueueReport(report *metering.Report) {
 	key, err := cache.MetaNamespaceKeyFunc(report)
 	if err != nil {
 		op.logger.WithError(err).Errorf("Couldn't get key for object %#v: %v", report, err)
@@ -88,7 +88,7 @@ func (op *Reporting) enqueueReport(report *cbTypes.Report) {
 	op.reportQueue.Add(key)
 }
 
-func (op *Reporting) enqueueReportAfter(report *cbTypes.Report, duration time.Duration) {
+func (op *Reporting) enqueueReportAfter(report *metering.Report, duration time.Duration) {
 	key, err := cache.MetaNamespaceKeyFunc(report)
 	if err != nil {
 		op.logger.WithError(err).Errorf("Couldn't get key for object %#v: %v", report, err)
@@ -98,7 +98,7 @@ func (op *Reporting) enqueueReportAfter(report *cbTypes.Report, duration time.Du
 }
 
 func (op *Reporting) addReportDataSource(obj interface{}) {
-	ds := obj.(*cbTypes.ReportDataSource)
+	ds := obj.(*metering.ReportDataSource)
 	if ds.DeletionTimestamp != nil {
 		op.deleteReportDataSource(ds)
 		return
@@ -108,8 +108,8 @@ func (op *Reporting) addReportDataSource(obj interface{}) {
 }
 
 func (op *Reporting) updateReportDataSource(prev, cur interface{}) {
-	curReportDataSource := cur.(*cbTypes.ReportDataSource)
-	prevReportDataSource := prev.(*cbTypes.ReportDataSource)
+	curReportDataSource := cur.(*metering.ReportDataSource)
+	prevReportDataSource := prev.(*metering.ReportDataSource)
 	if curReportDataSource.DeletionTimestamp != nil {
 		op.deleteReportDataSource(curReportDataSource)
 		return
@@ -135,14 +135,14 @@ func (op *Reporting) updateReportDataSource(prev, cur interface{}) {
 }
 
 func (op *Reporting) deleteReportDataSource(obj interface{}) {
-	dataSource, ok := obj.(*cbTypes.ReportDataSource)
+	dataSource, ok := obj.(*metering.ReportDataSource)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			op.logger.WithFields(log.Fields{"reportDataSsource": dataSource.Name, "namespace": dataSource.Namespace}).Errorf("Couldn't get object from tombstone %#v", obj)
 			return
 		}
-		dataSource, ok = tombstone.Obj.(*cbTypes.ReportDataSource)
+		dataSource, ok = tombstone.Obj.(*metering.ReportDataSource)
 		if !ok {
 			op.logger.WithFields(log.Fields{"reportDataSsource": dataSource.Name, "namespace": dataSource.Namespace}).Errorf("Tombstone contained object that is not a ReportDataSource %#v", obj)
 			return
@@ -156,7 +156,7 @@ func (op *Reporting) deleteReportDataSource(obj interface{}) {
 	op.reportDataSourceQueue.Add(key)
 }
 
-func (op *Reporting) enqueueReportDataSource(ds *cbTypes.ReportDataSource) {
+func (op *Reporting) enqueueReportDataSource(ds *metering.ReportDataSource) {
 	key, err := cache.MetaNamespaceKeyFunc(ds)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"reportDataSource": ds.Name, "namespace": ds.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", ds)
@@ -165,7 +165,7 @@ func (op *Reporting) enqueueReportDataSource(ds *cbTypes.ReportDataSource) {
 	op.reportDataSourceQueue.Add(key)
 }
 
-func (op *Reporting) enqueueReportDataSourceAfter(ds *cbTypes.ReportDataSource, duration time.Duration) {
+func (op *Reporting) enqueueReportDataSourceAfter(ds *metering.ReportDataSource, duration time.Duration) {
 	key, err := cache.MetaNamespaceKeyFunc(ds)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"reportDataSource": ds.Name, "namespace": ds.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", ds)
@@ -175,14 +175,14 @@ func (op *Reporting) enqueueReportDataSourceAfter(ds *cbTypes.ReportDataSource, 
 }
 
 func (op *Reporting) addReportQuery(obj interface{}) {
-	query := obj.(*cbTypes.ReportQuery)
+	query := obj.(*metering.ReportQuery)
 	op.logger.Infof("adding ReportQuery %s/%s", query.Namespace, query.Name)
 	op.enqueueReportQuery(query)
 }
 
 func (op *Reporting) updateReportQuery(prev, cur interface{}) {
-	curReportQuery := cur.(*cbTypes.ReportQuery)
-	prevReportQuery := prev.(*cbTypes.ReportQuery)
+	curReportQuery := cur.(*metering.ReportQuery)
+	prevReportQuery := prev.(*metering.ReportQuery)
 	logger := op.logger.WithFields(log.Fields{"reportQuery": curReportQuery.Name, "namespace": curReportQuery.Namespace})
 
 	// Only skip queuing if we're not missing a view
@@ -202,7 +202,7 @@ func (op *Reporting) updateReportQuery(prev, cur interface{}) {
 	op.enqueueReportQuery(curReportQuery)
 }
 
-func (op *Reporting) enqueueReportQuery(query *cbTypes.ReportQuery) {
+func (op *Reporting) enqueueReportQuery(query *metering.ReportQuery) {
 	key, err := cache.MetaNamespaceKeyFunc(query)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"reportQuery": query.Name, "namespace": query.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", query)
@@ -212,7 +212,7 @@ func (op *Reporting) enqueueReportQuery(query *cbTypes.ReportQuery) {
 }
 
 func (op *Reporting) addPrestoTable(obj interface{}) {
-	table := obj.(*cbTypes.PrestoTable)
+	table := obj.(*metering.PrestoTable)
 	if table.DeletionTimestamp != nil {
 		op.deletePrestoTable(table)
 		return
@@ -223,7 +223,7 @@ func (op *Reporting) addPrestoTable(obj interface{}) {
 }
 
 func (op *Reporting) updatePrestoTable(_, cur interface{}) {
-	curPrestoTable := cur.(*cbTypes.PrestoTable)
+	curPrestoTable := cur.(*metering.PrestoTable)
 	if curPrestoTable.DeletionTimestamp != nil {
 		op.deletePrestoTable(curPrestoTable)
 		return
@@ -234,14 +234,14 @@ func (op *Reporting) updatePrestoTable(_, cur interface{}) {
 }
 
 func (op *Reporting) deletePrestoTable(obj interface{}) {
-	prestoTable, ok := obj.(*cbTypes.PrestoTable)
+	prestoTable, ok := obj.(*metering.PrestoTable)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			op.logger.WithFields(log.Fields{"prestoTable": prestoTable.Name, "namespace": prestoTable.Namespace}).Errorf("Couldn't get object from tombstone %#v", obj)
 			return
 		}
-		prestoTable, ok = tombstone.Obj.(*cbTypes.PrestoTable)
+		prestoTable, ok = tombstone.Obj.(*metering.PrestoTable)
 		if !ok {
 			op.logger.WithFields(log.Fields{"prestoTable": prestoTable.Name, "namespace": prestoTable.Namespace}).Errorf("Tombstone contained object that is not a PrestoTable %#v", obj)
 			return
@@ -263,7 +263,7 @@ func (op *Reporting) deletePrestoTable(obj interface{}) {
 	op.prestoTableQueue.Add(key)
 }
 
-func (op *Reporting) enqueuePrestoTable(table *cbTypes.PrestoTable) {
+func (op *Reporting) enqueuePrestoTable(table *metering.PrestoTable) {
 	key, err := cache.MetaNamespaceKeyFunc(table)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"prestoTable": table.Name, "namespace": table.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", table)
@@ -273,7 +273,7 @@ func (op *Reporting) enqueuePrestoTable(table *cbTypes.PrestoTable) {
 }
 
 func (op *Reporting) addHiveTable(obj interface{}) {
-	table := obj.(*cbTypes.HiveTable)
+	table := obj.(*metering.HiveTable)
 	if table.DeletionTimestamp != nil {
 		op.deleteHiveTable(table)
 		return
@@ -284,7 +284,7 @@ func (op *Reporting) addHiveTable(obj interface{}) {
 }
 
 func (op *Reporting) updateHiveTable(_, cur interface{}) {
-	curHiveTable := cur.(*cbTypes.HiveTable)
+	curHiveTable := cur.(*metering.HiveTable)
 	if curHiveTable.DeletionTimestamp != nil {
 		op.deleteHiveTable(curHiveTable)
 		return
@@ -295,14 +295,14 @@ func (op *Reporting) updateHiveTable(_, cur interface{}) {
 }
 
 func (op *Reporting) deleteHiveTable(obj interface{}) {
-	hiveTable, ok := obj.(*cbTypes.HiveTable)
+	hiveTable, ok := obj.(*metering.HiveTable)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			op.logger.WithFields(log.Fields{"hiveTable": hiveTable.Name, "namespace": hiveTable.Namespace}).Errorf("Couldn't get object from tombstone %#v", obj)
 			return
 		}
-		hiveTable, ok = tombstone.Obj.(*cbTypes.HiveTable)
+		hiveTable, ok = tombstone.Obj.(*metering.HiveTable)
 		if !ok {
 			op.logger.WithFields(log.Fields{"hiveTable": hiveTable.Name, "namespace": hiveTable.Namespace}).Errorf("Tombstone contained object that is not a HiveTable %#v", obj)
 			return
@@ -323,7 +323,7 @@ func (op *Reporting) deleteHiveTable(obj interface{}) {
 	op.hiveTableQueue.Add(key)
 }
 
-func (op *Reporting) enqueueHiveTable(table *cbTypes.HiveTable) {
+func (op *Reporting) enqueueHiveTable(table *metering.HiveTable) {
 	key, err := cache.MetaNamespaceKeyFunc(table)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"hiveTable": table.Name, "namespace": table.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", table)
@@ -333,7 +333,7 @@ func (op *Reporting) enqueueHiveTable(table *cbTypes.HiveTable) {
 }
 
 func (op *Reporting) addStorageLocation(obj interface{}) {
-	storageLocation := obj.(*cbTypes.StorageLocation)
+	storageLocation := obj.(*metering.StorageLocation)
 	if storageLocation.DeletionTimestamp != nil {
 		op.deleteStorageLocation(storageLocation)
 		return
@@ -344,7 +344,7 @@ func (op *Reporting) addStorageLocation(obj interface{}) {
 }
 
 func (op *Reporting) updateStorageLocation(_, cur interface{}) {
-	curStorageLocation := cur.(*cbTypes.StorageLocation)
+	curStorageLocation := cur.(*metering.StorageLocation)
 	if curStorageLocation.DeletionTimestamp != nil {
 		op.deleteStorageLocation(curStorageLocation)
 		return
@@ -355,14 +355,14 @@ func (op *Reporting) updateStorageLocation(_, cur interface{}) {
 }
 
 func (op *Reporting) deleteStorageLocation(obj interface{}) {
-	storageLocation, ok := obj.(*cbTypes.StorageLocation)
+	storageLocation, ok := obj.(*metering.StorageLocation)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			op.logger.WithFields(log.Fields{"storageLocation": storageLocation.Name, "namespace": storageLocation.Namespace}).Errorf("Couldn't get object from tombstone %#v", obj)
 			return
 		}
-		storageLocation, ok = tombstone.Obj.(*cbTypes.StorageLocation)
+		storageLocation, ok = tombstone.Obj.(*metering.StorageLocation)
 		if !ok {
 			op.logger.WithFields(log.Fields{"storageLocation": storageLocation.Name, "namespace": storageLocation.Namespace}).Errorf("Tombstone contained object that is not a StorageLocation %#v", obj)
 			return
@@ -383,7 +383,7 @@ func (op *Reporting) deleteStorageLocation(obj interface{}) {
 	op.storageLocationQueue.Add(key)
 }
 
-func (op *Reporting) enqueueStorageLocation(storageLocation *cbTypes.StorageLocation) {
+func (op *Reporting) enqueueStorageLocation(storageLocation *metering.StorageLocation) {
 	key, err := cache.MetaNamespaceKeyFunc(storageLocation)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"storageLocation": storageLocation.Name, "namespace": storageLocation.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", storageLocation)

--- a/pkg/operator/reporting/templates_test.go
+++ b/pkg/operator/reporting/templates_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator/prestostore"
 	"github.com/operator-framework/operator-metering/pkg/presto"
@@ -579,19 +578,19 @@ func TestRenderQuery(t *testing.T) {
 }
 
 // newPrestoTableCustom allows us to insert a custom name, as opposed to testhelpers.NewPrestoTable
-func newTestPrestoTable(name, namespace, schema, catalog string, columns []presto.Column) *v1alpha1.PrestoTable {
-	return &v1alpha1.PrestoTable{
+func newTestPrestoTable(name, namespace, schema, catalog string, columns []presto.Column) *metering.PrestoTable {
+	return &metering.PrestoTable{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Status: v1alpha1.PrestoTableStatus{
+		Status: metering.PrestoTableStatus{
 			Catalog:   catalog,
 			Schema:    schema,
 			TableName: name,
 			Columns:   columns,
 		},
-		Spec: v1alpha1.PrestoTableSpec{
+		Spec: metering.PrestoTableSpec{
 			Catalog:   catalog,
 			Schema:    schema,
 			TableName: name,

--- a/pkg/operator/reporting/validate.go
+++ b/pkg/operator/reporting/validate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 )
 
@@ -13,7 +12,7 @@ func GetAndValidateQueryDependencies(
 	dataSourceGetter ReportDataSourceGetter,
 	reportGetter ReportGetter,
 	query *metering.ReportQuery,
-	inputVals []cbTypes.ReportQueryInputValue,
+	inputVals []metering.ReportQueryInputValue,
 	handler *UninitialiedDependendenciesHandler,
 ) (*ReportQueryDependencies, error) {
 	deps, err := GetQueryDependencies(queryGetter, dataSourceGetter, reportGetter, query, inputVals)
@@ -32,7 +31,7 @@ func GetQueryDependencies(
 	dataSourceGetter ReportDataSourceGetter,
 	reportGetter ReportGetter,
 	query *metering.ReportQuery,
-	inputVals []cbTypes.ReportQueryInputValue,
+	inputVals []metering.ReportQueryInputValue,
 ) (*ReportQueryDependencies, error) {
 	result, err := NewDependencyResolver(queryGetter, dataSourceGetter, reportGetter).ResolveDependencies(query.Namespace, query.Spec.Inputs, inputVals)
 	if err != nil {

--- a/pkg/operator/reportingutil/util.go
+++ b/pkg/operator/reportingutil/util.go
@@ -6,7 +6,7 @@ import (
 	"time"
 	"unicode"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/hive"
 	"github.com/operator-framework/operator-metering/pkg/presto"
 )
@@ -35,7 +35,7 @@ func AWSBillingPeriodTimestamp(date time.Time) string {
 	return date.Format(AWSUsagePartitionDateStringLayout)
 }
 
-func FullyQualifiedTableName(prestoTable *cbTypes.PrestoTable) (string, error) {
+func FullyQualifiedTableName(prestoTable *metering.PrestoTable) (string, error) {
 	var errs []string
 	if len(prestoTable.Status.Catalog) == 0 {
 		errs = append(errs, "prestoTable.Status.Catalog is unset")
@@ -79,7 +79,7 @@ func TruncateToMinute(t time.Time) time.Time {
 	return t.Truncate(time.Minute)
 }
 
-func GenerateHiveColumns(query *cbTypes.ReportQuery) []hive.Column {
+func GenerateHiveColumns(query *metering.ReportQuery) []hive.Column {
 	var columns []hive.Column
 	for _, col := range query.Spec.Columns {
 		columns = append(columns, hive.Column{Name: col.Name, Type: col.Type})
@@ -87,7 +87,7 @@ func GenerateHiveColumns(query *cbTypes.ReportQuery) []hive.Column {
 	return columns
 }
 
-func GeneratePrestoColumns(query *cbTypes.ReportQuery) []presto.Column {
+func GeneratePrestoColumns(query *metering.ReportQuery) []presto.Column {
 	var columns []presto.Column
 	for _, col := range query.Spec.Columns {
 		columns = append(columns, presto.Column{Name: col.Name, Type: col.Type})
@@ -254,7 +254,7 @@ func PrestoColumnToHiveColumn(column presto.Column) (hive.Column, error) {
 	return hive.Column{}, fmt.Errorf("unsupported hive type: %q", column.Type)
 }
 
-func ConvertInputDefinitionsIntoInputList(defs []cbTypes.ReportQueryInputDefinition) (required []string) {
+func ConvertInputDefinitionsIntoInputList(defs []metering.ReportQueryInputDefinition) (required []string) {
 	for _, def := range defs {
 		if def.Required {
 			required = append(required, def.Name)

--- a/pkg/operator/reportquery.go
+++ b/pkg/operator/reportquery.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator/reporting"
 )
 
@@ -43,7 +43,7 @@ func (op *Reporting) syncReportQuery(logger log.FieldLogger, key string) error {
 	return op.handleReportQuery(logger, q)
 }
 
-func (op *Reporting) handleReportQuery(logger log.FieldLogger, query *cbTypes.ReportQuery) error {
+func (op *Reporting) handleReportQuery(logger log.FieldLogger, query *metering.ReportQuery) error {
 	// queue any reportDataSources using this query to create views
 	return op.queueDependentReportDataSourcesForQuery(query)
 }
@@ -54,7 +54,7 @@ func (op *Reporting) uninitialiedDependendenciesHandler() *reporting.Uninitialie
 	}
 }
 
-func (op *Reporting) queueDependentReportDataSourcesForQuery(query *cbTypes.ReportQuery) error {
+func (op *Reporting) queueDependentReportDataSourcesForQuery(query *metering.ReportQuery) error {
 	reportDataSourceLister := op.meteringClient.MeteringV1alpha1().ReportDataSources(query.Namespace)
 	reportDataSources, err := reportDataSourceLister.List(metav1.ListOptions{})
 	if err != nil {

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	cbutil "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
 	"github.com/operator-framework/operator-metering/pkg/hive"
 	"github.com/operator-framework/operator-metering/pkg/operator/reporting"
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	reportFinalizer = cbTypes.GroupName + "/report"
+	reportFinalizer = metering.GroupName + "/report"
 )
 
 var (
@@ -106,18 +106,18 @@ type reportSchedule interface {
 	Next(time.Time) time.Time
 }
 
-func getSchedule(reportSched *cbTypes.ReportSchedule) (reportSchedule, error) {
+func getSchedule(reportSched *metering.ReportSchedule) (reportSchedule, error) {
 	var cronSpec string
 	switch reportSched.Period {
-	case cbTypes.ReportPeriodCron:
+	case metering.ReportPeriodCron:
 		if reportSched.Cron == nil || reportSched.Cron.Expression == "" {
 			return nil, fmt.Errorf("spec.schedule.cron.expression must be specified")
 		}
 		return cron.ParseStandard(reportSched.Cron.Expression)
-	case cbTypes.ReportPeriodHourly:
+	case metering.ReportPeriodHourly:
 		sched := reportSched.Hourly
 		if sched == nil {
-			sched = &cbTypes.ReportScheduleHourly{}
+			sched = &metering.ReportScheduleHourly{}
 		}
 		if err := validateMinute(sched.Minute); err != nil {
 			return nil, err
@@ -126,10 +126,10 @@ func getSchedule(reportSched *cbTypes.ReportSchedule) (reportSchedule, error) {
 			return nil, err
 		}
 		cronSpec = fmt.Sprintf("%d %d * * * *", sched.Second, sched.Minute)
-	case cbTypes.ReportPeriodDaily:
+	case metering.ReportPeriodDaily:
 		sched := reportSched.Daily
 		if sched == nil {
-			sched = &cbTypes.ReportScheduleDaily{}
+			sched = &metering.ReportScheduleDaily{}
 		}
 		if err := validateHour(sched.Hour); err != nil {
 			return nil, err
@@ -141,10 +141,10 @@ func getSchedule(reportSched *cbTypes.ReportSchedule) (reportSchedule, error) {
 			return nil, err
 		}
 		cronSpec = fmt.Sprintf("%d %d %d * * *", sched.Second, sched.Minute, sched.Hour)
-	case cbTypes.ReportPeriodWeekly:
+	case metering.ReportPeriodWeekly:
 		sched := reportSched.Weekly
 		if sched == nil {
-			sched = &cbTypes.ReportScheduleWeekly{}
+			sched = &metering.ReportScheduleWeekly{}
 		}
 		dow := 0
 		if sched.DayOfWeek != nil {
@@ -164,10 +164,10 @@ func getSchedule(reportSched *cbTypes.ReportSchedule) (reportSchedule, error) {
 			return nil, err
 		}
 		cronSpec = fmt.Sprintf("%d %d %d * * %d", sched.Second, sched.Minute, sched.Hour, dow)
-	case cbTypes.ReportPeriodMonthly:
+	case metering.ReportPeriodMonthly:
 		sched := reportSched.Monthly
 		if sched == nil {
-			sched = &cbTypes.ReportScheduleMonthly{}
+			sched = &metering.ReportScheduleMonthly{}
 		}
 		dom := int64(1)
 		if sched.DayOfMonth != nil {
@@ -192,7 +192,7 @@ func getSchedule(reportSched *cbTypes.ReportSchedule) (reportSchedule, error) {
 	return cron.Parse(cronSpec)
 }
 
-func (op *Reporting) handleReport(logger log.FieldLogger, report *cbTypes.Report) error {
+func (op *Reporting) handleReport(logger log.FieldLogger, report *metering.Report) error {
 	if op.cfg.EnableFinalizers && reportNeedsFinalizer(report) {
 		var err error
 		report, err = op.addReportFinalizer(report)
@@ -210,9 +210,9 @@ type reportPeriod struct {
 }
 
 // isReportFinished checks the running condition of the report parameter and returns true if the report has previously run
-func isReportFinished(logger log.FieldLogger, report *cbTypes.Report) bool {
+func isReportFinished(logger log.FieldLogger, report *metering.Report) bool {
 	// check if this report was previously finished
-	runningCond := cbutil.GetReportCondition(report.Status, cbTypes.ReportRunning)
+	runningCond := cbutil.GetReportCondition(report.Status, metering.ReportRunning)
 
 	if runningCond == nil {
 		logger.Infof("new report, validating report")
@@ -244,11 +244,11 @@ func isReportFinished(logger log.FieldLogger, report *cbTypes.Report) bool {
 
 // validateReport takes a Report structure and checks if it contains valid fields
 func validateReport(
-	report *cbTypes.Report,
+	report *metering.Report,
 	queryGetter reporting.ReportQueryGetter,
 	depResolver DependencyResolver,
 	handler *reporting.UninitialiedDependendenciesHandler,
-) (*cbTypes.ReportQuery, *reporting.DependencyResolutionResult, error) {
+) (*metering.ReportQuery, *reporting.DependencyResolutionResult, error) {
 	// Validate the ReportQuery is set
 	if report.Spec.QueryName == "" {
 		return nil, nil, errors.New("must set spec.query")
@@ -290,7 +290,7 @@ func validateReport(
 
 // getReportPeriod determines a Report's reporting period based off the report parameter's fields.
 // Returns a pointer to a reportPeriod structure if no error was encountered, else panic or return an error.
-func getReportPeriod(now time.Time, logger log.FieldLogger, report *cbTypes.Report) (*reportPeriod, error) {
+func getReportPeriod(now time.Time, logger log.FieldLogger, report *metering.Report) (*reportPeriod, error) {
 	var reportPeriod *reportPeriod
 
 	// check if the report's schedule spec is set
@@ -343,13 +343,13 @@ func getReportPeriod(now time.Time, logger log.FieldLogger, report *cbTypes.Repo
 // according the report's schedule. If the next scheduled reporting period
 // hasn't elapsed, runReport will requeue the resource for a time when
 // the period has elapsed.
-func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) error {
+func (op *Reporting) runReport(logger log.FieldLogger, report *metering.Report) error {
 	// check if the report was previously finished; store result in bool
 	if reportFinished := isReportFinished(logger, report); reportFinished {
 		return nil
 	}
 
-	runningCond := cbutil.GetReportCondition(report.Status, cbTypes.ReportRunning)
+	runningCond := cbutil.GetReportCondition(report.Status, metering.ReportRunning)
 	queryGetter := reporting.NewReportQueryListerGetter(op.reportQueryLister)
 
 	// validate that Report contains valid Spec fields
@@ -374,7 +374,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 
 	// create the table before we check to see if the report has dependencies
 	// that are missing data
-	var prestoTable *cbTypes.PrestoTable
+	var prestoTable *metering.PrestoTable
 	// if tableName isn't set, this report is still new and we should make sure
 	// no tables exist already in case of a previously failed cleanup.
 	if report.Status.TableRef.Name != "" {
@@ -409,7 +409,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 		}
 
 		logger.Infof("creating table %s", tableName)
-		hiveTable, err := op.createHiveTableCR(report, cbTypes.ReportGVK, params, false, nil)
+		hiveTable, err := op.createHiveTableCR(report, metering.ReportGVK, params, false, nil)
 		if err != nil {
 			return fmt.Errorf("error creating table for Report %s: %s", report.Name, err)
 		}
@@ -425,11 +425,11 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 		logger.Infof("created table %s", tableName)
 		dataSourceName := fmt.Sprintf("report-%s", report.Name)
 		logger.Infof("creating PrestoTable ReportDataSource %s pointing at report table %s", dataSourceName, prestoTable.Status.TableName)
-		ownerRef := metav1.NewControllerRef(prestoTable, cbTypes.PrestoTableGVK)
-		newReportDataSource := &cbTypes.ReportDataSource{
+		ownerRef := metav1.NewControllerRef(prestoTable, metering.PrestoTableGVK)
+		newReportDataSource := &metering.ReportDataSource{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ReportDataSource",
-				APIVersion: cbTypes.ReportDataSourceGVK.GroupVersion().String(),
+				APIVersion: metering.ReportDataSourceGVK.GroupVersion().String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dataSourceName,
@@ -439,8 +439,8 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 					*ownerRef,
 				},
 			},
-			Spec: cbTypes.ReportDataSourceSpec{
-				PrestoTable: &cbTypes.PrestoTableDataSource{
+			Spec: metering.ReportDataSourceSpec{
+				PrestoTable: &metering.PrestoTableDataSource{
 					TableRef: v1.LocalObjectReference{
 						Name: prestoTable.Name,
 					},
@@ -484,13 +484,13 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 			waitMsg := fmt.Sprintf("Next scheduled report period is [%s to %s]. next run time is %s.", reportPeriod.periodStart, reportPeriod.periodEnd, reportPeriod.periodEnd)
 			logger.Infof(waitMsg+". waiting %s", waitTime)
 
-			if runningCond := cbutil.GetReportCondition(report.Status, cbTypes.ReportRunning); runningCond != nil && runningCond.Status == v1.ConditionTrue && runningCond.Reason == cbutil.ReportingPeriodWaitingReason {
+			if runningCond := cbutil.GetReportCondition(report.Status, metering.ReportRunning); runningCond != nil && runningCond.Status == v1.ConditionTrue && runningCond.Reason == cbutil.ReportingPeriodWaitingReason {
 				op.enqueueReportAfter(report, waitTime)
 				return nil
 			}
 
 			var err error
-			report, err = op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionFalse, cbutil.ReportingPeriodWaitingReason, waitMsg))
+			report, err = op.updateReportStatus(report, cbutil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, cbutil.ReportingPeriodWaitingReason, waitMsg))
 			if err != nil {
 				return err
 			}
@@ -578,13 +578,13 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 				return nil
 			}
 			logger.Warnf(unmetMsg)
-			_, err := op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionFalse, cbutil.ReportingPeriodUnmetDependenciesReason, unmetMsg))
+			_, err := op.updateReportStatus(report, cbutil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, cbutil.ReportingPeriodUnmetDependenciesReason, unmetMsg))
 			return err
 		}
 	}
 	logger.Infof(runningMsg + " Running now.")
 
-	report, err = op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionTrue, runningReason, runningMsg))
+	report, err = op.updateReportStatus(report, cbutil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, runningReason, runningMsg))
 	if err != nil {
 		return err
 	}
@@ -660,7 +660,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 		// update the status to Failed with message containing the
 		// error
 		errMsg := fmt.Sprintf("error occurred while generating report: %s", err)
-		_, updateErr := op.updateReportStatus(report, cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionFalse, cbutil.GenerateReportFailedReason, errMsg))
+		_, updateErr := op.updateReportStatus(report, cbutil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, cbutil.GenerateReportFailedReason, errMsg))
 		if updateErr != nil {
 			logger.WithError(updateErr).Errorf("unable to update Report status")
 			return updateErr
@@ -677,7 +677,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 	// the status to indicate the report has finished
 	if report.Spec.ReportingEnd != nil && report.Status.LastReportTime.Time.Equal(report.Spec.ReportingEnd.Time) {
 		msg := fmt.Sprintf("Report has finished reporting. Report has reached the configured spec.reportingEnd: %s", report.Spec.ReportingEnd.Time)
-		runningCond := cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionFalse, cbutil.ReportFinishedReason, msg)
+		runningCond := cbutil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, cbutil.ReportFinishedReason, msg)
 		cbutil.SetReportCondition(&report.Status, *runningCond)
 		logger.Infof(msg)
 	} else if report.Spec.Schedule != nil {
@@ -699,7 +699,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 		waitTime := nextRunTime.Sub(now)
 
 		waitMsg := fmt.Sprintf("Next scheduled report period is [%s to %s]. next run time is %s.", reportPeriod.periodStart, reportPeriod.periodEnd, nextRunTime)
-		runningCond := cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionFalse, cbutil.ReportingPeriodWaitingReason, waitMsg)
+		runningCond := cbutil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, cbutil.ReportingPeriodWaitingReason, waitMsg)
 		cbutil.SetReportCondition(&report.Status, *runningCond)
 		logger.Infof(waitMsg+". waiting %s", waitTime)
 		op.enqueueReportAfter(report, waitTime)
@@ -721,7 +721,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *cbTypes.Report) e
 	return nil
 }
 
-func getRunOnceReportPeriod(report *cbTypes.Report) (*reportPeriod, error) {
+func getRunOnceReportPeriod(report *metering.Report) (*reportPeriod, error) {
 	if report.Spec.ReportingEnd == nil || report.Spec.ReportingStart == nil {
 		return nil, fmt.Errorf("run-once reports must have both ReportingEnd and ReportingStart")
 	}
@@ -732,7 +732,7 @@ func getRunOnceReportPeriod(report *cbTypes.Report) (*reportPeriod, error) {
 	return reportPeriod, nil
 }
 
-func getNextReportPeriod(schedule reportSchedule, period cbTypes.ReportPeriod, lastScheduled time.Time) *reportPeriod {
+func getNextReportPeriod(schedule reportSchedule, period metering.ReportPeriod, lastScheduled time.Time) *reportPeriod {
 	periodStart := lastScheduled.UTC()
 	periodEnd := schedule.Next(periodStart)
 	return &reportPeriod{
@@ -761,7 +761,7 @@ func convertDayOfWeek(dow string) (int, error) {
 	return 0, fmt.Errorf("invalid day of week: %s", dow)
 }
 
-func (op *Reporting) addReportFinalizer(report *cbTypes.Report) (*cbTypes.Report, error) {
+func (op *Reporting) addReportFinalizer(report *metering.Report) (*metering.Report, error) {
 	report.Finalizers = append(report.Finalizers, reportFinalizer)
 	newReport, err := op.meteringClient.MeteringV1alpha1().Reports(report.Namespace).Update(report)
 	logger := op.logger.WithFields(log.Fields{"report": report.Name, "namespace": report.Namespace})
@@ -773,7 +773,7 @@ func (op *Reporting) addReportFinalizer(report *cbTypes.Report) (*cbTypes.Report
 	return newReport, nil
 }
 
-func (op *Reporting) removeReportFinalizer(report *cbTypes.Report) (*cbTypes.Report, error) {
+func (op *Reporting) removeReportFinalizer(report *metering.Report) (*metering.Report, error) {
 	if !slice.ContainsString(report.ObjectMeta.Finalizers, reportFinalizer, nil) {
 		return report, nil
 	}
@@ -788,39 +788,39 @@ func (op *Reporting) removeReportFinalizer(report *cbTypes.Report) (*cbTypes.Rep
 	return newReport, nil
 }
 
-func reportNeedsFinalizer(report *cbTypes.Report) bool {
+func reportNeedsFinalizer(report *metering.Report) bool {
 	return report.ObjectMeta.DeletionTimestamp == nil && !slice.ContainsString(report.ObjectMeta.Finalizers, reportFinalizer, nil)
 }
 
-func (op *Reporting) updateReportStatus(report *cbTypes.Report, cond *cbTypes.ReportCondition) (*cbTypes.Report, error) {
+func (op *Reporting) updateReportStatus(report *metering.Report, cond *metering.ReportCondition) (*metering.Report, error) {
 	cbutil.SetReportCondition(&report.Status, *cond)
 	return op.meteringClient.MeteringV1alpha1().Reports(report.Namespace).Update(report)
 }
 
-func (op *Reporting) setReportStatusInvalidReport(report *cbTypes.Report, msg string) error {
+func (op *Reporting) setReportStatusInvalidReport(report *metering.Report, msg string) error {
 	logger := op.logger.WithFields(log.Fields{"report": report.Name, "namespace": report.Namespace})
 	// don't update unless the validation error changes
-	if runningCond := cbutil.GetReportCondition(report.Status, cbTypes.ReportRunning); runningCond != nil && runningCond.Status == v1.ConditionFalse && runningCond.Reason == cbutil.InvalidReportReason && runningCond.Message == msg {
+	if runningCond := cbutil.GetReportCondition(report.Status, metering.ReportRunning); runningCond != nil && runningCond.Status == v1.ConditionFalse && runningCond.Reason == cbutil.InvalidReportReason && runningCond.Message == msg {
 		logger.Debugf("Report %s failed validation last reconcile, skipping updating status", report.Name)
 		return nil
 	}
 
 	logger.Warnf("Report %s failed validation: %s", report.Name, msg)
-	cond := cbutil.NewReportCondition(cbTypes.ReportRunning, v1.ConditionFalse, cbutil.InvalidReportReason, msg)
+	cond := cbutil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, cbutil.InvalidReportReason, msg)
 	_, err := op.updateReportStatus(report, cond)
 	return err
 }
 
 // GetReportQueryForReport returns the ReportQuery that was used in the Report parameter
-func GetReportQueryForReport(report *cbTypes.Report, queryGetter reporting.ReportQueryGetter) (*cbTypes.ReportQuery, error) {
+func GetReportQueryForReport(report *metering.Report, queryGetter reporting.ReportQueryGetter) (*metering.ReportQuery, error) {
 	return queryGetter.GetReportQuery(report.Namespace, report.Spec.QueryName)
 }
 
-func (op *Reporting) getReportDependencies(report *cbTypes.Report) (*reporting.ReportQueryDependencies, error) {
+func (op *Reporting) getReportDependencies(report *metering.Report) (*reporting.ReportQueryDependencies, error) {
 	return op.getQueryDependencies(report.Namespace, report.Spec.QueryName, report.Spec.Inputs)
 }
 
-func (op *Reporting) queueDependentReportsForReport(report *cbTypes.Report) error {
+func (op *Reporting) queueDependentReportsForReport(report *metering.Report) error {
 	// Look for all reports in the namespace
 	reports, err := op.reportLister.Reports(report.Namespace).List(labels.Everything())
 	if err != nil {
@@ -849,7 +849,7 @@ func (op *Reporting) queueDependentReportsForReport(report *cbTypes.Report) erro
 // queueDependentReportQueriesForReport will queue all
 // ReportQueries in the namespace which have a dependency on the
 // report
-func (op *Reporting) queueDependentReportQueriesForReport(report *cbTypes.Report) error {
+func (op *Reporting) queueDependentReportQueriesForReport(report *metering.Report) error {
 	queryLister := op.meteringClient.MeteringV1alpha1().ReportQueries(report.Namespace)
 	queries, err := queryLister.List(metav1.ListOptions{})
 	if err != nil {

--- a/pkg/operator/reports_test.go
+++ b/pkg/operator/reports_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/operator-framework/operator-metering/pkg/operator/reporting"
 
-	"github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	meteringUtil "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
 	"github.com/operator-framework/operator-metering/test/testhelpers"
@@ -127,12 +126,12 @@ func TestIsReportFinished(t *testing.T) {
 	}{
 		{
 			name:           "new report returns false",
-			report:         testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:         testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			expectFinished: false,
 		},
 		{
 			name: "finished status on run-once report returns true",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
@@ -141,7 +140,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "unset reportingEnd returns false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, nil, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, nil, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
@@ -150,7 +149,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "reportingEnd > lastReportTime returns false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
@@ -160,7 +159,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "reportingEnd < lastReportTime returns true",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
@@ -170,7 +169,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is false and reason is Scheduled return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ScheduledReason, testReportMessage),
 				},
@@ -179,7 +178,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is true and reason is Scheduled return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.ScheduledReason, testReportMessage),
 				},
@@ -188,7 +187,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is false and reason is InvalidReport return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.InvalidReportReason, testReportMessage),
 				},
@@ -197,7 +196,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is true and reason is InvalidReport return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.InvalidReportReason, testReportMessage),
 				},
@@ -206,7 +205,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is false and reason is RunImmediately return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.RunImmediatelyReason, testReportMessage),
 				},
@@ -215,7 +214,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is true and reason is RunImmediately return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.RunImmediatelyReason, testReportMessage),
 				},
@@ -323,43 +322,43 @@ func TestValidateReport(t *testing.T) {
 	}{
 		{
 			name:         "empty spec.query returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, "", reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:       testhelpers.NewReport(testReportName, testNamespace, "", reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			expectErr:    true,
 			expectErrMsg: "must set spec.query",
 		},
 		{
 			name:         "spec.ReportingStart > spec.ReportingEnd returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportEnd, reportStart, v1alpha1.ReportStatus{}, nil, false),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportEnd, reportStart, metering.ReportStatus{}, nil, false),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("spec.reportingEnd (%s) must be after spec.reportingStart (%s)", reportStart.String(), reportEnd.String()),
 		},
 		{
 			name:         "spec.ReportingEnd is unset and spec.RunImmediately is set returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, nil, v1alpha1.ReportStatus{}, nil, true),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, nil, metering.ReportStatus{}, nil, true),
 			expectErr:    true,
 			expectErrMsg: "spec.reportingEnd must be set if report.spec.runImmediately is true",
 		},
 		{
 			name:         "spec.QueryName does not exist returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("ReportQuery (%s) does not exist", testNonExistentQueryName),
 		},
 		{
 			name:         "valid report with missing DataSource returns error",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, true),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, true),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("failed to resolve ReportQuery dependencies %s: %s", testInvalidQueryName, "ReportDataSource.metering.openshift.io \"this-does-not-exist\" not found"),
 		},
 		{
 			name:         "valid report with uninitalized DataSource returns error",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName2, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, true),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName2, reportStart, reportEnd, metering.ReportStatus{}, nil, true),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("failed to validate ReportQuery dependencies %s: ReportQueryDependencyValidationError: uninitialized ReportDataSource dependencies: %s", testInvalidQueryName2, ds2.Name),
 		},
 		{
 			name:         "valid report with valid DataSource returns nil",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, true),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, true),
 			expectErr:    false,
 			expectErrMsg: "",
 		},
@@ -412,47 +411,47 @@ func TestGetReportPeriod(t *testing.T) {
 	}{
 		{
 			name:      "invalid report with an unset spec.Schedule field returns an error",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, v1alpha1.ReportStatus{}, nil, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, metering.ReportStatus{}, nil, false),
 			expectErr: true,
 		},
 		{
 			name:      "valid report with an unset spec.Schedule field returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, nil, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
 			expectErr: false,
 		},
 		{
 			name:      "invalid schedule with a set spec.Schedule field returns error",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, invalidSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, invalidSchedule, false),
 			expectErr: true,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and a set Spec.Status.LastReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{LastReportTime: lastReportTime}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{LastReportTime: lastReportTime}, validSchedule, false),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and a set Spec.ReportingStart returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and an unset Spec.ReportingStart returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, v1alpha1.ReportStatus{}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, metering.ReportStatus{}, validSchedule, false),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and a set Spec.NextReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, v1alpha1.ReportStatus{NextReportTime: nextReportTime}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, metering.ReportStatus{NextReportTime: nextReportTime}, validSchedule, false),
 			expectErr: false,
 		},
 		{
 			name:        "unset Spec.Schedule with reportPeriod.periodStart > reportPeriod.periodEnd returns panic",
-			report:      testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportEnd, reportStart, v1alpha1.ReportStatus{NextReportTime: nextReportTime}, nil, false),
+			report:      testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportEnd, reportStart, metering.ReportStatus{NextReportTime: nextReportTime}, nil, false),
 			expectErr:   false,
 			expectPanic: true,
 		},

--- a/pkg/operator/reports_test.go
+++ b/pkg/operator/reports_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
-	"github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
+	meteringUtil "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
 	"github.com/operator-framework/operator-metering/test/testhelpers"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -134,7 +134,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "finished status on run-once report returns true",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ReportFinishedReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
 			}, nil, false),
 			expectFinished: true,
@@ -143,7 +143,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "unset reportingEnd returns false",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, nil, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ReportFinishedReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
 			}, schedule, false),
 			expectFinished: false,
@@ -152,7 +152,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "reportingEnd > lastReportTime returns false",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ReportFinishedReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
 				LastReportTime: &metav1.Time{Time: reportStart.AddDate(0, 0, 0)},
 			}, schedule, false),
@@ -162,7 +162,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "reportingEnd < lastReportTime returns true",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ReportFinishedReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
 				LastReportTime: &metav1.Time{Time: reportStart.AddDate(0, 2, 0)},
 			}, schedule, false),
@@ -172,7 +172,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "when status running is false and reason is Scheduled return false",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.ScheduledReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ScheduledReason, testReportMessage),
 				},
 			}, schedule, false),
 			expectFinished: false,
@@ -181,7 +181,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "when status running is true and reason is Scheduled return false",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, util.ScheduledReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.ScheduledReason, testReportMessage),
 				},
 			}, schedule, false),
 			expectFinished: false,
@@ -190,7 +190,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "when status running is false and reason is InvalidReport return false",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.InvalidReportReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.InvalidReportReason, testReportMessage),
 				},
 			}, schedule, false),
 			expectFinished: false,
@@ -199,7 +199,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "when status running is true and reason is InvalidReport return false",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, util.InvalidReportReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.InvalidReportReason, testReportMessage),
 				},
 			}, schedule, false),
 			expectFinished: false,
@@ -208,7 +208,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "when status running is false and reason is RunImmediately return false",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, util.RunImmediatelyReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.RunImmediatelyReason, testReportMessage),
 				},
 			}, schedule, false),
 			expectFinished: false,
@@ -217,7 +217,7 @@ func TestIsReportFinished(t *testing.T) {
 			name: "when status running is true and reason is RunImmediately return false",
 			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, v1alpha1.ReportStatus{
 				Conditions: []metering.ReportCondition{
-					*util.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, util.RunImmediatelyReason, testReportMessage),
+					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.RunImmediatelyReason, testReportMessage),
 				},
 			}, schedule, false),
 			expectFinished: false,

--- a/pkg/operator/storage.go
+++ b/pkg/operator/storage.go
@@ -3,21 +3,21 @@ package operator
 import (
 	"fmt"
 
-	cbTypes "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	cbListers "github.com/operator-framework/operator-metering/pkg/generated/listers/metering/v1alpha1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func (op *Reporting) getDefaultStorageLocation(lister cbListers.StorageLocationLister, namespace string) (*cbTypes.StorageLocation, error) {
+func (op *Reporting) getDefaultStorageLocation(lister cbListers.StorageLocationLister, namespace string) (*metering.StorageLocation, error) {
 	storageLocations, err := lister.StorageLocations(namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	var defaultStorageLocations []*cbTypes.StorageLocation
+	var defaultStorageLocations []*metering.StorageLocation
 
 	for _, storageLocation := range storageLocations {
-		if storageLocation.Annotations[cbTypes.IsDefaultStorageLocationAnnotation] == "true" {
+		if storageLocation.Annotations[metering.IsDefaultStorageLocationAnnotation] == "true" {
 			defaultStorageLocations = append(defaultStorageLocations, storageLocation)
 		}
 	}
@@ -35,7 +35,7 @@ func (op *Reporting) getDefaultStorageLocation(lister cbListers.StorageLocationL
 
 }
 
-func (op *Reporting) getStorage(storage *cbTypes.StorageLocationRef, namespace string) (*cbTypes.StorageLocation, error) {
+func (op *Reporting) getStorage(storage *metering.StorageLocationRef, namespace string) (*metering.StorageLocation, error) {
 	// Nothing specified, try to use default storage location
 	if storage == nil || storage.StorageLocationName == "" {
 		storageLocation, err := op.getDefaultStorageLocation(op.storageLocationLister, namespace)
@@ -52,7 +52,7 @@ func (op *Reporting) getStorage(storage *cbTypes.StorageLocationRef, namespace s
 	return nil, fmt.Errorf("no default storageLocation and storageLocationName is empty")
 }
 
-func (op *Reporting) getHiveStorage(storageRef *cbTypes.StorageLocationRef, namespace string) (*cbTypes.StorageLocation, error) {
+func (op *Reporting) getHiveStorage(storageRef *metering.StorageLocationRef, namespace string) (*metering.StorageLocation, error) {
 	storageLocation, err := op.getStorage(storageRef, namespace)
 	if err != nil {
 		return nil, err

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	meteringv1alpha1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/test/framework"
 )
 
@@ -53,9 +53,9 @@ func TestMain(m *testing.M) {
 
 func TestReportingProducesData(t *testing.T) {
 	// cron schedule to run every minute
-	cronSchedule := &meteringv1alpha1.ReportSchedule{
-		Period: meteringv1alpha1.ReportPeriodCron,
-		Cron: &meteringv1alpha1.ReportScheduleCron{
+	cronSchedule := &metering.ReportSchedule{
+		Period: metering.ReportPeriodCron,
+		Cron: &metering.ReportScheduleCron{
 			Expression: fmt.Sprintf("*/1 * * * *"),
 		},
 	}

--- a/test/e2e/report_test.go
+++ b/test/e2e/report_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	meteringv1alpha1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator/reporting"
 	"github.com/operator-framework/operator-metering/test/framework"
 )
@@ -15,8 +15,8 @@ import (
 type reportProducesDataTestCase struct {
 	name          string
 	queryName     string
-	schedule      *meteringv1alpha1.ReportSchedule
-	newReportFunc func(name, queryName string, schedule *meteringv1alpha1.ReportSchedule, start, end *time.Time) *meteringv1alpha1.Report
+	schedule      *metering.ReportSchedule
+	newReportFunc func(name, queryName string, schedule *metering.ReportSchedule, start, end *time.Time) *metering.Report
 	skip          bool
 	parallel      bool
 }
@@ -52,7 +52,7 @@ func testReportsProduceData(t *testing.T, testFramework *framework.Framework, te
 
 			// for each datasource, wait until it's EarliestImportedMetricTime is set
 			for _, ds := range dependencies.ReportDataSources {
-				_, err := testFramework.WaitForMeteringReportDataSource(t, ds.Name, 5*time.Second, 5*time.Minute, func(dataSource *meteringv1alpha1.ReportDataSource) (bool, error) {
+				_, err := testFramework.WaitForMeteringReportDataSource(t, ds.Name, 5*time.Second, 5*time.Minute, func(dataSource *metering.ReportDataSource) (bool, error) {
 					if dataSource.Spec.PrometheusMetricsImporter == nil {
 						return true, nil
 					}

--- a/test/framework/datasource.go
+++ b/test/framework/datasource.go
@@ -9,17 +9,17 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	meteringv1alpha1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/stretchr/testify/require"
 )
 
-func (f *Framework) GetMeteringReportDataSource(name string) (*meteringv1alpha1.ReportDataSource, error) {
+func (f *Framework) GetMeteringReportDataSource(name string) (*metering.ReportDataSource, error) {
 	return f.MeteringClient.ReportDataSources(f.Namespace).Get(name, meta.GetOptions{})
 }
 
-func (f *Framework) WaitForMeteringReportDataSourceTable(t *testing.T, name string, pollInterval, timeout time.Duration) (*meteringv1alpha1.ReportDataSource, error) {
+func (f *Framework) WaitForMeteringReportDataSourceTable(t *testing.T, name string, pollInterval, timeout time.Duration) (*metering.ReportDataSource, error) {
 	t.Helper()
-	ds, err := f.WaitForMeteringReportDataSource(t, name, pollInterval, timeout, func(ds *meteringv1alpha1.ReportDataSource) (bool, error) {
+	ds, err := f.WaitForMeteringReportDataSource(t, name, pollInterval, timeout, func(ds *metering.ReportDataSource) (bool, error) {
 		if ds.Status.TableRef.Name == "" {
 			t.Logf("ReportDataSource %s table is not created yet", name)
 			return false, nil
@@ -35,9 +35,9 @@ func (f *Framework) WaitForMeteringReportDataSourceTable(t *testing.T, name stri
 	return ds, nil
 }
 
-func (f *Framework) WaitForAllMeteringReportDataSourceTables(t *testing.T, pollInterval, timeout time.Duration) ([]*meteringv1alpha1.ReportDataSource, error) {
+func (f *Framework) WaitForAllMeteringReportDataSourceTables(t *testing.T, pollInterval, timeout time.Duration) ([]*metering.ReportDataSource, error) {
 	t.Helper()
-	var reportDataSources []*meteringv1alpha1.ReportDataSource
+	var reportDataSources []*metering.ReportDataSource
 	return reportDataSources, wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
 		reportDataSourcesList, err := f.MeteringClient.ReportDataSources(f.Namespace).List(meta.ListOptions{})
 		require.NoError(t, err, "should not have errors querying API for list of ReportDataSources")
@@ -53,9 +53,9 @@ func (f *Framework) WaitForAllMeteringReportDataSourceTables(t *testing.T, pollI
 	})
 }
 
-func (f *Framework) WaitForMeteringReportDataSource(t *testing.T, name string, pollInterval, timeout time.Duration, dsFunc func(ds *meteringv1alpha1.ReportDataSource) (bool, error)) (*meteringv1alpha1.ReportDataSource, error) {
+func (f *Framework) WaitForMeteringReportDataSource(t *testing.T, name string, pollInterval, timeout time.Duration, dsFunc func(ds *metering.ReportDataSource) (bool, error)) (*metering.ReportDataSource, error) {
 	t.Helper()
-	var ds *meteringv1alpha1.ReportDataSource
+	var ds *metering.ReportDataSource
 	return ds, wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
 		var err error
 		ds, err = f.GetMeteringReportDataSource(name)

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -14,12 +14,12 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	meteringv1alpha1 "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator"
 )
 
 type Framework struct {
-	MeteringClient        meteringv1alpha1.MeteringV1alpha1Interface
+	MeteringClient        metering.MeteringV1alpha1Interface
 	KubeClient            kubernetes.Interface
 	HTTPClient            *http.Client
 	Namespace             string
@@ -75,7 +75,7 @@ func New(namespace, kubeconfig string, httpsAPI, useKubeProxyForReportingAPI boo
 		httpc.Timeout = configCopy.Timeout
 	}
 
-	meteringClient, err := meteringv1alpha1.NewForConfig(config)
+	meteringClient, err := metering.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("creating monitoring client failed: err %v", err)
 	}

--- a/test/framework/report.go
+++ b/test/framework/report.go
@@ -18,20 +18,20 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	meteringv1alpha1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
-	meteringutil "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	meteringUtil "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1/util"
 )
 
-func (f *Framework) CreateMeteringReport(report *meteringv1alpha1.Report) error {
+func (f *Framework) CreateMeteringReport(report *metering.Report) error {
 	_, err := f.MeteringClient.Reports(f.Namespace).Create(report)
 	return err
 }
 
-func (f *Framework) GetMeteringReport(name string) (*meteringv1alpha1.Report, error) {
+func (f *Framework) GetMeteringReport(name string) (*metering.Report, error) {
 	return f.MeteringClient.Reports(f.Namespace).Get(name, meta.GetOptions{})
 }
 
-func (f *Framework) NewSimpleReport(name, queryName string, schedule *meteringv1alpha1.ReportSchedule, reportingStart, reportingEnd *time.Time) *meteringv1alpha1.Report {
+func (f *Framework) NewSimpleReport(name, queryName string, schedule *metering.ReportSchedule, reportingStart, reportingEnd *time.Time) *metering.Report {
 	var start, end *meta.Time
 	if reportingStart != nil {
 		start = &meta.Time{*reportingStart}
@@ -39,12 +39,12 @@ func (f *Framework) NewSimpleReport(name, queryName string, schedule *meteringv1
 	if reportingEnd != nil {
 		end = &meta.Time{*reportingEnd}
 	}
-	return &meteringv1alpha1.Report{
+	return &metering.Report{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: f.Namespace,
 		},
-		Spec: meteringv1alpha1.ReportSpec{
+		Spec: metering.ReportSpec{
 			QueryName:      queryName,
 			Schedule:       schedule,
 			ReportingStart: start,
@@ -53,7 +53,7 @@ func (f *Framework) NewSimpleReport(name, queryName string, schedule *meteringv1
 	}
 }
 
-func (f *Framework) RequireReportSuccessfullyRuns(t *testing.T, report *meteringv1alpha1.Report, waitTimeout time.Duration) {
+func (f *Framework) RequireReportSuccessfullyRuns(t *testing.T, report *metering.Report, waitTimeout time.Duration) {
 	t.Helper()
 	err := f.MeteringClient.Reports(f.Namespace).Delete(report.Name, nil)
 	assert.Condition(t, func() bool {
@@ -71,8 +71,8 @@ func (f *Framework) RequireReportSuccessfullyRuns(t *testing.T, report *metering
 		if err != nil {
 			return false, err
 		}
-		cond := meteringutil.GetReportCondition(report.Status, meteringv1alpha1.ReportRunning)
-		if cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == meteringutil.ReportFinishedReason {
+		cond := meteringUtil.GetReportCondition(report.Status, metering.ReportRunning)
+		if cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == meteringUtil.ReportFinishedReason {
 			return true, nil
 		}
 
@@ -86,7 +86,7 @@ func (f *Framework) RequireReportSuccessfullyRuns(t *testing.T, report *metering
 	require.NoErrorf(t, err, "expected Report to finished within %s timeout", waitTimeout)
 }
 
-func (f *Framework) GetReportResults(t *testing.T, report *meteringv1alpha1.Report, waitTimeout time.Duration) []map[string]interface{} {
+func (f *Framework) GetReportResults(t *testing.T, report *metering.Report, waitTimeout time.Duration) []map[string]interface{} {
 	t.Helper()
 	var reportResults []map[string]interface{}
 	var reportData []byte

--- a/test/testhelpers/helpers.go
+++ b/test/testhelpers/helpers.go
@@ -6,13 +6,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1alpha1"
 	"github.com/operator-framework/operator-metering/pkg/operator/reportingutil"
 	"github.com/operator-framework/operator-metering/pkg/presto"
 )
 
 // NewReport creates a mock report used for testing purposes.
-func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *time.Time, status v1alpha1.ReportStatus, schedule *v1alpha1.ReportSchedule, runImmediately bool) *v1alpha1.Report {
+func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *time.Time, status metering.ReportStatus, schedule *metering.ReportSchedule, runImmediately bool) *metering.Report {
 	var start, end *meta.Time
 	if reportStart != nil {
 		start = &meta.Time{*reportStart}
@@ -20,12 +20,12 @@ func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *ti
 	if reportEnd != nil {
 		end = &meta.Time{*reportEnd}
 	}
-	return &v1alpha1.Report{
+	return &metering.Report{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.ReportSpec{
+		Spec: metering.ReportSpec{
 			QueryName:      testQueryName,
 			ReportingStart: start,
 			ReportingEnd:   end,
@@ -36,20 +36,20 @@ func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *ti
 	}
 }
 
-func NewReportQuery(name, namespace string, columns []v1alpha1.ReportQueryColumn) *v1alpha1.ReportQuery {
-	return &v1alpha1.ReportQuery{
+func NewReportQuery(name, namespace string, columns []metering.ReportQueryColumn) *metering.ReportQuery {
+	return &metering.ReportQuery{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.ReportQuerySpec{
+		Spec: metering.ReportQuerySpec{
 			Columns: columns,
 		},
 	}
 }
 
-func NewReportDataSource(name, namespace string) *v1alpha1.ReportDataSource {
-	return &v1alpha1.ReportDataSource{
+func NewReportDataSource(name, namespace string) *metering.ReportDataSource {
+	return &metering.ReportDataSource{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -57,13 +57,13 @@ func NewReportDataSource(name, namespace string) *v1alpha1.ReportDataSource {
 	}
 }
 
-func NewPrestoTable(name, namespace, catalog, schema string, columns []presto.Column) *v1alpha1.PrestoTable {
-	return &v1alpha1.PrestoTable{
+func NewPrestoTable(name, namespace, catalog, schema string, columns []presto.Column) *metering.PrestoTable {
+	return &metering.PrestoTable{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      reportingutil.TableResourceNameFromKind("Report", namespace, name),
 			Namespace: namespace,
 		},
-		Status: v1alpha1.PrestoTableStatus{
+		Status: metering.PrestoTableStatus{
 			Catalog:   catalog,
 			Schema:    schema,
 			TableName: name,
@@ -73,61 +73,61 @@ func NewPrestoTable(name, namespace, catalog, schema string, columns []presto.Co
 }
 
 type ReportDataSourceStore struct {
-	datasources map[string]*v1alpha1.ReportDataSource
+	datasources map[string]*metering.ReportDataSource
 }
 
-func NewReportDataSourceStore(datasources []*v1alpha1.ReportDataSource) (store *ReportDataSourceStore) {
-	m := make(map[string]*v1alpha1.ReportDataSource)
+func NewReportDataSourceStore(datasources []*metering.ReportDataSource) (store *ReportDataSourceStore) {
+	m := make(map[string]*metering.ReportDataSource)
 	for _, dataSource := range datasources {
 		m[dataSource.Namespace+"/"+dataSource.Name] = dataSource
 	}
 	return &ReportDataSourceStore{m}
 }
 
-func (store *ReportDataSourceStore) GetReportDataSource(namespace, name string) (*v1alpha1.ReportDataSource, error) {
+func (store *ReportDataSourceStore) GetReportDataSource(namespace, name string) (*metering.ReportDataSource, error) {
 	dataSource, ok := store.datasources[namespace+"/"+name]
 	if ok {
 		return dataSource, nil
 	}
-	return nil, errors.NewNotFound(v1alpha1.Resource("ReportDataSource"), name)
+	return nil, errors.NewNotFound(metering.Resource("ReportDataSource"), name)
 }
 
 type ReportQueryStore struct {
-	queries map[string]*v1alpha1.ReportQuery
+	queries map[string]*metering.ReportQuery
 }
 
-func NewReportQueryStore(queries []*v1alpha1.ReportQuery) (store *ReportQueryStore) {
-	m := make(map[string]*v1alpha1.ReportQuery)
+func NewReportQueryStore(queries []*metering.ReportQuery) (store *ReportQueryStore) {
+	m := make(map[string]*metering.ReportQuery)
 	for _, query := range queries {
 		m[query.Namespace+"/"+query.Name] = query
 	}
 	return &ReportQueryStore{m}
 }
 
-func (store *ReportQueryStore) GetReportQuery(namespace, name string) (*v1alpha1.ReportQuery, error) {
+func (store *ReportQueryStore) GetReportQuery(namespace, name string) (*metering.ReportQuery, error) {
 	query, ok := store.queries[namespace+"/"+name]
 	if ok {
 		return query, nil
 	}
-	return nil, errors.NewNotFound(v1alpha1.Resource("ReportQuery"), name)
+	return nil, errors.NewNotFound(metering.Resource("ReportQuery"), name)
 }
 
 type ReportStore struct {
-	reports map[string]*v1alpha1.Report
+	reports map[string]*metering.Report
 }
 
-func NewReportStore(reports []*v1alpha1.Report) (store *ReportStore) {
-	m := make(map[string]*v1alpha1.Report)
+func NewReportStore(reports []*metering.Report) (store *ReportStore) {
+	m := make(map[string]*metering.Report)
 	for _, report := range reports {
 		m[report.Namespace+"/"+report.Name] = report
 	}
 	return &ReportStore{m}
 }
 
-func (store *ReportStore) GetReport(namespace, name string) (*v1alpha1.Report, error) {
+func (store *ReportStore) GetReport(namespace, name string) (*metering.Report, error) {
 	report, ok := store.reports[namespace+"/"+name]
 	if ok {
 		return report, nil
 	}
-	return nil, errors.NewNotFound(v1alpha1.Resource("Report"), name)
+	return nil, errors.NewNotFound(metering.Resource("Report"), name)
 }


### PR DESCRIPTION
Used `find pkg/ test/ -type f -exec sed -i 's/cbTypes/metering/g' {} \;` and `grep -nrw . -e "cbTypes"` to find all the occurences. 

The remaining import identifiers are most likely the generated files in the `pkg/` directory, and inconsistently named ones like `meteringv1alpha`.