### PR TITLE
charts: Set java HeapDumpPath and ErrorFile for JVM based components

### DIFF
--- a/charts/openshift-metering/templates/hdfs/hdfs-configmap.yaml
+++ b/charts/openshift-metering/templates/hdfs/hdfs-configmap.yaml
@@ -103,12 +103,12 @@ data:
         echo "Setting HADOOP_HEAPSIZE to ${HADOOP_HEAPSIZE}M"
     fi
 
+    export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"
     # Set garbage collection settings
-    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError"
+    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${HADOOP_LOG_DIR}/heap_dump.bin -XX:+ExitOnOutOfMemoryError -XX:ErrorFile=${HADOOP_LOG_DIR}/java_error%p.log"
     # Set JMX options
     export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
     # Set garbage collection logs
-    export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"
     export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
 
     # set name node options

--- a/charts/openshift-metering/templates/hdfs/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hdfs/hdfs-datanode-statefulset.yaml
@@ -170,6 +170,8 @@ spec:
         # required for openshift
         - name: namenode-empty
           mountPath: /hadoop/dfs/name
+        - name: hadoop-logs
+          mountPath: /opt/hadoop/logs
         livenessProbe:
           exec:
             command: ["/hadoop-config/check-datanode-healthy.sh" ]

--- a/charts/openshift-metering/templates/presto/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/hive-metastore-statefulset.yaml
@@ -97,6 +97,8 @@ spec:
           mountPath: /hadoop/dfs/name
         - name: datanode-empty
           mountPath: /hadoop/dfs/data
+        - name: hadoop-logs
+          mountPath: /opt/hadoop/logs
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
         - name: hive-warehouse-data
           mountPath: {{ .Values.presto.spec.config.sharedVolume.mountPath }}

--- a/charts/openshift-metering/templates/presto/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/presto/hive-scripts-configmap.yaml
@@ -59,12 +59,12 @@ data:
     ln -s -f /hive-config/hive-log4j2.properties $HIVE_HOME/conf/hive-log4j2.properties
     ln -s -f /hive-config/hive-exec-log4j2.properties $HIVE_HOME/conf/hive-exec-log4j2.properties
 
+    export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"
     # Set garbage collection settings
-    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError"
+    export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${HADOOP_LOG_DIR}/heap_dump.bin -XX:+ExitOnOutOfMemoryError -XX:ErrorFile=${HADOOP_LOG_DIR}/java_error%p.log"
     # Set JMX options
     export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
     # Set garbage collection logs
-    export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"
     export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
 
     export HIVE_LOGLEVEL="${HIVE_LOGLEVEL:-INFO}"

--- a/charts/openshift-metering/templates/presto/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/hive-server-statefulset.yaml
@@ -101,6 +101,8 @@ spec:
           mountPath: /hadoop/dfs/name
         - name: datanode-empty
           mountPath: /hadoop/dfs/data
+        - name: hadoop-logs
+          mountPath: /opt/hadoop/logs
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
         - name: hive-warehouse-data
           mountPath: {{ .Values.presto.spec.config.sharedVolume.mountPath }}

--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -79,7 +79,9 @@ data:
 {{- end }}
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/var/presto/logs/heap_dump.bin
     -XX:+ExitOnOutOfMemoryError
+    -XX:ErrorFile=/var/presto/logs/java_error%p.log
     -XX:ReservedCodeCacheSize=512M
     -Djdk.nio.maxCachedBufferSize=2000000
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -78,7 +78,9 @@ data:
 {{- end }}
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/var/presto/logs/heap_dump.bin
     -XX:+ExitOnOutOfMemoryError
+    -XX:ErrorFile=/var/presto/logs/java_error%p.log
     -XX:ReservedCodeCacheSize=512M
     -Djdk.nio.maxCachedBufferSize=2000000
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml


### PR DESCRIPTION
Ensures these files end up in an emptyDir so that we can inspect these
errors in case of an JVM OOM or other JVM fatal error.