### PR TITLE
metering-ansible-operator: Use different loop_var for prune_resources.yml

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -1,11 +1,13 @@
 - name: Query for {{ resource.apis | map(attribute='kind') | join(', ') }} resources with selector {{ label_selector }} to delete
   k8s_facts:
-    api_version: "{{ item.api_version | default(omit) }}"
-    kind: "{{ item.kind }}"
+    api_version: "{{ to_delete_item.api_version | default(omit) }}"
+    kind: "{{ to_delete_item.kind }}"
     namespace: "{{ namespace }}"
     label_selectors:
       - "{{ label_selector }}"
   loop: "{{ resource.apis }}"
+  loop_control:
+    loop_var: to_delete_item
   vars:
     label_selector: "{{ meteringconfig_prune_label_key }}={{ resource.prune_label_value }}"
   register: to_delete


### PR DESCRIPTION
`item` was already used in a task higher up in the stack, this changes
the loop_var in prune_resources.yml to avoid a conflict.