### PR TITLE
Update Presto and reporting-operator resources to reflect changes made to values.yaml

### DIFF
--- a/charts/openshift-metering/templates/presto/presto-auth-secrets.yaml
+++ b/charts/openshift-metering/templates/presto/presto-auth-secrets.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.presto.spec.presto.config.auth.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.presto.spec.presto.config.auth.secretName }}
+  labels:
+    app: presto
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.presto.spec.presto.config.auth.certificate | b64enc | quote }}
+  tls.key: {{ .Values.presto.spec.presto.config.auth.key | b64enc | quote }}
+  ca.crt: {{.Values.presto.spec.presto.config.auth.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -167,11 +167,11 @@ spec:
         emptyDir: {}
       - name: presto-server-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.tls.serverCertificateSecretName }}
+          secretName: {{ .Values.presto.spec.presto.config.tls.secretName }}
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
       - name: presto-client-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.auth.clientCertificateSecretName }}
+          secretName: {{ .Values.presto.spec.presto.config.auth.secretName }}
 {{- end }}
 {{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}

--- a/charts/openshift-metering/templates/presto/presto-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/presto/presto-tls-secrets.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.presto.spec.presto.config.tls.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.presto.spec.presto.config.tls.secretName }}
+  labels:
+    app: presto
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.presto.spec.presto.config.tls.certificate | b64enc | quote }}
+  tls.key: {{ .Values.presto.spec.presto.config.tls.key | b64enc | quote }}
+  ca.crt: {{.Values.presto.spec.presto.config.tls.caCertificate | b64enc | quote }}
+{{- end -}}
+
+---
+
+{{- if .Values.presto.spec.presto.config.auth.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.presto.spec.presto.config.auth.secretName }}
+  labels:
+    app: presto
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.presto.spec.presto.config.auth.certificate | b64enc | quote }}
+  tls.key: {{ .Values.presto.spec.presto.config.auth.key | b64enc | quote }}
+  ca.crt: {{.Values.presto.spec.presto.config.auth.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/templates/presto/presto-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/presto/presto-tls-secrets.yaml
@@ -11,19 +11,3 @@ data:
   tls.key: {{ .Values.presto.spec.presto.config.tls.key | b64enc | quote }}
   ca.crt: {{.Values.presto.spec.presto.config.tls.caCertificate | b64enc | quote }}
 {{- end -}}
-
----
-
-{{- if .Values.presto.spec.presto.config.auth.createSecret -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.presto.spec.presto.config.auth.secretName }}
-  labels:
-    app: presto
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ .Values.presto.spec.presto.config.auth.certificate | b64enc | quote }}
-  tls.key: {{ .Values.presto.spec.presto.config.auth.key | b64enc | quote }}
-  ca.crt: {{.Values.presto.spec.presto.config.auth.caCertificate | b64enc | quote }}
-{{- end -}}

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -167,11 +167,11 @@ spec:
         emptyDir: {}
       - name: presto-server-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.tls.serverCertificateSecretName }}
+          secretName: {{ .Values.presto.spec.presto.config.tls.secretName }}
 {{- if .Values.presto.spec.presto.config.auth.enabled }}
       - name: presto-client-pem
         secret:
-          secretName: {{ .Values.presto.spec.presto.config.auth.clientCertificateSecretName }}
+          secretName: {{ .Values.presto.spec.presto.config.auth.secretName }}
 {{- end }}
 {{- end }}
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -16,7 +16,7 @@ data:
   disable-prometheus-metrics-importer: {{ $operatorValues.spec.config.disablePrometheusMetricsImporter | quote}}
   enable-finalizers: {{ $operatorValues.spec.config.enableFinalizers | quote}}
 {{- if $operatorValues.spec.config.prestoTLS.enabled }}
-  presto-ca-file: "/var/run/secrets/presto-tls/tls.crt"
+  presto-ca-file: "/var/run/secrets/presto-tls/ca.crt"
 {{- if $operatorValues.spec.config.prestoAuth.enabled }}
   presto-client-cert-file: "/var/run/secrets/presto-auth/tls.crt"
   presto-client-key-file: "/var/run/secrets/presto-auth/tls.key"

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -35,6 +35,9 @@ spec:
 {{- if and $operatorValues.spec.config.tls.enabled $operatorValues.spec.config.tls.createSecret }}
         reporting-operator-tls-secrets-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-tls-secrets.yaml") . | sha256sum }}
 {{- end }}
+{{- if and $operatorValues.spec.config.prestoTLS.enabled $operatorValues.spec.config.prestoTLS.createSecret }}
+        reporting-operator-presto-tls-secrets-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-presto-tls-secrets.yaml") . | sha256sum }}
+{{- end }}
 {{- if and $operatorValues.spec.authProxy.enabled $operatorValues.spec.authProxy.createCookieSecret }}
         reporting-operator-auth-proxy-cookie-secrets-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-auth-proxy-cookie-secret.yaml") . | sha256sum }}
 {{- end }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-auth-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-auth-secrets.yaml
@@ -1,0 +1,14 @@
+{{- $operatorValues :=  index .Values "reporting-operator" -}}
+{{- if $operatorValues.spec.config.prestoAuth.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $operatorValues.spec.config.prestoAuth.secretName }}
+  labels:
+    app: reporting-operator
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $operatorValues.spec.config.prestoAuth.certificate | b64enc | quote }}
+  tls.key: {{ $operatorValues.spec.config.prestoAuth.key | b64enc | quote }}
+  ca.crt: {{ $operatorValues.spec.config.prestoAuth.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-tls-secrets.yaml
@@ -6,23 +6,7 @@ metadata:
   name: {{ $operatorValues.spec.config.prestoTLS.secretName }}
   labels:
     app: reporting-operator
-type: generic
+type: Opaque
 data:
   ca.crt: {{ $operatorValues.spec.config.prestoTLS.caCertificate | b64enc | quote }}
-{{- end -}}
-
----
-
-{{- if $operatorValues.spec.config.prestoAuth.createSecret -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ $operatorValues.spec.config.prestoAuth.secretName }}
-  labels:
-    app: reporting-operator
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ $operatorValues.spec.config.prestoAuth.certificate | b64enc | quote }}
-  tls.key: {{ $operatorValues.spec.config.prestoAuth.key | b64enc | quote }}
-  ca.crt: {{ $operatorValues.spec.config.prestoAuth.caCertificate | b64enc | quote }}
 {{- end -}}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-tls-secrets.yaml
@@ -1,0 +1,28 @@
+{{- $operatorValues :=  index .Values "reporting-operator" -}}
+{{- if $operatorValues.spec.config.prestoTLS.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $operatorValues.spec.config.prestoTLS.secretName }}
+  labels:
+    app: reporting-operator
+type: generic
+data:
+  ca.crt: {{ $operatorValues.spec.config.prestoTLS.caCertificate | b64enc | quote }}
+{{- end -}}
+
+---
+
+{{- if $operatorValues.spec.config.prestoAuth.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $operatorValues.spec.config.prestoAuth.secretName }}
+  labels:
+    app: reporting-operator
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $operatorValues.spec.config.prestoAuth.certificate | b64enc | quote }}
+  tls.key: {{ $operatorValues.spec.config.prestoAuth.key | b64enc | quote }}
+  ca.crt: {{ $operatorValues.spec.config.prestoAuth.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -230,9 +230,21 @@ reporting-operator:
       prestoHost: presto:8080
       prestoMaxQueryLength: null
       prestoTLS:
+        # CA for the server cert
+        caCertificate: ""
+
+        createSecret: false
         enabled: false
         secretName: ""
       prestoAuth:
+        # client cert
+        certificate: ""
+        # client private key
+        key: ""
+        # CA for the client cert
+        caCertificate: ""
+
+        createSecret: false
         enabled: false
         secretName: ""
       prometheusCertificateAuthority:
@@ -425,11 +437,28 @@ presto:
       annotations: {}
       config:
         tls:
+          # server cert
+          certificate: ""
+          # server private key
+          key: ""
+          # CA for the server cert
+          caCertificate: ""
+
+          createSecret: false
           enabled: false
-          serverCertificateSecretName: ""
+          secretName: ""
+
         auth:
+          # client cert
+          certificate: ""
+          # client private key
+          key: ""
+          # CA for the client cert
+          caCertificate: ""
+
+          createSecret: false
           enabled: false
-          clientCertificateSecretName: ""
+          secretName: ""
         connectors:
           extraConnectorFiles: []
         environment: production

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -70,6 +70,8 @@ meteringconfig_create_hadoop_aws_credentials: "{{ _hadoop_spec.config.aws.create
 meteringconfig_create_hive_metastore_pvc: "{{ _presto_spec.hive.metastore.storage.create | default(true) }}"
 meteringconfig_create_presto_shared_volume_pvc: "{{ _presto_spec.config.sharedVolume.enabled and _presto_spec.config.sharedVolume.createPVC | default(false) }}"
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.createAwsCredentialsSecret | default(false) }}"
+meteringconfig_create_presto_tls_secrets: "{{ _presto_spec.presto.config.tls.enabled and _presto_spec.presto.config.tls.createSecret | default(false) }}"
+meteringconfig_create_presto_auth_secrets: "{{ _presto_spec.presto.config.auth.enabled and _presto_spec.presto.config.auth.createSecret | default(false) }}"
 
 meteringconfig_create_reporting_operator_auth_proxy_cookie_secret: "{{ _reporting_op_spec.authProxy.enabled and _reporting_op_spec.authProxy.createCookieSecret | default(true) }}"
 meteringconfig_create_reporting_operator_auth_proxy_htpasswd_secret: "{{ _reporting_op_spec.authProxy.enabled and _reporting_op_spec.authProxy.createHtpasswdSecret | default(true) }}"
@@ -78,6 +80,8 @@ meteringconfig_create_reporting_operator_auth_proxy_rbac: "{{ _reporting_op_spec
 meteringconfig_create_reporting_operator_prometheus_bearer_token: "{{ _reporting_op_spec.config.prometheusImporter.auth.tokenSecret.create | default(false) }}"
 meteringconfig_create_reporting_operator_prometheus_certificate_authority: "{{ _reporting_op_spec.config.prometheusCertificateAuthority.configMap.create | default(false) }}"
 meteringconfig_create_reporting_operator_aws_credentials: "{{ _reporting_op_spec.config.createAwsCredentialsSecret | default(false) }}"
+meteringconfig_create_reporting_operator_presto_tls_secrets: "{{ _reporting_op_spec.config.prestoTLS.enabled and _reporting_op_spec.config.prestoTLS.createSecret | default(false) }}"
+meteringconfig_create_reporting_operator_presto_auth_secrets: "{{ _reporting_op_spec.config.prestoAuth.enabled and _reporting_op_spec.config.prestoAuth.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_tls_secrets: "{{ _reporting_op_spec.config.tls.createSecret or _reporting_op_spec.config.metricsTLS.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_route: "{{ _reporting_op_spec.route.enabled | default(false) }}"
 meteringconfig_create_reporting_operator_cluster_monitoring_view_rbac: "{{ _reporting_op_spec.config.createClusterMonitoringViewRBAC | default(true) }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
@@ -9,6 +9,14 @@
         apis: [ {kind: secret} ]
         prune_label_value: presto-aws-credentials-secret
         create: "{{ meteringconfig_create_presto_aws_credentials }}"
+      - template_file: templates/presto/presto-tls-secrets.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: presto-tls-secrets
+        create: "{{ meteringconfig_create_presto_tls_secrets }}"
+      - template_file: templates/presto/presto-auth-secrets.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: presto-auth-secrets
+        create: "{{ meteringconfig_create_presto_auth_secrets }}"
       - template_file: templates/presto/presto-catalog-config-secret.yaml
         apis: [ {kind: secret} ]
         prune_label_value: presto-catalog-config-secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
@@ -53,6 +53,14 @@
         apis: [ {kind: secrets} ]
         prune_label_value: reporting-operator-tls-secrets
         create: "{{ meteringconfig_create_reporting_operator_tls_secrets }}"
+      - template_file: templates/reporting-operator/reporting-operator-presto-tls-secrets.yaml
+        apis: [ {kind: secrets} ]
+        prune_label_value: reporting-operator-presto-tls-secrets
+        create: "{{ meteringconfig_create_reporting_operator_presto_tls_secrets }}"
+      - template_file: templates/reporting-operator/reporting-operator-presto-auth-secrets.yaml
+        apis: [ {kind: secrets} ]
+        prune_label_value: reporting-operator-presto-auth-secrets
+        create: "{{ meteringconfig_create_reporting_operator_presto_auth_secrets }}"
       - template_file: templates/reporting-operator/reporting-operator-route.yaml
         apis: [ {kind: route, api_version: 'route.openshift.io/v1'} ]
         prune_label_value: reporting-operator-route


### PR DESCRIPTION
This would update the Presto TLS/auth fields in the helm templating default values that the `MeteringConfig`. 

In the initial state of this PR, a user can specify a secret by populating the `secretName` field in the appropriate tls/auth fields. What's not fully implemented is if a user wants to provide PEM files containing a certificate, key, and certificate authority (when applicable). **Edit**: this has now been implemented.