### PR TITLE
Update the Presto and reporting-operator charts to handle a user providing client/server certificates that were signed by different CAs.

### DIFF
--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -8,7 +8,7 @@ data:
     set -e
 
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
-    cat $PRESTO_CLIENT_KEYFILE $PRESTO_CLIENT_CRTFILE > $PRESTO_TRUSTSTORE_PEM
+    cat $PRESTO_CLIENT_KEYFILE $PRESTO_CLIENT_CRTFILE $PRESTO_CLIENT_CA_CRTFILE > $PRESTO_TRUSTSTORE_PEM
 {{- end }}
 {{- if .Values.presto.spec.presto.config.tls.enabled }}
     # copy all necessary tls.crt/tls.key from read-only secret volumes - append server bundle and CA cert to truststore

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -71,6 +71,8 @@ spec:
           value: /presto-client/tls.key
         - name: PRESTO_CLIENT_CRTFILE
           value: /presto-client/tls.crt
+        - name: PRESTO_CLIENT_CA_CRTFILE
+          value: /presto-client/ca.crt
 {{- end }}
 {{- end }}
 {{- include "presto-common-env" . | indent 8 }}

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -71,6 +71,8 @@ spec:
           value: /presto-client/tls.key
         - name: PRESTO_CLIENT_CRTFILE
           value: /presto-client/tls.crt
+        - name: PRESTO_CLIENT_CA_CRTFILE
+          value: /presto-client/ca.crt
 {{- end }}
 {{- end }}
 {{- include "presto-common-env" . | indent 8 }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -20,6 +20,7 @@ data:
 {{- if $operatorValues.spec.config.prestoAuth.enabled }}
   presto-client-cert-file: "/var/run/secrets/presto-auth/tls.crt"
   presto-client-key-file: "/var/run/secrets/presto-auth/tls.key"
+  presto-client-ca-cert-file: "/var/run/secrets/presto-auth/ca.crt"
 {{- end }}
 {{- end }}
 {{- if $operatorValues.spec.config.prometheusMetricsImporterPollInterval }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -211,6 +211,11 @@ spec:
             configMapKeyRef:
               name: reporting-operator-config
               key: presto-client-key-file
+        - name: REPORTING_OPERATOR_PRESTO_CLIENT_CA_CERT_FILE
+          valueFrom:
+            configMapKeyRef:
+              name: reporting-operator-config
+              key: presto-client-ca-cert-file
 {{- else }}
         - name: REPORTING_OPERATOR_PRESTO_USE_AUTH
           value: "false"

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -83,6 +83,7 @@ func init() {
 	startCmd.Flags().StringVar(&cfg.PrestoCAFile, "presto-ca-file", "", "The path to the certificate authority to use to connect to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientCertFile, "presto-client-cert-file", "", "The path to the client certificate to use to connect to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientKeyFile, "presto-client-key-file", "", "The path to the client private key to use to connect to Presto.")
+	startCmd.Flags().StringVar(&cfg.PrestoClientCACertFile, "presto-client-ca-cert-file", "", "The path to the client certificate authority to use to connect to Presto.")
 
 	startCmd.Flags().StringVar(&cfg.PrometheusConfig.Address, "prometheus-host", defaultPromHost, "the URL string for connecting to Prometheus")
 	startCmd.Flags().BoolVar(&cfg.PrometheusConfig.SkipTLSVerify, "prometheus-skip-tls-verify", false, "Skip TLS verification")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -111,6 +111,7 @@ type Config struct {
 	PrestoCAFile            string
 	PrestoClientCertFile    string
 	PrestoClientKeyFile     string
+	PrestoClientCACertFile  string
 
 	PrestoMaxQueryLength int
 
@@ -466,9 +467,17 @@ func (op *Reporting) Run(ctx context.Context) error {
 				return fmt.Errorf("presto: Error loading SSL Client cert/key file: %v", err)
 			}
 
+			clientCACert, err := ioutil.ReadFile(op.cfg.PrestoClientCACertFile)
+			if err != nil {
+				return fmt.Errorf("presto: Error loading SSL Client CA Cert File: %v", err)
+			}
+
+			clientCAPool := x509.NewCertPool()
+			clientCAPool.AppendCertsFromPEM(clientCACert)
+
 			// mutate the necessary structure fields in prestoTLSConfig to work with client certificates
 			prestoTLSConfig.Certificates = []tls.Certificate{clientCert}
-			prestoTLSConfig.ClientCAs = rootCertPool
+			prestoTLSConfig.ClientCAs = clientCAPool
 			prestoTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 		}
 


### PR DESCRIPTION
Previously we used the passed the same CA to the `RootCAs` and `ClientCAs` field to the custom http client. This wouldn't work if the user provided client and server certificates that were signed by different certificate authorities.