### PR TITLE
charts: Replace scripted jvm max heap configuration with built-in JVM container support

### DIFF
--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -7,38 +7,32 @@ data:
     #!/bin/bash
     set -e
 
-    max_memory() {
-        local memory_limit=$1
-        local ratio=${JAVA_MAX_MEM_RATIO:-50}
-        echo "${memory_limit} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}'
-    }
-
-    # Check for container memory limits/request and use it to set JVM Heap size.
-    # Defaults to 50% of the limit/request value.
-    if [ -n "$MY_MEM_LIMIT" ]; then
-        export HADOOP_HEAPSIZE="$( max_memory $MY_MEM_LIMIT )"
-    elif [ -n "$MY_MEM_REQUEST" ]; then
-        export HADOOP_HEAPSIZE="$( max_memory $MY_MEM_REQUEST )"
-    fi
-
-    if [ -z "$HADOOP_HEAPSIZE" ]; then
-        echo "Unable to automatically set HADOOP_HEAPSIZE"
-    else
-        echo "Setting HADOOP_HEAPSIZE to ${HADOOP_HEAPSIZE}M"
-    fi
-
     export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"
     # Set garbage collection settings
     export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${HADOOP_LOG_DIR}/heap_dump.bin -XX:+ExitOnOutOfMemoryError -XX:ErrorFile=${HADOOP_LOG_DIR}/java_error%p.log"
+
+    export VM_OPTIONS="$VM_OPTIONS -XX:+UseContainerSupport"
+
+    if [ -n "$JVM_INITIAL_RAM_PERCENTAGE" ]; then
+      VM_OPTIONS="$VM_OPTIONS -XX:InitialRAMPercentage=$JVM_INITIAL_RAM_PERCENTAGE"
+    fi
+    if [ -n "$JVM_MAX_RAM_PERCENTAGE" ]; then
+      VM_OPTIONS="$VM_OPTIONS -XX:MaxRAMPercentage=$JVM_MAX_RAM_PERCENTAGE"
+    fi
+
+    if [ -n "$JVM_MIN_RAM_PERCENTAGE" ]; then
+      VM_OPTIONS="$VM_OPTIONS -XX:MinRAMPercentage=$JVM_MIN_RAM_PERCENTAGE"
+    fi
+
     # Set JMX options
     export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
     # Set garbage collection logs
     export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
 
     # set name node options
-    export HDFS_NAMENODE_OPTS="${HDFS_NAMENODE_OPTS} -Dhadoop.security.logger=INFO,RFAS ${GC_SETTINGS} ${JMX_OPTIONS}"
+    export HDFS_NAMENODE_OPTS="${HDFS_NAMENODE_OPTS} -Dhadoop.security.logger=INFO,RFAS ${VM_OPTIONS} ${GC_SETTINGS} ${JMX_OPTIONS}"
     # set datanode options
-    export HDFS_DATANODE_OPTS="${HDFS_DATANODE_OPTS} -Dhadoop.security.logger=ERROR,RFAS ${GC_SETTINGS} ${JMX_OPTIONS}"
+    export HDFS_DATANODE_OPTS="${HDFS_DATANODE_OPTS} -Dhadoop.security.logger=ERROR,RFAS ${VM_OPTIONS} ${GC_SETTINGS} ${JMX_OPTIONS}"
 
     # add UID to /etc/passwd if missing
     if ! whoami &> /dev/null; then

--- a/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
@@ -160,8 +160,18 @@ spec:
             resourceFieldRef:
               containerName: hdfs-datanode
               resource: limits.memory
-        - name: JAVA_MAX_MEM_RATIO
-          value: "50"
+{{- if .Values.hadoop.spec.hdfs.datanode.config.jvm.initialRAMPercentage }}
+        - name: JVM_INITIAL_RAM_PERCENTAGE
+          value: {{ .Values.hadoop.spec.hdfs.datanode.config.jvm.initialRAMPercentage }}"
+{{- end }}
+{{- if .Values.hadoop.spec.hdfs.datanode.config.jvm.maxRAMPercentage }}
+        - name: JVM_MAX_RAM_PERCENTAGE
+          value: {{ .Values.hadoop.spec.hdfs.datanode.config.jvm.maxRAMPercentage }}"
+{{- end }}
+{{- if .Values.hadoop.spec.hdfs.datanode.config.jvm.maxRAMPercentage }}
+        - name: JVM_MIN_RAM_PERCENTAGE
+          value: {{ .Values.hadoop.spec.hdfs.datanode.config.jvm.minRAMPercentage }}"
+{{- end }}
         ports:
         - containerPort: 9864
           name: http

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -149,8 +149,18 @@ spec:
             resourceFieldRef:
               containerName: hdfs-namenode
               resource: limits.memory
-        - name: JAVA_MAX_MEM_RATIO
-          value: "50"
+{{- if .Values.hadoop.spec.hdfs.namenode.config.jvm.initialRAMPercentage }}
+        - name: JVM_INITIAL_RAM_PERCENTAGE
+          value: {{ .Values.hadoop.spec.hdfs.namenode.config.jvm.initialRAMPercentage }}"
+{{- end }}
+{{- if .Values.hadoop.spec.hdfs.namenode.config.jvm.maxRAMPercentage }}
+        - name: JVM_MAX_RAM_PERCENTAGE
+          value: {{ .Values.hadoop.spec.hdfs.namenode.config.jvm.maxRAMPercentage }}"
+{{- end }}
+{{- if .Values.hadoop.spec.hdfs.namenode.config.jvm.maxRAMPercentage }}
+        - name: JVM_MIN_RAM_PERCENTAGE
+          value: {{ .Values.hadoop.spec.hdfs.namenode.config.jvm.minRAMPercentage }}"
+{{- end }}
         ports:
         - containerPort: 9820
           name: fs

--- a/charts/openshift-metering/templates/presto/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/hive-metastore-statefulset.yaml
@@ -68,8 +68,18 @@ spec:
         env:
         - name: HIVE_LOGLEVEL
           value: {{ upper .Values.presto.spec.hive.metastore.config.logLevel | quote}}
-        - name: JAVA_MAX_MEM_RATIO
-          value: "{{ .Values.presto.spec.hive.metastore.config.jvm.percentMemoryLimitAsHeap }}"
+{{- if .Values.presto.spec.hive.metastore.config.jvm.initialRAMPercentage }}
+        - name: JVM_INITIAL_RAM_PERCENTAGE
+          value: {{ .Values.presto.spec.hive.metastore.config.jvm.initialRAMPercentage }}"
+{{- end }}
+{{- if .Values.presto.spec.hive.metastore.config.jvm.maxRAMPercentage }}
+        - name: JVM_MAX_RAM_PERCENTAGE
+          value: {{ .Values.presto.spec.hive.metastore.config.jvm.maxRAMPercentage }}"
+{{- end }}
+{{- if .Values.presto.spec.hive.metastore.config.jvm.maxRAMPercentage }}
+        - name: JVM_MIN_RAM_PERCENTAGE
+          value: {{ .Values.presto.spec.hive.metastore.config.jvm.minRAMPercentage }}"
+{{- end }}
 {{ include "hive-env" . | indent 8 }}
         - name: MY_MEM_REQUEST
           valueFrom:

--- a/charts/openshift-metering/templates/presto/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/presto/hive-scripts-configmap.yaml
@@ -7,26 +7,6 @@ data:
     #!/bin/bash
     set -e
 
-    max_memory() {
-        local memory_limit=$1
-        local ratio=${JAVA_MAX_MEM_RATIO:-50}
-        echo "${memory_limit} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}'
-    }
-
-    # Check for container memory limits/request and use it to set JVM Heap size.
-    # Defaults to 50% of the limit/request value.
-    if [ -n "$MY_MEM_LIMIT" ]; then
-        export HADOOP_HEAPSIZE="$( max_memory $MY_MEM_LIMIT )"
-    elif [ -n "$MY_MEM_REQUEST" ]; then
-        export HADOOP_HEAPSIZE="$( max_memory $MY_MEM_REQUEST )"
-    fi
-
-    if [ -z "$HADOOP_HEAPSIZE" ]; then
-        echo "Unable to automatically set HADOOP_HEAPSIZE"
-    else
-        echo "Setting HADOOP_HEAPSIZE to ${HADOOP_HEAPSIZE}M"
-    fi
-
     # add UID to /etc/passwd if missing
     if ! whoami &> /dev/null; then
         if [ -w /etc/passwd ]; then
@@ -55,6 +35,7 @@ data:
     else
       echo "/hadoop-config/hdfs-site.xml doesnt exist, skipping symlink"
     fi
+
     ln -s -f /hive-config/hive-site.xml $HIVE_HOME/conf/hive-site.xml
     ln -s -f /hive-config/hive-log4j2.properties $HIVE_HOME/conf/hive-log4j2.properties
     ln -s -f /hive-config/hive-exec-log4j2.properties $HIVE_HOME/conf/hive-exec-log4j2.properties
@@ -62,13 +43,26 @@ data:
     export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"
     # Set garbage collection settings
     export GC_SETTINGS="-XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${HADOOP_LOG_DIR}/heap_dump.bin -XX:+ExitOnOutOfMemoryError -XX:ErrorFile=${HADOOP_LOG_DIR}/java_error%p.log"
+
+    export VM_OPTIONS="$VM_OPTIONS -XX:+UseContainerSupport"
+
+    if [ -n "$JVM_INITIAL_RAM_PERCENTAGE" ]; then
+      VM_OPTIONS="$VM_OPTIONS -XX:InitialRAMPercentage=$JVM_INITIAL_RAM_PERCENTAGE"
+    fi
+    if [ -n "$JVM_MAX_RAM_PERCENTAGE" ]; then
+      VM_OPTIONS="$VM_OPTIONS -XX:MaxRAMPercentage=$JVM_MAX_RAM_PERCENTAGE"
+    fi
+    if [ -n "$JVM_MIN_RAM_PERCENTAGE" ]; then
+      VM_OPTIONS="$VM_OPTIONS -XX:MinRAMPercentage=$JVM_MIN_RAM_PERCENTAGE"
+    fi
+
     # Set JMX options
     export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
     # Set garbage collection logs
     export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
 
     export HIVE_LOGLEVEL="${HIVE_LOGLEVEL:-INFO}"
-    export HADOOP_OPTS="${HADOOP_OPTS} ${GC_SETTINGS} ${JMX_OPTIONS}"
+    export HADOOP_OPTS="${HADOOP_OPTS} ${VM_OPTIONS} ${GC_SETTINGS} ${JMX_OPTIONS}"
     export HIVE_METASTORE_HADOOP_OPTS=" -Dhive.log.level=${HIVE_LOGLEVEL} "
     export HIVE_OPTS="${HIVE_OPTS} --hiveconf hive.root.logger=${HIVE_LOGLEVEL},console "
 

--- a/charts/openshift-metering/templates/presto/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/hive-server-statefulset.yaml
@@ -72,8 +72,18 @@ spec:
         env:
         - name: HIVE_LOGLEVEL
           value: {{ upper .Values.presto.spec.hive.server.config.logLevel | quote}}
-        - name: JAVA_MAX_MEM_RATIO
-          value: "{{ .Values.presto.spec.hive.server.config.percentMemoryLimitAsHeap }}"
+{{- if .Values.presto.spec.hive.server.config.jvm.initialRAMPercentage }}
+        - name: JVM_INITIAL_RAM_PERCENTAGE
+          value: {{ .Values.presto.spec.hive.server.config.jvm.initialRAMPercentage }}"
+{{- end }}
+{{- if .Values.presto.spec.hive.server.config.jvm.maxRAMPercentage }}
+        - name: JVM_MAX_RAM_PERCENTAGE
+          value: {{ .Values.presto.spec.hive.server.config.jvm.maxRAMPercentage }}"
+{{- end }}
+{{- if .Values.presto.spec.hive.server.config.jvm.maxRAMPercentage }}
+        - name: JVM_MIN_RAM_PERCENTAGE
+          value: {{ .Values.presto.spec.hive.server.config.jvm.minRAMPercentage }}"
+{{- end }}
 {{ include "hive-env" . | indent 8 }}
         - name: MY_MEM_REQUEST
           valueFrom:

--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -22,50 +22,6 @@ data:
     #!/bin/bash
     set -e
 
-    max_memory() {
-        local memory_limit=$1
-        local ratio=${JAVA_MAX_MEM_RATIO:-50}
-        echo "${memory_limit} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}'
-    }
-
-    # Check for container memory limits/request and use it to set JVM Heap size.
-    # Defaults to 50% of the limit/request value.
-    if [ -n "$MY_MEM_LIMIT" ]; then
-        export MAX_HEAPSIZE="$( max_memory $MY_MEM_LIMIT )"
-    elif [ -n "$MY_MEM_REQUEST" ]; then
-        export MAX_HEAPSIZE="$( max_memory $MY_MEM_REQUEST )"
-    fi
-
-    if [ -z "$MAX_HEAPSIZE" ]; then
-        echo "Unable to automatically set Presto JVM Max Heap Size based on pod request/limits"
-        export MAX_HEAPSIZE=1024
-        echo "Setting Presto JVM Max Heap Size to ${MAX_HEAPSIZE}M"
-    else
-        echo "Setting Presto JVM Max Heap Size to ${MAX_HEAPSIZE}M"
-    fi
-
-    # set min to max to avoid pauses caused by heap expansion
-    export MIN_HEAPSIZE="$MAX_HEAPSIZE"
-
-    JVM_CONFIG="${PRESTO_HOME}/etc/jvm.config"
-    # ensure there's a newline between the last item in the config and what we add
-    echo "" >> $JVM_CONFIG
-    if [ -n "$MAX_HEAPSIZE" ]; then
-      # add heapsize to jvm config if not already
-      if ! grep -q -F 'Xmx' "$JVM_CONFIG"; then
-        FLAG="-Xmx${MAX_HEAPSIZE}M"
-        echo "Adding $FLAG to $JVM_CONFIG"
-        echo "$FLAG" >> "$JVM_CONFIG"
-      fi
-    fi
-    if [ -n "$MIN_HEAPSIZE" ]; then
-      if ! grep -q -F 'Xms' "$JVM_CONFIG"; then
-        FLAG="-Xms${MIN_HEAPSIZE}M"
-        echo "Adding $FLAG to $JVM_CONFIG"
-        echo "$FLAG" >> "$JVM_CONFIG"
-      fi
-    fi
-
     # add node id to node config
     NODE_CONFIG="${PRESTO_HOME}/etc/node.properties"
     # ensure there's a newline between the last item in the config and what we add

--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -54,6 +54,7 @@ data:
 
   jvm.config: |
     -server
+    -XX:+UseContainerSupport
     -XX:+UseG1GC
     -XX:+UseGCOverheadLimit
 {{- if .Values.presto.spec.presto.coordinator.config.jvm.G1HeapRegionSize }}
@@ -74,6 +75,24 @@ data:
 {{- if .Values.presto.spec.presto.coordinator.config.jvm.initiatingHeapOccupancyPercent }}
     -XX:InitiatingHeapOccupancyPercent={{ .Values.presto.spec.presto.coordinator.config.jvm.initiatingHeapOccupancyPercent }}
 {{- end }}
+{{- if .Values.presto.spec.presto.coordinator.config.jvm.initialRAMPercentage }}
+    -XX:InitialRAMPercentage={{ .Values.presto.spec.presto.coordinator.config.jvm.initialRAMPercentage }}
+{{- end }}
+{{- if .Values.presto.spec.presto.coordinator.config.jvm.maxRAMPercentage }}
+    -XX:MaxRAMPercentage={{ .Values.presto.spec.presto.coordinator.config.jvm.maxRAMPercentage }}
+{{- end }}
+{{- if .Values.presto.spec.presto.coordinator.config.jvm.minRAMPercentage }}
+    -XX:MinRAMPercentage={{ .Values.presto.spec.presto.coordinator.config.jvm.minRAMPercentage }}
+{{- end }}
+{{- if .Values.presto.spec.presto.coordinator.config.jvm.reservedCodeCacheSize }}
+    -XX:ReservedCodeCacheSize={{ .Values.presto.spec.presto.coordinator.config.jvm.reservedCodeCacheSize }}
+{{- end }}
+{{- if .Values.presto.spec.presto.coordinator.config.jvm.maxCachedBufferSize }}
+    -Djdk.nio.maxCachedBufferSize={{ .Values.presto.spec.presto.coordinator.config.jvm.maxCachedBufferSize }}
+{{- end }}
+{{- if .Values.presto.spec.presto.coordinator.config.jvm.maxDirectMemorySize }}
+    -XX:MaxDirectMemorySize={{ .Values.presto.spec.presto.coordinator.config.jvm.maxDirectMemorySize  }}
+{{- end }}
 {{- range .Values.presto.spec.presto.coordinator.config.jvm.extraFlags }}
     {{ . }}
 {{- end }}
@@ -82,8 +101,11 @@ data:
     -XX:HeapDumpPath=/var/presto/logs/heap_dump.bin
     -XX:+ExitOnOutOfMemoryError
     -XX:ErrorFile=/var/presto/logs/java_error%p.log
-    -XX:ReservedCodeCacheSize=512M
-    -Djdk.nio.maxCachedBufferSize=2000000
+    -verbose:gc
+    -XX:+PrintGCDetails
+    -XX:+PrintGCTimeStamps
+    -XX:+PrintGCDateStamps
+    -Xloggc:/var/presto/logs/gc.log
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
     -Dcom.sun.management.jmxremote
     -Dcom.sun.management.jmxremote.local.only=false
@@ -92,8 +114,3 @@ data:
     -Dcom.sun.management.jmxremote.port=8081
     -Dcom.sun.management.jmxremote.rmi.port=8081
     -Djava.rmi.server.hostname=127.0.0.1
-    -verbose:gc
-    -XX:+PrintGCDetails
-    -XX:+PrintGCTimeStamps
-    -XX:+PrintGCDateStamps
-    -Xloggc:/var/presto/logs/gc.log

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -111,8 +111,6 @@ spec:
         command: ['/presto-common/entrypoint.sh']
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
         env:
-        - name: JAVA_MAX_MEM_RATIO
-          value: "{{ .Values.presto.spec.presto.coordinator.config.jvm.percentMemoryLimitAsHeap }}"
 {{- include "presto-common-env" . | indent 8 }}
         ports:
         - name: http

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -53,6 +53,7 @@ data:
 
   jvm.config: |
     -server
+    -XX:+UseContainerSupport
     -XX:+UseG1GC
     -XX:+UseGCOverheadLimit
 {{- if .Values.presto.spec.presto.worker.config.jvm.G1HeapRegionSize }}
@@ -73,6 +74,24 @@ data:
 {{- if .Values.presto.spec.presto.worker.config.jvm.initiatingHeapOccupancyPercent }}
     -XX:InitiatingHeapOccupancyPercent={{ .Values.presto.spec.presto.worker.config.jvm.initiatingHeapOccupancyPercent }}
 {{- end }}
+{{- if .Values.presto.spec.presto.worker.config.jvm.initialRAMPercentage }}
+    -XX:InitialRAMPercentage={{ .Values.presto.spec.presto.worker.config.jvm.initialRAMPercentage }}
+{{- end }}
+{{- if .Values.presto.spec.presto.worker.config.jvm.maxRAMPercentage }}
+    -XX:MaxRAMPercentage={{ .Values.presto.spec.presto.worker.config.jvm.maxRAMPercentage }}
+{{- end }}
+{{- if .Values.presto.spec.presto.worker.config.jvm.minRAMPercentage }}
+    -XX:MinRAMPercentage={{ .Values.presto.spec.presto.worker.config.jvm.minRAMPercentage }}
+{{- end }}
+{{- if .Values.presto.spec.presto.worker.config.jvm.reservedCodeCacheSize }}
+    -XX:ReservedCodeCacheSize={{ .Values.presto.spec.presto.worker.config.jvm.reservedCodeCacheSize }}
+{{- end }}
+{{- if .Values.presto.spec.presto.worker.config.jvm.maxCachedBufferSize }}
+    -Djdk.nio.maxCachedBufferSize={{ .Values.presto.spec.presto.worker.config.jvm.maxCachedBufferSize }}
+{{- end }}
+{{- if .Values.presto.spec.presto.worker.config.jvm.maxDirectMemorySize }}
+    -XX:MaxDirectMemorySize={{ .Values.presto.spec.presto.worker.config.jvm.maxDirectMemorySize  }}
+{{- end }}
 {{- range .Values.presto.spec.presto.worker.config.jvm.extraFlags }}
     {{ . }}
 {{- end }}
@@ -81,8 +100,11 @@ data:
     -XX:HeapDumpPath=/var/presto/logs/heap_dump.bin
     -XX:+ExitOnOutOfMemoryError
     -XX:ErrorFile=/var/presto/logs/java_error%p.log
-    -XX:ReservedCodeCacheSize=512M
-    -Djdk.nio.maxCachedBufferSize=2000000
+    -verbose:gc
+    -XX:+PrintGCDetails
+    -XX:+PrintGCTimeStamps
+    -XX:+PrintGCDateStamps
+    -Xloggc:/var/presto/logs/gc.log
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
     -Dcom.sun.management.jmxremote
     -Dcom.sun.management.jmxremote.local.only=false
@@ -91,8 +113,3 @@ data:
     -Dcom.sun.management.jmxremote.port=8081
     -Dcom.sun.management.jmxremote.rmi.port=8081
     -Djava.rmi.server.hostname=127.0.0.1
-    -verbose:gc
-    -XX:+PrintGCDetails
-    -XX:+PrintGCTimeStamps
-    -XX:+PrintGCDateStamps
-    -Xloggc:/var/presto/logs/gc.log

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -111,8 +111,6 @@ spec:
         command: ['/presto-common/entrypoint.sh']
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
         env:
-        - name: JAVA_MAX_MEM_RATIO
-          value: "{{ .Values.presto.spec.presto.worker.config.jvm.percentMemoryLimitAsHeap }}"
 {{- include "presto-common-env" . | indent 8 }}
         ports:
         - name: http

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -367,7 +367,9 @@ presto:
         affinity: {}
         config:
           jvm:
-            percentMemoryLimitAsHeap: "50"
+            initialRAMPercentage: null
+            maxRAMPercentage: null
+            minRAMPercentage: null
           logLevel: info
         livenessProbe:
           failureThreshold: 3
@@ -405,7 +407,9 @@ presto:
         affinity: {}
         config:
           jvm:
-            percentMemoryLimitAsHeap: "50"
+            initialRAMPercentage: null
+            maxRAMPercentage: null
+            minRAMPercentage: null
           logLevel: info
         livenessProbe:
           failureThreshold: 3
@@ -483,10 +487,18 @@ presto:
             concGCThreads: null
             extraFlags: []
             initiatingHeapOccupancyPercent: null
-            maxGcPauseMillis: 200
+            maxGcPauseMillis: null
             parallelGCThreads: null
-            percentMemoryLimitAsHeap: "50"
+            initialRAMPercentage: "50.0"
+            maxRAMPercentage: "50.0"
+            minRAMPercentage: null
             permSize: null
+            reservedCodeCacheSize: null
+            maxCachedBufferSize: null
+            maxDirectMemorySize: null
+          logLevel: info
+          taskMaxWorkerThreads: null
+          taskMinDrivers: null
           logLevel: info
           taskMaxWorkerThreads: null
           taskMinDrivers: null
@@ -509,6 +521,7 @@ presto:
         fsGroup: null
         runAsNonRoot: true
       worker:
+        replicas: 0
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -527,13 +540,17 @@ presto:
             initiatingHeapOccupancyPercent: null
             maxGcPauseMillis: null
             parallelGCThreads: null
-            percentMemoryLimitAsHeap: "50"
+            initialRAMPercentage: "50.0"
+            maxRAMPercentage: "50.0"
+            minRAMPercentage: null
             permSize: null
+            reservedCodeCacheSize: null
+            maxCachedBufferSize: null
+            maxDirectMemorySize: null
           logLevel: info
           taskMaxWorkerThreads: null
           taskMinDrivers: null
         nodeSelector: {}
-        replicas: 0
         resources:
           limits:
             cpu: "2"
@@ -578,6 +595,12 @@ hadoop:
         terminationGracePeriodSeconds: 30
         replicas: 1
 
+        config:
+          jvm:
+            initialRAMPercentage: null
+            maxRAMPercentage: null
+            minRAMPercentage: null
+
         resources:
           limits:
             cpu: 250m
@@ -606,6 +629,12 @@ hadoop:
         nodeSelector: {}
         terminationGracePeriodSeconds: 30
         tolerations: []
+
+        config:
+          jvm:
+            initialRAMPercentage: null
+            maxRAMPercentage: null
+            minRAMPercentage: null
 
         resources:
           limits:


### PR DESCRIPTION
Uses the native container support built into the JVM instead of hackily setting env vars and JVM properties for adjusting these values.

Previously this functionality was only available in Java 9 or later, but it was recently backported to Java 8. Read more at https://blog.softwaremill.com/docker-support-in-new-java-8-finally-fd595df0ca54.