### PR TITLE
Stop using async ansible tasks

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
@@ -46,21 +46,7 @@
     namespace: "{{ meta.namespace }}"
     definition: "{{ updated_template_results | flatten }}"
     merge_type: ['merge', 'strategic-merge']
-  async: "{{ async_seconds | default(0) }}"
-  poll: 0
   when: template_results.changed and resource is not none
-  register: create_resources_async_result
-
-- name: Wait for resources to finish deploying when deployed asynchronously
-  async_status:
-    jid: "{{ create_resources_async_result.ansible_job_id }}"
-  when: create_resources_async_result.changed and async_seconds is defined and async_seconds != 0
-  until: create_resources_job_result.finished
-  # delay is 1 second, so retry up to async_seconds, meaning, wait for all
-  # async tasks to complete within the time given to each
-  retries: "{{ async_seconds }}"
-  delay: 1
-  register: create_resources_job_result
 
 - name: Prune resources
   include_tasks: prune_resources.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
@@ -54,7 +54,7 @@
 - name: Wait for resources to finish deploying when deployed asynchronously
   async_status:
     jid: "{{ create_resources_async_result.ansible_job_id }}"
-  when: async_seconds != 0 and create_resources_async_result.changed
+  when: create_resources_async_result.changed and async_seconds is defined and async_seconds != 0
   until: create_resources_job_result.finished
   # delay is 1 second, so retry up to async_seconds, meaning, wait for all
   # async tasks to complete within the time given to each

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -24,7 +24,7 @@
 - name: Wait for resources to being deleted when deleted asynchronously
   async_status:
     jid: "{{ delete_resources_async_result.ansible_job_id }}"
-  when: async_seconds != 0 and delete_resources_async_result.results is defined
+  when: delete_resources_async_result.results is defined and async_seconds is defined and async_seconds != 0
   until: delete_resources_job_result.finished
   # delay is 1 second, so retry up to async_seconds, meaning, wait for all
   # async tasks to complete within the time given to each

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -16,18 +16,4 @@
     definition: "{{ to_delete.results | map(attribute='resources') | flatten }}"
   vars:
     label_selector: "{{ meteringconfig_prune_label_key }}={{ resource.prune_label_value }}"
-  async: "{{ async_seconds | default(0) }}"
-  poll: 0
   when: to_delete.changed
-  register: delete_resources_async_result
-
-- name: Wait for resources to being deleted when deleted asynchronously
-  async_status:
-    jid: "{{ delete_resources_async_result.ansible_job_id }}"
-  when: delete_resources_async_result.results is defined and async_seconds is defined and async_seconds != 0
-  until: delete_resources_job_result.finished
-  # delay is 1 second, so retry up to async_seconds, meaning, wait for all
-  # async tasks to complete within the time given to each
-  retries: "{{ async_seconds }}"
-  delay: 1
-  register: delete_resources_job_result

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
@@ -3,7 +3,6 @@
 - name: Deploy hdfs resources
   include_tasks: deploy_resources.yml
   vars:
-    async_seconds: 120
     values_file: /tmp/metering-values.yaml
     resources:
       - template_file: templates/hdfs/hdfs-configmap.yaml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -3,7 +3,6 @@
 - name: Deploy hive resources
   include_tasks: deploy_resources.yml
   vars:
-    async_seconds: 120
     values_file: /tmp/metering-values.yaml
     resources:
       - template_file: templates/presto/hive-metastore-pvc.yaml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
@@ -3,7 +3,6 @@
 - name: Deploy metering resources
   include_tasks: deploy_resources.yml
   vars:
-    async_seconds: 120
     values_file: /tmp/metering-values.yaml
     resources:
       - template_file: templates/metering/metering-roles.yaml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
@@ -3,7 +3,6 @@
 - name: Deploy monitoring resources
   include_tasks: deploy_resources.yml
   vars:
-    async_seconds: 120
     values_file: /tmp/metering-values.yaml
     resources:
       - template_file: templates/monitoring/monitoring-rbac.yaml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
@@ -3,7 +3,6 @@
 - name: Deploy presto resources
   include_tasks: deploy_resources.yml
   vars:
-    async_seconds: 120
     values_file: /tmp/metering-values.yaml
     resources:
       - template_file: templates/presto/presto-aws-credentials-secret.yaml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
@@ -3,7 +3,6 @@
 - name: Deploy reporting resources
   include_tasks: deploy_resources.yml
   vars:
-    async_seconds: 120
     values_file: /tmp/metering-values.yaml
     resources:
       - template_file: templates/metering/default-storage-location.yaml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
@@ -3,7 +3,6 @@
 - name: Deploy reporting-operator resources
   include_tasks: deploy_resources.yml
   vars:
-    async_seconds: 120
     values_file: /tmp/metering-values.yaml
     resources:
       - template_file: templates/reporting-operator/reporting-operator-auth-proxy-authenticated-emails-secret.yaml


### PR DESCRIPTION
Previously we used async because we looped over each resource to create/delete which caused deploy times to take too long.
We don't need the async tasks anymore now that we submit multiple resources to created/deleted at the same time instead of looping individual resources.

Closes #744