### PR TITLE
pkg/operator: Never stop re queuing StorageLocations

### DIFF
--- a/pkg/operator/queues.go
+++ b/pkg/operator/queues.go
@@ -446,7 +446,7 @@ func (op *Reporting) handleErr(logger log.FieldLogger, err error, objType string
 
 	// This controller retries up to maxRequeues times if something goes wrong.
 	// After that, it stops trying.
-	if queue.NumRequeues(obj) < maxRequeues {
+	if maxRequeues == -1 || queue.NumRequeues(obj) < maxRequeues {
 		logger.WithError(err).Errorf("error syncing %s %q, adding back to queue", objType, obj)
 		queue.AddRateLimited(obj)
 		return

--- a/pkg/operator/storagelocations.go
+++ b/pkg/operator/storagelocations.go
@@ -22,26 +22,9 @@ const (
 func (op *Reporting) runStorageLocationWorker() {
 	logger := op.logger.WithField("component", "storageLocationWorker")
 	logger.Infof("StorageLocation worker started")
-	const maxRequeues = 10
+	const maxRequeues = -1
 	for op.processResource(logger, op.syncStorageLocation, "StorageLocation", op.storageLocationQueue, maxRequeues) {
 	}
-}
-
-func (op *Reporting) processStorageLocation(logger log.FieldLogger) bool {
-	obj, quit := op.storageLocationQueue.Get()
-	if quit {
-		logger.Infof("queue is shutting down, exiting StorageLocation worker")
-		return false
-	}
-	defer op.storageLocationQueue.Done(obj)
-
-	logger = logger.WithFields(newLogIdentifier(op.rand))
-	if key, ok := op.getKeyFromQueueObj(logger, "StorageLocation", obj, op.storageLocationQueue); ok {
-		err := op.syncStorageLocation(logger, key)
-		const maxRequeues = 10
-		op.handleErr(logger, err, "StorageLocation", key, op.storageLocationQueue, maxRequeues)
-	}
-	return true
 }
 
 func (op *Reporting) syncStorageLocation(logger log.FieldLogger, key string) error {


### PR DESCRIPTION
I noticed sometimes with the new setup that the reporting-operator stops processing storageLocations because hive-server/hive-metastore isn't reachable when reporting-operator starts, and it errors enough times to stop processing storageLocations. This fixes that by requeuing storageLocation resources forever. These are fairly important and if they don't get processed the reporting-operator is effectively stuck until restarted.