### PR TITLE
charts/openshift-metering: Fix the ordering of TLS/Auth tasks in the presto-common-config.yaml.

### DIFF
--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -9,12 +9,11 @@ data:
 
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
     cat $PRESTO_CLIENT_KEYFILE $PRESTO_CLIENT_CRTFILE > $PRESTO_TRUSTSTORE_PEM
-
+{{- end }}
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
     # copy all necessary tls.crt/tls.key from read-only secret volumes - append server bundle and CA cert to truststore
     cat $PRESTO_SERVER_KEYFILE $PRESTO_SERVER_CRTFILE $PRESTO_CA_CRTFILE > $PRESTO_KEYSTORE_PEM
     cat $PRESTO_SERVER_KEYFILE $PRESTO_SERVER_CRTFILE $PRESTO_CA_CRTFILE >> $PRESTO_TRUSTSTORE_PEM
-{{- end }}
 {{- end }}
 
     cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/


### PR DESCRIPTION
This was problematic if the user had enabled TLS, but not authentication as the `...config.tls.enabled` conditional would never be evaluated as it's nested under the `...config.auth.enabled` conditional, which would evaluate to false.