### PR TITLE
Monitor JMX metrics from Hadoop, Hive and Presto

### DIFF
--- a/charts/metering-ci/templates/metering.yaml
+++ b/charts/metering-ci/templates/metering.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ .Values.deployPlatform }}-metering"
 spec:
   monitoring:
-    enabled: false
+    enabled: true
 
   openshift-reporting:
     spec:

--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -27,7 +27,8 @@ data:
     # Set JMX options
     export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
     # Set garbage collection logs
-    export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
+    GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
+    GC_SETTINGS="${GC_SETTINGS} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M"
 
     # set name node options
     export HDFS_NAMENODE_OPTS="${HDFS_NAMENODE_OPTS} -Dhadoop.security.logger=INFO,RFAS ${VM_OPTIONS} ${GC_SETTINGS} ${JMX_OPTIONS}"

--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -25,7 +25,8 @@ data:
     fi
 
     # Set JMX options
-    export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
+    export JMX_OPTIONS="-javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8081 -Dcom.sun.management.jmxremote.rmi.port=8081 -Djava.rmi.server.hostname=127.0.0.1"
+
     # Set garbage collection logs
     GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
     GC_SETTINGS="${GC_SETTINGS} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M"

--- a/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
@@ -4,31 +4,43 @@ kind: Service
 metadata:
   name: hdfs-datanode
   labels:
-    app: hdfs-datanode
+    app: hdfs
     hdfs: datanode
+    component: hdfs-datanode
 spec:
   ports:
   - port: 9866
     name: fs
+  - port: 9864
+    name: web
+  - port: 9867
+    name: ipc
+  - port: 8082
+    name: metrics
   clusterIP: None
   selector:
-    app: hdfs-datanode
+    app: hdfs
+    hdfs: datanode
+
 ---
-# A headless service for the web interface.
+
+# A clusterIP service for the web interface.
 apiVersion: v1
 kind: Service
 metadata:
   name: hdfs-datanode-web
   labels:
-    app: hdfs-datanode
+    app: hdfs
     hdfs: datanode
+    component: hdfs-datanode
 spec:
   ports:
   - port: 9864
     name: web
   selector:
-    app: hdfs-datanode
+    app: hdfs
     hdfs: datanode
+
 ---
 
 apiVersion: apps/v1
@@ -36,7 +48,7 @@ kind: StatefulSet
 metadata:
   name: hdfs-datanode
   labels:
-    app: hdfs-datanode
+    app: hdfs
     hdfs: datanode
 spec:
   serviceName: "hdfs-datanode"
@@ -45,7 +57,7 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: hdfs-datanode
+      app: hdfs
       hdfs: datanode
 {{- if .Values.hadoop.spec.hdfs.datanode.labels }}
 {{ toYaml .Values.hadoop.spec.hdfs.datanode.labels | indent 6 }}
@@ -53,7 +65,7 @@ spec:
   template:
     metadata:
       labels:
-        app: hdfs-datanode
+        app: hdfs
         hdfs: datanode
 {{- if .Values.hadoop.spec.hdfs.datanode.labels }}
 {{ toYaml .Values.hadoop.spec.hdfs.datanode.labels | indent 8 }}
@@ -61,6 +73,7 @@ spec:
       annotations:
         hadoop-config-hash: {{ include (print $.Template.BasePath "/hadoop/hadoop-configmap.yaml") . | sha256sum }}
         hadoop-scripts-hash: {{ include (print $.Template.BasePath "/hadoop/hadoop-scripts.yaml") . | sha256sum }}
+        hdfs-jmx-config-hash: {{ include (print $.Template.BasePath "/hadoop/hdfs-jmx-config.yaml") . | sha256sum }}
 {{- if .Values.hadoop.spec.config.aws.createCredentialsSecret }}
         hadoop-aws-credentials-hash: {{ include (print $.Template.BasePath "/hadoop/hadoop-aws-credentials.yaml") . | sha256sum }}
 {{- end }}
@@ -179,11 +192,15 @@ spec:
           name: fs
         - containerPort: 9867
           name: ipc
+        - containerPort: 8082
+          name: metrics
         volumeMounts:
         - name: hadoop-config
           mountPath: /hadoop-config
         - name: hadoop-scripts
           mountPath: /hadoop-scripts
+        - name: hdfs-jmx-config
+          mountPath: /opt/jmx_exporter/config
         - name: hdfs-datanode-data
           mountPath: /hadoop/dfs/data
           # we use a subPath to avoid the lost+found directory at the root of
@@ -217,6 +234,9 @@ spec:
         configMap:
           name: hadoop-scripts
           defaultMode: 0555
+      - name: hdfs-jmx-config
+        configMap:
+          name: hdfs-jmx-config
       - name: namenode-empty
         emptyDir: {}
       - name: hadoop-logs
@@ -225,7 +245,7 @@ spec:
   - metadata:
       name: "hdfs-datanode-data"
       labels:
-        app: hdfs-datanode
+        app: hdfs
         hdfs: datanode
     spec:
       accessModes: ["ReadWriteOnce"]

--- a/charts/openshift-metering/templates/hadoop/hdfs-jmx-config.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-jmx-config.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hdfs-jmx-config
+  labels:
+    app: hdfs
+data:
+  config.yml: |
+    ---
+    startDelaySeconds: 0
+    ssl: false
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    whitelistObjectNames:
+      - 'Hadoop:service=DataNode,name=*'
+      - 'Hadoop:service=NameNode,name=*'
+      - 'Hadoop:service=NameNode,name=MetricsSystem,sub=*'
+      - 'Hadoop:service=DataNode,name=MetricsSystem,sub=*'
+    blacklistObjectNames:
+      - 'Hadoop:service=DataNode,name=RpcActivity*'
+      - 'Hadoop:service=DataNode,name=RpcDetailedActivity*'
+      - 'Hadoop:service=DataNode,name=UgiMetrics'
+      - 'Hadoop:service=NameNode,name=RetryCache.NameNodeRetryCache'
+      - 'Hadoop:service=NameNode,name=RpcActivity*'
+      - 'Hadoop:service=NameNode,name=RpcDetailedActivity*'
+      - 'Hadoop:service=NameNode,name=UgiMetrics'
+    rules:
+      # MetricsSystem
+      - pattern: 'Hadoop<service=(.*), name=MetricsSystem, sub=(.*)><>(.*): (\d+)'
+        attrNameSnakeCase: true
+        name: hadoop_$1_$3
+        value: $4
+        labels:
+          role: $1
+          kind: 'MetricsSystem'
+          sub: $2
+        type: GAUGE
+      # FSDatasetState (also extracts the FSDataset ID)
+      - pattern: 'Hadoop<service=(.*), name=FSDatasetState-(.*)><>(.*): (\d+)'
+        attrNameSnakeCase: true
+        name: hadoop_$1_$3
+        value: $4
+        labels:
+          role: $1
+          fsdatasetid: $2
+          kind: 'FSDatasetState'
+        type: GAUGE
+      # DataNodeActivity (also extracts hostname and port)
+      - pattern: 'Hadoop<service=(.*), name=DataNodeActivity-(.*)-(\d+)><>(.*): (\d+)'
+        attrNameSnakeCase: true
+        name: hadoop_$1_$4
+        value: $5
+        labels:
+          role: $1
+          datanode: $2
+          port: $3
+          kind: 'DataNodeActivity'
+        type: GAUGE
+      # All other services can be handled generically
+      - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*): (\d+)'
+        attrNameSnakeCase: true
+        name: hadoop_$1_$3
+        value: $4
+        labels:
+          role: $1
+          kind: $2
+        type: GAUGE

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -4,50 +4,41 @@ kind: Service
 metadata:
   name: hdfs-namenode
   labels:
-    app: hdfs-namenode
+    app: hdfs
     hdfs: namenode
+    component: hdfs-namenode
 spec:
   ports:
   - port: 9820
     name: fs
+  - port: 9870
+    name: web
+  - port: 8082
+    name: metrics
   clusterIP: None
   selector:
-    app: hdfs-namenode
+    app: hdfs
     hdfs: namenode
 
 ---
 
-apiVersion: v1
-kind: Service
-metadata:
-  name: hdfs-namenode-proxy
-  labels:
-    app: hdfs-namenode
-    hdfs: namenode
-spec:
-  ports:
-  - port: 9820
-    name: fs
-  selector:
-    app: hdfs-namenode
-    hdfs: namenode
-
----
-# A headless service for the web interface.
+# A clusterIP service for the web interface.
 apiVersion: v1
 kind: Service
 metadata:
   name: hdfs-namenode-web
   labels:
-    app: hdfs-namenode
+    app: hdfs
     hdfs: namenode
+    component: hdfs-namenode
 spec:
   ports:
   - port: 9870
     name: web
   selector:
-    app: hdfs-namenode
+    app: hdfs
     hdfs: namenode
+
 ---
 
 apiVersion: apps/v1
@@ -55,7 +46,7 @@ kind: StatefulSet
 metadata:
   name: hdfs-namenode
   labels:
-    app: hdfs-namenode
+    app: hdfs
     hdfs: namenode
 spec:
   serviceName: "hdfs-namenode"
@@ -64,7 +55,7 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: hdfs-namenode
+      app: hdfs
       hdfs: namenode
 {{- if .Values.hadoop.spec.hdfs.namenode.labels }}
 {{ toYaml .Values.hadoop.spec.hdfs.namenode.labels | indent 6 }}
@@ -72,7 +63,7 @@ spec:
   template:
     metadata:
       labels:
-        app: hdfs-namenode
+        app: hdfs
         hdfs: namenode
 {{- if .Values.hadoop.spec.hdfs.namenode.labels }}
 {{ toYaml .Values.hadoop.spec.hdfs.namenode.labels | indent 8 }}
@@ -80,6 +71,7 @@ spec:
       annotations:
         hadoop-config-hash: {{ include (print $.Template.BasePath "/hadoop/hadoop-configmap.yaml") . | sha256sum }}
         hadoop-scripts-hash: {{ include (print $.Template.BasePath "/hadoop/hadoop-scripts.yaml") . | sha256sum }}
+        hdfs-jmx-config-hash: {{ include (print $.Template.BasePath "/hadoop/hdfs-jmx-config.yaml") . | sha256sum }}
 {{- if .Values.hadoop.spec.config.aws.createCredentialsSecret }}
         hadoop-aws-credentials-hash: {{ include (print $.Template.BasePath "/hadoop/hadoop-aws-credentials.yaml") . | sha256sum }}
 {{- end }}
@@ -166,11 +158,15 @@ spec:
           name: fs
         - containerPort: 9870
           name: web
+        - containerPort: 8082
+          name: metrics
         volumeMounts:
         - name: hadoop-config
           mountPath: /hadoop-config
         - name: hadoop-scripts
           mountPath: /hadoop-scripts
+        - name: hdfs-jmx-config
+          mountPath: /opt/jmx_exporter/config
         - name: hdfs-namenode-data
           mountPath: /hadoop/dfs/name
           # we use a subPath to avoid the lost+found directory at the root of
@@ -197,6 +193,9 @@ spec:
         configMap:
           name: hadoop-scripts
           defaultMode: 0555
+      - name: hdfs-jmx-config
+        configMap:
+          name: hdfs-jmx-config
       - name: datanode-empty
         emptyDir: {}
       - name: hadoop-logs
@@ -205,7 +204,7 @@ spec:
   - metadata:
       name: "hdfs-namenode-data"
       labels:
-        app: hdfs-namenode
+        app: hdfs
         hdfs: namenode
     spec:
       accessModes: ["ReadWriteOnce"]

--- a/charts/openshift-metering/templates/monitoring/hdfs-service-monitor.yaml
+++ b/charts/openshift-metering/templates/monitoring/hdfs-service-monitor.yaml
@@ -2,9 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: metering-presto
+  name: metering-hdfs
   labels:
-    k8s-app: metering-presto
+    k8s-app: metering-hdfs
 spec:
   jobLabel: component
   endpoints:
@@ -13,7 +13,7 @@ spec:
     scheme: "http"
   selector:
     matchLabels:
-      app: presto
+      app: hdfs
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/openshift-metering/templates/monitoring/hive-service-monitor.yaml
+++ b/charts/openshift-metering/templates/monitoring/hive-service-monitor.yaml
@@ -2,9 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: metering-presto
+  name: metering-hive
   labels:
-    k8s-app: metering-presto
+    k8s-app: metering-hive
 spec:
   jobLabel: component
   endpoints:
@@ -13,7 +13,7 @@ spec:
     scheme: "http"
   selector:
     matchLabels:
-      app: presto
+      app: hive
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/openshift-metering/templates/monitoring/reporting-operator-service-monitor.yaml
+++ b/charts/openshift-metering/templates/monitoring/reporting-operator-service-monitor.yaml
@@ -3,20 +3,21 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: metering-reporting-operator
+  labels:
+    k8s-app: metering-reporting-operator
 spec:
-  jobLabel: app
+  jobLabel: component
   endpoints:
   - port: metrics
     scheme: "https"
     interval: 30s
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: reporting-operator-metrics.{{ .Release.Namespace }}.svc
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      serverName: reporting-operator.{{ .Release.Namespace }}.svc
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   selector:
     matchLabels:
       app: reporting-operator
-      metrics: "true"
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/openshift-metering/templates/presto/hive-configmap.yaml
+++ b/charts/openshift-metering/templates/presto/hive-configmap.yaml
@@ -18,6 +18,18 @@ data:
         <value>NOSASL</value>
       </property>
       <property>
+        <name>hive.metastore.metrics.enabled</name>
+        <value>true</value>
+      </property>
+      <property>
+        <name>hive.server2.metrics.enabled</name>
+        <value>true</value>
+      </property>
+      <property>
+        <name>hive.service.metrics.reporter</name>
+        <value>JMX</value>
+      </property>
+      <property>
         <name>hive.metastore.uris</name>
         <value>{{ .Values.presto.spec.hive.config.metastoreURIs }}</value>
       </property>

--- a/charts/openshift-metering/templates/presto/hive-jmx-config.yaml
+++ b/charts/openshift-metering/templates/presto/hive-jmx-config.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hive-jmx-config
+  labels:
+    app: hive
+data:
+  config.yml: |
+    ---
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    attrNameSnakeCase: true
+    whitelistObjectNames:
+      - 'metrics:name=active_calls_*'
+      - 'metrics:name=api_*'
+      - 'metrics:name=create_*'
+      - 'metrics:name=delete_*'
+      - 'metrics:name=init_*'
+      - 'metrics:name=exec_*'
+      - 'metrics:name=hs2_*'
+      - 'metrics:name=open_connections'
+      - 'metrics:name=open_operations'
+    rules:
+      - pattern: 'metrics<name=(.*)><>Value'
+        name: hive_$1
+        type: GAUGE
+      - pattern: 'metrics<name=(.*)><>Count'
+        name: hive_$1_count
+        type: GAUGE
+      - pattern: 'metrics<name=(.*)><>(\d+)thPercentile'
+        name: hive_$1
+        type: GAUGE
+        labels:
+          quantile: "0.$2"

--- a/charts/openshift-metering/templates/presto/hive-metastore-service.yaml
+++ b/charts/openshift-metering/templates/presto/hive-metastore-service.yaml
@@ -9,8 +9,8 @@ spec:
   ports:
   - name: meta
     port: 9083
-    protocol: TCP
-    targetPort: 9083
+  - name: metrics
+    port: 8082
   selector:
     app: hive
     hive: metastore

--- a/charts/openshift-metering/templates/presto/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/hive-metastore-statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       annotations:
         hive-configmap-hash: {{ include (print $.Template.BasePath "/presto/hive-configmap.yaml") . | sha256sum }}
         hive-scripts-hash: {{ include (print $.Template.BasePath "/presto/hive-scripts-configmap.yaml") . | sha256sum }}
+        hive-jmx-config-hash: {{ include (print $.Template.BasePath "/presto/hive-jmx-config.yaml") . | sha256sum }}
         presto-aws-credentials-secret-hash: {{ include (print $.Template.BasePath "/presto/presto-aws-credentials-secret.yaml") . | sha256sum }}
 {{- if .Values.presto.spec.hive.annotations }}
 {{ toYaml .Values.presto.spec.hive.annotations | indent 8 }}
@@ -57,6 +58,8 @@ spec:
         - name: meta
           containerPort: 9083
           protocol: TCP
+        - containerPort: 8082
+          name: metrics
 {{- if .Values.presto.spec.hive.metastore.readinessProbe }}
         readinessProbe:
 {{ toYaml .Values.presto.spec.hive.metastore.readinessProbe | indent 10 }}
@@ -100,6 +103,8 @@ spec:
         - name: hdfs-config
           mountPath: /hadoop-config
 {{- end }}
+        - name: hive-jmx-config
+          mountPath: /opt/jmx_exporter/config
         - name: hive-metastore-db-data
           mountPath: /var/lib/hive
         # openshift requires volumeMounts for VOLUMEs in a Dockerfile
@@ -140,6 +145,9 @@ spec:
         configMap:
           name: {{ .Values.presto.spec.hive.config.hdfsConfigMapName }}
 {{- end }}
+      - name: hive-jmx-config
+        configMap:
+          name: hive-jmx-config
       # these emptyDir volumes are necessary because Openshift requires VOLUMEs
       # in a Dockerfile have a corresponding volumeMount
       - name: hive-warehouse-empty

--- a/charts/openshift-metering/templates/presto/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/presto/hive-scripts-configmap.yaml
@@ -57,7 +57,8 @@ data:
     fi
 
     # Set JMX options
-    export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
+    export JMX_OPTIONS="-javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8081 -Dcom.sun.management.jmxremote.rmi.port=8081 -Djava.rmi.server.hostname=127.0.0.1"
+
     # Set garbage collection logs
     GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
     GC_SETTINGS="${GC_SETTINGS} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M"

--- a/charts/openshift-metering/templates/presto/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/presto/hive-scripts-configmap.yaml
@@ -59,7 +59,8 @@ data:
     # Set JMX options
     export JMX_OPTIONS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
     # Set garbage collection logs
-    export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
+    GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_LOG_DIR}/gc.log"
+    GC_SETTINGS="${GC_SETTINGS} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M"
 
     export HIVE_LOGLEVEL="${HIVE_LOGLEVEL:-INFO}"
     export HADOOP_OPTS="${HADOOP_OPTS} ${VM_OPTIONS} ${GC_SETTINGS} ${JMX_OPTIONS}"

--- a/charts/openshift-metering/templates/presto/hive-server-service.yaml
+++ b/charts/openshift-metering/templates/presto/hive-server-service.yaml
@@ -9,12 +9,10 @@ spec:
   ports:
   - name: thrift
     port: 10000
-    protocol: TCP
-    targetPort: 10000
   - name: ui
     port: 10002
-    protocol: TCP
-    targetPort: 10002
+  - name: metrics
+    port: 8082
   selector:
     app: hive
     hive: server

--- a/charts/openshift-metering/templates/presto/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/hive-server-statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       annotations:
         hive-configmap-hash: {{ include (print $.Template.BasePath "/presto/hive-configmap.yaml") . | sha256sum }}
         hive-scripts-hash: {{ include (print $.Template.BasePath "/presto/hive-scripts-configmap.yaml") . | sha256sum }}
+        hive-jmx-config-hash: {{ include (print $.Template.BasePath "/presto/hive-jmx-config.yaml") . | sha256sum }}
         presto-aws-credentials-secret-hash: {{ include (print $.Template.BasePath "/presto/presto-aws-credentials-secret.yaml") . | sha256sum }}
 {{- if .Values.presto.spec.hive.annotations }}
 {{ toYaml .Values.presto.spec.hive.annotations | indent 8 }}
@@ -60,6 +61,8 @@ spec:
         - name: ui
           containerPort: 10002
           protocol: TCP
+        - containerPort: 8082
+          name: metrics
 {{- if .Values.presto.spec.hive.server.readinessProbe }}
         readinessProbe:
 {{ toYaml .Values.presto.spec.hive.server.readinessProbe | indent 10 }}
@@ -104,6 +107,8 @@ spec:
         - name: hdfs-config
           mountPath: /hadoop-config
 {{- end}}
+        - name: hive-jmx-config
+          mountPath: /opt/jmx_exporter/config
         # openshift requires volumeMounts for VOLUMEs in a Dockerfile
         - name: hive-metastore-db-data
           mountPath: /var/lib/hive
@@ -144,6 +149,9 @@ spec:
         configMap:
           name: {{ .Values.presto.spec.hive.config.hdfsConfigMapName }}
 {{- end }}
+      - name: hive-jmx-config
+        configMap:
+          name: hive-jmx-config
       # these emptyDir volumes are necessary because Openshift requires VOLUMEs
       # in a Dockerfile have a corresponding volumeMount
       - name: hive-warehouse-empty

--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -102,10 +102,13 @@ data:
     -XX:+ExitOnOutOfMemoryError
     -XX:ErrorFile=/var/presto/logs/java_error%p.log
     -verbose:gc
+    -Xloggc:/var/presto/logs/gc.log
     -XX:+PrintGCDetails
     -XX:+PrintGCTimeStamps
     -XX:+PrintGCDateStamps
-    -Xloggc:/var/presto/logs/gc.log
+    -XX:+UseGCLogFileRotation
+    -XX:NumberOfGCLogFiles=5
+    -XX:GCLogFileSize=3M
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
     -Dcom.sun.management.jmxremote
     -Dcom.sun.management.jmxremote.local.only=false

--- a/charts/openshift-metering/templates/presto/presto-jmx-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-jmx-config.yaml
@@ -7,43 +7,75 @@ metadata:
 data:
   config.yml: |
     ---
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    attrNameSnakeCase: false
     rules:
-      - pattern: "com.facebook.presto.hive<type=(.+), name=hive><>(.+AllTime.+): (.*)"
-        name: "presto_hive_$1_$2"
+      # capture percentile and set quantile label
+      - pattern: 'presto.plugin.hive<type=(.+), name=hive><>(.+AllTime).P(\d+): (.*)'
+        name: 'presto_hive_$1_$2_seconds'
         type: GAUGE
-      - pattern: "com.facebook.presto.hive<type=(.+), name=hive><>(.+TotalCount.*): (.*)"
-        name: "presto_hive_$1_$2_total"
+        valueFactor: 0.001
+        labels:
+          quantile: '0.$3'
+      # match non-percentiles
+      - pattern: 'presto.plugin.hive<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+        name: 'presto_hive_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+        # counts
+      - pattern: 'presto.plugin.hive<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+        name: 'presto_hive_$1_$2_total'
         type: COUNTER
-      - pattern: "com.facebook.presto.hive.s3<type=(.+), name=hive><>(.+AllTime.+): (.*)"
-        name: "presto_hive_s3_$1_$2"
+      # capture percentile and set quantile label
+      - pattern: 'presto.plugin.hive.s3<type=(.+), name=hive><>(.+AllTime).P(\d+): (.*)'
+        name: 'presto_hive_s3_$1_$2_seconds'
         type: GAUGE
-      - pattern: "com.facebook.presto.hive.s3<type=(.+), name=hive><>(.+TotalCount.*): (.*)"
-        name: "presto_hive_s3_$1_$2_total"
+        valueFactor: 0.001
+        labels:
+          quantile: '0.$3'
+      # match non-percentiles
+      - pattern: 'presto.plugin.hive.s3<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+        name: 'presto_hive_s3_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+        # counts
+      - pattern: 'presto.plugin.hive.s3<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+        name: 'presto_hive_s3_$1_$2_total'
         type: COUNTER
-      - pattern: "com.facebook.presto.hive.metastore.thrift<type=(.+), name=hive><>(.+AllTime.+): (.*)"
-        name: "presto_hive_metastore_thrift_$1_$2"
+      # capture percentile and set quantile label
+      - pattern: 'presto.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+AllTime).P(\d+): (.*)'
+        name: 'presto_hive_metastore_thrift_$1_$2_seconds'
         type: GAUGE
-      - pattern: "com.facebook.presto.hive.metastore.thrift<type=(.+), name=hive><>(.+TotalCount.*): (.*)"
-        name: "presto_hive_metastore_thrift_$1_$2_total"
+        valueFactor: 0.001
+        labels:
+          quantile: '0.$3'
+      # match non-percentiles
+      - pattern: 'presto.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+        name: 'presto_hive_metastore_thrift_$1_$2_count_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+      # counts
+      - pattern: 'presto.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+        name: 'presto_hive_metastore_thrift_$1_$2_total'
         type: COUNTER
-      - pattern: "com.facebook.presto.execution<name=(.+)><>(.+AllTime.+): (.*)"
-        name: "presto_execution_$1_$2"
+      - pattern: 'presto.execution<name=(.+)><>(.+AllTime).P(\d+): (.*)'
+        name: 'presto_execution_$1_$2_seconds'
         type: GAUGE
-      - pattern: "com.facebook.presto.execution<name=(.+)><>(.+TotalCount.*): (.*)"
-        name: "presto_execution_$1_$2_total"
+        valueFactor: 0.001
+        labels:
+          quantile: '0.$3'
+      - pattern: 'presto.execution<name=(.+)><>(.+AllTime.+): (.*)'
+        name: 'presto_execution_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+      # counts
+      - pattern: 'presto.execution<name=(.+)><>(.+TotalCount.*): (.*)'
+        name: 'presto_execution_$1_$2_total'
         type: COUNTER
-      - pattern: "com.facebook.presto.execution.executor<name=(.+)><>(.+AllTime.*): (.*)"
-        name: "presto_executor_$1_$2"
+      - pattern: 'presto.memory<type=(.*), name=(.*)><>(.+): (.*)'
+        name: 'presto_memory_$1_$2_$3'
         type: GAUGE
-      - pattern: "com.facebook.presto.execution.executor<name=(.+)><>(.+TotalCount.*): (.*)"
-        name: "presto_executor_$1_$2_total"
-        type: COUNTER
-      - pattern: "com.facebook.presto.memory<name=ClusterMemoryManager><>(.+): (.*)"
-        name: "presto_clustermemorymanager_$1"
-        type: GAUGE
-      - pattern: "com.facebook.presto.memory<type=ClusterMemoryPool, name=(.*)><>(.+): (.*)"
-        name: "presto_clustermemorypool_$1_$2"
-        type: GAUGE
-      - pattern: "com.facebook.presto.failureDetector<name=HeartbeatFailureDetector><>ActiveCount: (.*)"
-        name: "presto_heartbeatdetector_activecount"
+      - pattern: 'presto.failuredetector<name=HeartbeatFailureDetector><>ActiveCount: (.*)'
+        name: 'presto_heartbeatdetector_activecount'
         type: GAUGE

--- a/charts/openshift-metering/templates/presto/presto-service.yaml
+++ b/charts/openshift-metering/templates/presto/presto-service.yaml
@@ -5,12 +5,13 @@ metadata:
   labels:
     app: presto
     presto: coordinator
+    component: presto-coordinator
 spec:
   ports:
   - name: http
     port: 8080
-    protocol: TCP
-    targetPort: 8080
+  - name: metrics
+    port: 8082
   selector:
     app: presto
     presto: coordinator
@@ -20,18 +21,20 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: presto-metrics
+  name: presto-worker
   labels:
     app: presto
-    metrics: "true"
+    presto: worker
+    component: presto-coordinator
 spec:
   ports:
+  - name: http
+    port: 8080
   - name: metrics
     port: 8082
-    protocol: TCP
-    targetPort: metrics
   selector:
     app: presto
+    presto: worker
 
 ---
 
@@ -45,8 +48,6 @@ spec:
   ports:
   - name: http
     port: 8080
-    protocol: TCP
-    targetPort: 8080
   clusterIP: None
   selector:
     app: presto

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -101,10 +101,13 @@ data:
     -XX:+ExitOnOutOfMemoryError
     -XX:ErrorFile=/var/presto/logs/java_error%p.log
     -verbose:gc
+    -Xloggc:/var/presto/logs/gc.log
     -XX:+PrintGCDetails
     -XX:+PrintGCTimeStamps
     -XX:+PrintGCDateStamps
-    -Xloggc:/var/presto/logs/gc.log
+    -XX:+UseGCLogFileRotation
+    -XX:NumberOfGCLogFiles=5
+    -XX:GCLogFileSize=3M
     -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
     -Dcom.sun.management.jmxremote
     -Dcom.sun.management.jmxremote.local.only=false

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -246,12 +246,10 @@ spec:
         - name: REPORTING_OPERATOR_USE_TLS
           value: "true"
 {{- end }}
-{{- end }}
-{{- if $operatorValues.spec.config.metricsTLS.enabled }}
         - name: REPORTING_OPERATOR_METRICS_TLS_KEY
-          value: "/metrics-tls/tls.key"
+          value: "/tls/tls.key"
         - name: REPORTING_OPERATOR_METRICS_TLS_CERT
-          value: "/metrics-tls/tls.crt"
+          value: "/tls/tls.crt"
         - name: REPORTING_OPERATOR_METRICS_USE_TLS
           value: "true"
 {{- end }}
@@ -305,8 +303,6 @@ spec:
 {{- if $operatorValues.spec.config.tls.enabled }}
         - name: api-tls
           mountPath: /tls
-        - name: metrics-tls
-          mountPath: /metrics-tls
 {{- end }}
 {{- if $operatorValues.spec.config.prometheusCertificateAuthority.configMap.enabled }}
         - name: prometheus-certificate-authority
@@ -397,11 +393,6 @@ spec:
       - name: prometheus-certificate-authority
         configMap:
           name: {{ $operatorValues.spec.config.prometheusCertificateAuthority.configMap.name }}
-{{- end }}
-{{- if $operatorValues.spec.config.metricsTLS.enabled }}
-      - name: metrics-tls
-        secret:
-          secretName: {{ $operatorValues.spec.config.metricsTLS.secretName }}
 {{- end }}
 {{- if $operatorValues.spec.authProxy.enabled }}
       - name: cookie-secret

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-service.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: reporting-operator
   labels:
     app: reporting-operator
+    component: reporting-operator
 {{- if $operatorValues.spec.service.annotations }}
   annotations:
 {{ toYaml $operatorValues.spec.service.annotations | indent 4 }}
@@ -15,7 +16,6 @@ spec:
     app: reporting-operator
   ports:
   - name: http
-    protocol: TCP
     port: 8080
 {{- if $operatorValues.spec.authProxy.enabled }}
     targetPort: auth-proxy
@@ -25,24 +25,6 @@ spec:
 {{- if and (eq (lower $operatorValues.spec.service.type) "nodeport" "loadbalancer") $operatorValues.spec.service.nodePort }}
     nodePort: {{ $operatorValues.spec.service.nodePort }}
 {{- end }}
-
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: reporting-operator-metrics
-  labels:
-    app: reporting-operator
-    metrics: "true"
-{{- if $operatorValues.spec.metricsService.annotations }}
-  annotations:
-{{ toYaml $operatorValues.spec.metricsService.annotations | indent 4 }}
-{{- end }}
-spec:
-  selector:
-    app: reporting-operator
-  ports:
-  - protocol: TCP
-    port: 8082
+  - port: 8082
     targetPort: metrics
     name: metrics

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-tls-secrets.yaml
@@ -11,18 +11,3 @@ data:
   tls.crt: {{ $operatorValues.spec.config.tls.certificateData | b64enc | quote }}
   tls.key: {{ $operatorValues.spec.config.tls.privateKeyData | b64enc | quote }}
 {{- end -}}
-
----
-
-{{- if $operatorValues.spec.config.metricsTLS.createSecret -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ $operatorValues.spec.config.metricsTLS.secretName }}
-  labels:
-    app: reporting-operator
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ $operatorValues.spec.config.metricsTLS.certificateData | b64enc | quote }}
-  tls.key: {{ $operatorValues.spec.config.metricsTLS.privateKeyData | b64enc | quote }}
-{{- end -}}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -221,12 +221,6 @@ reporting-operator:
       logDMLQueries: "false"
       logLevel: info
       logReports: "false"
-      metricsTLS:
-        certificateData: null
-        createSecret: false
-        enabled: true
-        privateKeyData: null
-        secretName: reporting-operator-metrics-tls-secrets
       prestoHost: presto:8080
       prestoMaxQueryLength: null
       prestoTLS:
@@ -292,9 +286,6 @@ reporting-operator:
       periodSeconds: 60
       successThreshold: 1
       timeoutSeconds: 60
-    metricsService:
-      annotations:
-        service.alpha.openshift.io/serving-cert-secret-name: reporting-operator-metrics-tls-secrets
     nodeSelector: {}
     readinessProbe:
       failureThreshold: 3
@@ -355,7 +346,7 @@ presto:
         enableMetastoreSchemaVerification: false
         metastoreClientSocketTimeout: null
         metastoreURIs: thrift://hive-metastore:9083
-        metastoreWarehouseDir: hdfs://hdfs-namenode-proxy:9820/operator_metering/default_hive_warehouse/
+        metastoreWarehouseDir: hdfs://hdfs-namenode-0.hdfs-namenode:9820/operator_metering/default_hive_warehouse/
         hdfsConfigMapName: hadoop-config
         useHdfsConfigMap: true
       image:

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -82,6 +82,6 @@ meteringconfig_create_reporting_operator_prometheus_certificate_authority: "{{ _
 meteringconfig_create_reporting_operator_aws_credentials: "{{ _reporting_op_spec.config.createAwsCredentialsSecret | default(false) }}"
 meteringconfig_create_reporting_operator_presto_tls_secrets: "{{ _reporting_op_spec.config.prestoTLS.enabled and _reporting_op_spec.config.prestoTLS.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_presto_auth_secrets: "{{ _reporting_op_spec.config.prestoAuth.enabled and _reporting_op_spec.config.prestoAuth.createSecret | default(false) }}"
-meteringconfig_create_reporting_operator_tls_secrets: "{{ _reporting_op_spec.config.tls.createSecret or _reporting_op_spec.config.metricsTLS.createSecret | default(false) }}"
+meteringconfig_create_reporting_operator_tls_secrets: "{{ _reporting_op_spec.config.tls.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_route: "{{ _reporting_op_spec.route.enabled | default(false) }}"
 meteringconfig_create_reporting_operator_cluster_monitoring_view_rbac: "{{ _reporting_op_spec.config.createClusterMonitoringViewRBAC | default(true) }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
@@ -13,6 +13,10 @@
         apis: [ {kind: configmap} ]
         prune_label_value: hadoop-scripts
         create: "{{ meteringconfig_enable_hdfs }}"
+      - template_file: templates/hadoop/hdfs-jmx-config.yaml
+        apis: [ {kind: configmap} ]
+        prune_label_value: hdfs-jmx-config
+        create: "{{ meteringconfig_enable_hdfs }}"
       - template_file: templates/hadoop/hadoop-configmap.yaml
         apis: [ {kind: configmap} ]
         prune_label_value: hadoop-configmap

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -19,6 +19,9 @@
       - template_file: templates/presto/hive-scripts-configmap.yaml
         apis: [ {kind: configmap} ]
         prune_label_value: hive-scripts-configmap
+      - template_file: templates/presto/hive-jmx-config.yaml
+        apis: [ {kind: configmap} ]
+        prune_label_value: hive-jmx-config
       - template_file: templates/presto/hive-metastore-service.yaml
         apis: [ {kind: service} ]
         prune_label_value: hive-metastore-service

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
@@ -7,14 +7,22 @@
     resources:
       - template_file: templates/monitoring/monitoring-rbac.yaml
         apis: [ {kind: role, api_version: 'rbac.authorization.k8s.io/v1'}, {kind: rolebindings, api_version: 'rbac.authorization.k8s.io/v1'} ]
-        prune_label_value: openshift-metering-monitoring-rbac
+        prune_label_value: metering-monitoring-rbac
         create: "{{ meteringconfig_create_metering_monitoring_rbac }}"
+      - template_file: templates/monitoring/hdfs-service-monitor.yaml
+        apis: [ {kind: serviceMonitor, api_version: 'monitoring.coreos.com/v1'} ]
+        prune_label_value: metering-hdfs-service-monitor
+        create: "{{ meteringconfig_create_metering_monitoring_resources }}"
+      - template_file: templates/monitoring/hive-service-monitor.yaml
+        apis: [ {kind: serviceMonitor, api_version: 'monitoring.coreos.com/v1'} ]
+        prune_label_value: metering-hive-service-monitor
+        create: "{{ meteringconfig_create_metering_monitoring_resources }}"
       - template_file: templates/monitoring/presto-service-monitor.yaml
         apis: [ {kind: serviceMonitor, api_version: 'monitoring.coreos.com/v1'} ]
-        prune_label_value: openshift-metering-presto-service-monitor
+        prune_label_value: metering-presto-service-monitor
         create: "{{ meteringconfig_create_metering_monitoring_resources }}"
       - template_file: templates/monitoring/reporting-operator-service-monitor.yaml
         apis: [ {kind: serviceMonitor, api_version: 'monitoring.coreos.com/v1'} ]
-        prune_label_value: openshift-metering-reporting-operator-service-monitor
+        prune_label_value: metering-reporting-operator-service-monitor
         create: "{{ meteringconfig_create_metering_monitoring_resources }}"
 


### PR DESCRIPTION
- Update presto jmx to use correct mbean names after updating to prestosql.io
- Configures Hadoop and Hive to run the jmx adapter now that it's in the hadoop image after https://github.com/operator-framework/hadoop/pull/8.