### PR TITLE
Disable HDFS by default and wait for user to configure storage

### DIFF
--- a/Documentation/common-configuration.md
+++ b/Documentation/common-configuration.md
@@ -2,6 +2,10 @@
 
 This document contains example configurations for configuration that spans one or more components.
 
+## Storage
+
+Storage has it's own documentation page at [configuring storage](configuring-storage.md).
+
 ## Resource requests and limits
 
 You can adjust the cpu, memory, or storage resource requests and/or limits for pods and volumes.

--- a/Documentation/configuring-hdfs.md
+++ b/Documentation/configuring-hdfs.md
@@ -1,0 +1,33 @@
+# Configuring HDFS
+
+By default, HDFS is not used or installed with Metering.
+However, if you set the `spec.unsupportedFeatures.enableHDFS` unsupported features toggle to true, then you can install a non-production grade HDFS cluster alongside metering for storage.
+
+We are not HDFS experts, and thus we will not directly support HDFS, and it should only be used for testing or development.
+Currently there is no way to secure the communications with HFDS, meaning all communications are done in plain text, without authentication.
+
+Proceed at your own risk.
+
+## Persistent Volumes created by HDFS
+
+- `hdfs-namenode-data-hdfs-namenode-0`
+  Used by the hdfs-namenode pod to store metadata about the files and blocks stored in the hdfs-datanodes.
+- One `hdfs-datanode-data-hdfs-datanode-$i` PV per hdfs-datanode replica.
+  Used by each hdfs-datanode pod to store blocks for files in the HDFS cluster.
+
+## Configuring the Storage Class for HDFS
+
+Use [hdfs-storage.yaml][hdfs-storage-config] as a template and adjust the `class: null` value to name of the `StorageClass` to use.
+Leaving the value `null` will cause Metering to use the default StorageClass for the cluster.
+
+- `spec.hadoop.spec.hdfs.datanode.storage.class`
+- `spec.hadoop.spec.hdfs.namenode.storage.class`
+
+## Configuring the volume sizes for HDFS
+
+Use [hdfs-storage.yaml][hdfs-storage-config] as a template and adjust the `size: "5Gi"` value to the desired capacity for the following sections:
+
+- `spec.hadoop.spec.hdfs.datanode.storage.size`
+- `spec.hadoop.spec.hdfs.namenode.storage.size`
+
+[hdfs-storage-config]: ../manifests/metering-config/hdfs-storage.yaml

--- a/Documentation/configuring-hive-metastore.md
+++ b/Documentation/configuring-hive-metastore.md
@@ -1,11 +1,39 @@
 # Configuring the Hive metastore
 
-Generally the default configuration of Hive metastore works for small clusters, but users may wish to improve performance or move storage requirements out of cluster by using a dedicated database for storing table metadata for Presto and Hive server.
+Hive metastore is responsible for storing all the metadata about the database tables we create in Presto and Hive.
+By default, the metastore stores this information in a local embedded Derby database in a PersistentVolume attached to the pod.
 
-## Use MySQL or Postgresql for the Hive Metastore database
+Generally the default configuration of Hive metastore works for small clusters, but users may wish to improve performance or move storage requirements out of cluster by using a dedicated SQL database for storing the Hive metastore data.
+
+## Configuring PersistentVolumes
+
+Hive, by default requires one Persistent Volume to operate.
+
+`hive-metastore-db-data` is the main PVC required by default.
+This PVC is used by Hive metastore to store metadata about tables, such as table name, columns, and location.
+Hive metastore is used by Presto and Hive server to lookup table metadata when processing queries.
+In practice, it is possible to remove this requirement by using [MySQL](#use-mysql-for-the-hive-metastore-database) or [PostgreSQL](#use-postgresql-for-the-hive-metastore-database) for the Hive metastore database.
+
+To install, Hive metastore requires that dynamic volume provisioning be enabled via a Storage Class, a persistent volume of the correct size must be manually pre-created, or that you use a pre-existing MySQL or PostgreSQL database.
+
+### Configuring the Storage Class for Hive Metastore
+
+To configure and specify a `StorageClass` for the hive-metastore-db-data PVC, specify the `StorageClass` in your MeteringConfig.
+A example `StorageClass` section is included in [metastore-storage.yaml][metastore-storage-config].
+
+Uncomment the `spec.presto.spec.hive.metastore.storage.class` sections and replace the `null` in `class: null` value with the name of the StorageClass to use.
+Leaving the value `null` will cause Metering to use the default StorageClass for the cluster.
+
+### Configuring the volume sizes for Hive Metastore
+
+Use [metastore-storage.yaml][metastore-storage-config] as a template and adjust the `size: "5Gi"` value to the desired capacity for the following sections:
+
+- `spec.presto.spec.hive.metastore.storage.size`
+
+## Use MySQL for the Hive Metastore database
 
 By default to make installation easier Metering configures Hive to use an embedded Java database called [Derby](https://db.apache.org/derby/#What+is+Apache+Derby%3F), however this is unsuited for larger environments or metering installations with a lot of reports and metrics being collected.
-Currently two alternative options are available, MySQL and Postgresql, both of which have been tested with operator metering.
+Currently two alternative options are available, MySQL and PostgreSQL, both of which have been tested with operator metering.
 
 There are 4 configuration options you can use to control the database used by Hive metastore: `dbConnectionURL` , `dbConnectionDriver` , `dbConnectionUsername` , and `dbConnectionPassword`.
 
@@ -25,7 +53,7 @@ spec:
 
 You can pass additional JDBC parameters using the `dbConnectionURL`, for more details see [the MySQL Connector/J documentation](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html).
 
-Using Postgresql:
+## Use PostgreSQL for the Hive Metastore database
 
 ```
 spec:
@@ -39,5 +67,6 @@ spec:
           dbConnectionPassword: "REPLACEME"
 ```
 
-You can pass additional JDBC parameters using the `dbConnectionURL`, for more details see [the Postgresql JDBC driver documentation](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters).
+You can pass additional JDBC parameters using the `dbConnectionURL`, for more details see [the PostgreSQL JDBC driver documentation](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters).
 
+[metastore-storage-config]: ../manifests/metering-config/metastore-storage.yaml

--- a/Documentation/configuring-storage.md
+++ b/Documentation/configuring-storage.md
@@ -1,96 +1,64 @@
 # Configuring Storage
 
-Metering by default requires persistent storage in a few areas, but can be configured so it doesn't require any real persistent storage within the cluster.
-The primary purpose of the storage requirements are to persist data collected by the reporting-operator and store the results of reports.
+By Default, Metering requires persistent storage in two main ways.
+The primary storage requirement is to persist data collected by the reporting-operator and store the results of reports. This is usually some form of object storage or distributed file system.
 
-## Persistent Volumes
-
-Metering by default requires at least 3 Persistent Volume to operate. The Persistent Volume Claims (PVCs) are listed below:
-
-- `hive-metastore-db-data` is generally the only _required_ volume.
-  It is used by hive metastore to retain information about the location of where data is stored, which Presto and Hive server use.
-  In practice, it is possible to remove this requirement by using [MySQL or Postgresql for the Hive metastore database][configuring-hive-metastore].
-- `hdfs-namenode-data-hdfs-namenode-0`
-  Used by the hdfs-namenode pod to store metadata about the files and blocks stored in the hdfs-datanodes.
-  This PVCs are not required to [store data in AWS S3](#storing-data-in-s3).
-- One `hdfs-datanode-data-hdfs-datanode-$i` PV per hdfs-datanode replica.
-  Used by each hdfs-datanode pod to store blocks for files in the HDFS cluster.
-  These PVCs are not required to [store data in AWS S3](#storing-data-in-s3).
-
-Each of these Persistent Volume Claims is created dynamically by a Stateful Set.
-Enabling this requires that dynamic volume provisioning be enabled via a Storage Class, or persistent volumes of the correct size must be manually pre-created.
-
-## Dynamically provisioning Persistent Volumes using Storage Classes
-
-Storage Classes may be used when dynamically provisioning Persistent Volume Claims using a Stateful Set.
-Use `kubectl get` to determine if Storage Classes have been created in your cluster.
-
-```
-$ kubectl get storageclasses
-```
-
-If the output includes `(default)` next to the `name` of any `StorageClass`, then that `StorageClass` is the default for the cluster.
-The default is used when `StorageClass` is unspecified or set to `null` in a `PersistentVolumeClaim` spec.
-
-If no `StorageClass` is listed, or if you wish to use a non-default `StorageClass`, see [Configuring the StorageClass for Metering](#configuring-the-storage-class-for-metering) below.
-
-For more information, see [Storage Classes][storage-classes] in the Kubernetes documentation.
-
-### Configuring the Storage Class for Metering
-
-To configure and specify a `StorageClass` for use in Metering, specify the `StorageClass` in `custom-values.yaml`. A example `StorageClass` section is included in [custom-storage.yaml][custom-storage-config].
-
-Uncomment the following sections and replace the `null` in `class: null` value with the name of the `StorageClass` to use. Leaving the value `null` will cause Metering to use the default StorageClass for the cluster.
-
-- `spec.presto.spec.hive.metastore.storage.class`
-- `spec.hadoop.spec.hdfs.datanode.storage.class`
-- `spec.hadoop.spec.hdfs.namenode.storage.class`
-
-### Configuring the volume sizes for Metering
-
-Use [custom-storage.yaml][custom-storage-config] as a template and adjust the `size: "5Gi"` value to the desired capacity for the following sections:
-
-- `spec.presto.spec.hive.metastore.storage.size`
-- `spec.hadoop.spec.hdfs.datanode.storage.size`
-- `spec.hadoop.spec.hdfs.namenode.storage.size`
-
-### Manually creating Persistent Volumes
-
-If a Storage Class that supports dynamic volume provisioning does not exist in the cluster, it is possible to manually create a Persistent Volume with the correct capacity.
-By default, the PVCs listed above each request 5Gi of storage.
-This can be adjusted in the same section as adjusting the Storage Class as documented in [Configuring the volume sizes for Metering](#configuring-the-volume-sizes-for-metering).
+Additionally, Hive metastore requires storage for it's database containing metadata about database tables managed by Presto or Hive. By default, this information is stored in an embedded database called Derby, which keeps it's data on disk in a PersistentVolume, but metastore can also be configured to use an existing Mysql or Postgresql database, instead of Derby. Read the [configuring the Hive metastore documentation][configuring-hive-metastore] for more details.
 
 ## Storing data in S3
 
-By default, the data that Metering collects and generates is stored in a single node HDFS cluster which is backed by a Persistent Volume.
-To store the data in a location outside of the cluster, configure Metering to store data in S3.
+By default, metering has no stored configured but can be configured to store data in S3.
 
-To use S3 for storage, edit the `spec.defaultStorage` section in the example [s3-storage.yaml][s3-storage-config] configuration.
-Set `awsAccessKeyID` and `awsSecretAccessKey` in the `reporting-operator.config` and `presto.config` sections.
+To use S3 for storage, edit the `spec.storage` section in the example [s3-storage.yaml][s3-storage-config] configuration.
+Set the `spec.storage.hive.s3.bucket` and `spec.storage.hive.s3.awsCredentialsSecretName`.
+The `bucket` should be the name and optionally the path within the bucket you wish to store metering data at.
+The `awsCredentialsSecretName` should be the name of a secret in the metering namespace containing AWS credentials in the `data.aws-access-key-id` and `data.aws-secret-access-key` fields.
 
-To store data in S3, the `awsAccessKeyID` and `awsSecretAccessKey` credentials must have read and write access to the bucket.
+For example:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-aws-secret
+data:
+  aws-access-key-id: "dGVzdAo="
+  aws-secret-access-key: "c2VjcmV0Cg=="
+```
+
+To store data in S3, the `aws-access-key-id` and `aws-secret-access-key` credentials must have read and write access to the bucket.
 For an example of an IAM policy granting the required permissions see the [aws/read-write.json](aws/read-write.json) file.
-Replace `operator-metering-data` with the name of your bucket.
+Replace `bucketname/path` with the name of the bucket and the path in the bucket you want to store metering data within.
 
-Please note that this must be done before installation. Changing these settings after installation may result in unexpected behavior.
-
-Because the deployed HDFS cluster will not be used to store data, it may also be disabled.
-In `s3-storage.yaml`, this has already been done by setting `spec.hadoop.spec.hdfs.enabled` to `false` and setting `presto.spec.hive.config.useHdfsConfigMap` to `false`.
+Please note that this must be done before installation.
+Changing these settings after installation will result in broken and unexpected behavior.
 
 ## Using shared volumes for storage
 
-Metering uses HDFS for storage by default, but can use any ReadWriteMany PersistentVolume or StorageClass.
+Metering has no storage by default, but can use any ReadWriteMany PersistentVolume or [StorageClass][storage-classes] that provisions a ReadWriteMany PersistentVolume.
 
-To use a ReadWriteMany for storage, modify the [shared-storage.yaml][shared-storage-config] configuration.
+To use a ReadWriteMany PersistentVolume for storage, modify the [shared-storage.yaml][shared-storage-config] configuration.
 
-Configure the `presto.spec.config.sharedVolume.storage.persistentVolumeClaimStorageClass` to a StorageClass with ReadWriteMany access mode.
+You have two options:
 
-Note that our example [shared-storage.yaml][shared-storage-config] disables HDFS by setting `spec.hadoop.spec.hdfs.enabled` to false since it will not be used.
+1) Set `storage.hive.sharedPVC.createPVC` to true and set the `storage.hive.sharedPVC.storageClass` to the name of a StorageClass with ReadWriteMany access mode. This will use dynamic volume provisioning to have a volume created automatically.
+2) Set `storage.hive.sharedPVC.claimName` to the name of an existing ReadWriteMany PVC. This is necessary if you don't have dynamic volume provisioning, or wish to have more control over how the PersistentVolume is created.
 
 > Note: NFS is not recommended to use with Metering.
 
+## Using HDFS for storage (unsupported)
+
+If you do not have access to S3, or storage provisioner that supports ReadWriteMany PVCs, you may also test using HDFS.
+
+HDFS is currently unsupported.
+We do not support running HDFS on Kubernetes as it's not very efficient, and has an increased complexity over using object storage.
+However, because we historically have used HDFS for development, there are options available within Metering to deploy and use HDFS if you're willing to enable unsupported features.
+
+For more details read [configuring HDFS][configuring-hdfs].
+
 [storage-classes]: https://kubernetes.io/docs/concepts/storage/storage-classes/
-[custom-storage-config]: ../manifests/metering-config/custom-storage.yaml
 [s3-storage-config]: ../manifests/metering-config/s3-storage.yaml
 [shared-storage-config]: ../manifests/metering-config/shared-storage.yaml
+[hdfs-storage-config]: ../manifests/metering-config/hdfs-storage.yaml
 [configuring-hive-metastore]: configuring-hive-metastore.md
+[configuring-hdfs]: configuring-hdfs.md

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -14,6 +14,7 @@
     - [configuring Authentication on Openshift](configuring-reporting-operator.md#openshift-authentication)
   - [configuring storage](configuring-storage.md)
     - [storing data in s3](configuring-storage.md#storing-data-in-s3)
+    - [storing data in a ReadWriteMany PVC](configuring-storage.md#using-shared-volumes-for-storage)
   - [configuring the Hive metastore](configuring-hive-metastore.md)
   - [configuring aws billing correlation for cost correlation](configuring-aws-billing.md)
   - [configuring for use with Telemeter](configuring-telemeter.md)

--- a/Documentation/storagelocations.md
+++ b/Documentation/storagelocations.md
@@ -1,7 +1,10 @@
 # Storage Locations
 
-A `StorageLocation` is a custom resource that configures where data will be stored.
+A `StorageLocation` is a custom resource that configures where data will be stored by the reporting-operator.
 This includes the data collected from Prometheus, and the results produced by generating a `Report`.
+
+Normally, users shouldn't need to configure StorageLocation's unless they want to store data in multiple locations, like multiple S3 buckets or both S3 and HDFS, or if they wish to access a database in Hive/Presto that was not created by metering.
+Instead, users should use the [configuring storage](configuring-storage.md) documentation to manage configuration of all components in the metering stack.
 
 The Operator Metering default installation provides a few ways of configuring the [Default StorageLocation](#default-storagelocation), and normally it shouldn't be necessary to create these directly.
 Refer to the [Metering Configuration doc](metering-config.md#storing-data-in-s3) for details on using the `Metering` resource to set your default StorageLocation.
@@ -19,7 +22,7 @@ Refer to the [Metering Configuration doc](metering-config.md#storing-data-in-s3)
 ## Example StorageLocation
 
 This first example is what the built-in local storage option looks like.
-As you can see, it's configured to use HDFS and supplies no additional options.
+As you can see, it's configured to use Hive, and by default data is stored wherever Hive is configured to use storage by default (HDFS, S3, or a ReadWriteMany PVC) since the location isn't set.
 
 ```yaml
 apiVersion: metering.openshift.io/v1alpha1
@@ -30,9 +33,9 @@ metadata:
     operator-metering: "true"
   spec:
     hive:
-      databaseName: default
-      unmanagedDatabase: true
-      location: "hdfs://hdfs-namenode-proxy:8020"
+      databaseName: metering
+      unmanagedDatabase: false
+      location: ""
 ```
 
 The example below uses an AWS S3 bucket for storage.

--- a/charts/metering-ci/templates/metering.yaml
+++ b/charts/metering-ci/templates/metering.yaml
@@ -6,6 +6,16 @@ spec:
   monitoring:
     enabled: true
 
+  unsupportedFeatures:
+    enableHDFS: true
+
+  storage:
+    type: "hive"
+    hive:
+      type: "hdfs"
+      hdfs:
+        namenode: "hdfs-namenode-0.hdfs-namenode:9820"
+
   openshift-reporting:
     spec:
       awsBillingReportDataSource:
@@ -110,6 +120,7 @@ spec:
       imagePullSecrets: [ { name: "{{ .Values.imagePullSecretName }}" } ]
 {{- end }}
       hdfs:
+        enabled: true
         datanode:
 {{- if .Values.dateAnnotationValue }}
           annotations: { "metering.deploy-custom/deploy-time": "{{ .Values.dateAnnotationValue }}" }

--- a/charts/openshift-metering/templates/metering/default-storage-location.yaml
+++ b/charts/openshift-metering/templates/metering/default-storage-location.yaml
@@ -1,19 +1,20 @@
-{{- if .Values.defaultStorage.create -}}
+{{- $reportingValues :=  index .Values "openshift-reporting" -}}
+{{- if $reportingValues.spec.defaultStorageLocation.create -}}
 apiVersion: metering.openshift.io/v1alpha1
 kind: StorageLocation
 metadata:
-  name: {{ .Values.defaultStorage.name }}
+  name: {{ $reportingValues.spec.defaultStorageLocation.name }}
   labels:
     operator-metering: "true"
-{{- if .Values.defaultStorage.isDefault }}
+{{- if $reportingValues.spec.defaultStorageLocation.isDefault }}
   annotations:
     storagelocation.metering.openshift.io/is-default: "true"
 {{- end }}
 spec:
-{{- if eq .Values.defaultStorage.type "hive" }}
+{{- if eq $reportingValues.spec.defaultStorageLocation.type "hive" }}
   hive:
-{{ toYaml .Values.defaultStorage.hive | indent 4 }}
+{{ toYaml $reportingValues.spec.defaultStorageLocation.hive | indent 4 }}
 {{- else }}
-{{ printf "Unsupported defaultStorage.type: '%s'" .Values.defaultStorage.type | fail }}
+{{ printf "Unsupported defaultStorageLocation.type: '%s'" $reportingValues.spec.defaultStorageLocation.type | fail }}
 {{- end -}}
 {{- end -}}

--- a/charts/openshift-metering/templates/presto/_hive_helpers.tpl
+++ b/charts/openshift-metering/templates/presto/_hive_helpers.tpl
@@ -11,16 +11,16 @@
   valueFrom:
     fieldRef:
       fieldPath: metadata.namespace
+{{- if or .Values.presto.spec.config.awsCredentialsSecretName .Values.presto.spec.config.createAwsCredentialsSecret }}
 - name: AWS_ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.presto.spec.config.awsCredentialsSecretName }}"
+      name: "{{ .Values.presto.spec.config.awsCredentialsSecretName | default "presto-aws-credentials" }}"
       key: aws-access-key-id
-      optional: true
 - name: AWS_SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.presto.spec.config.awsCredentialsSecretName }}"
+      name: "{{ .Values.presto.spec.config.awsCredentialsSecretName | default "presto-aws-credentials" }}"
       key: aws-secret-access-key
-      optional: true
+{{- end }}
 {{- end }}

--- a/charts/openshift-metering/templates/presto/_presto_helpers.tpl
+++ b/charts/openshift-metering/templates/presto/_presto_helpers.tpl
@@ -60,17 +60,16 @@ connector.name=tpch
     resourceFieldRef:
       containerName: presto
       resource: limits.memory
+{{- if or .Values.presto.spec.config.awsCredentialsSecretName .Values.presto.spec.config.createAwsCredentialsSecret }}
 - name: AWS_ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.presto.spec.config.awsCredentialsSecretName }}"
+      name: "{{ .Values.presto.spec.config.awsCredentialsSecretName | default "presto-aws-credentials" }}"
       key: aws-access-key-id
-      optional: true
 - name: AWS_SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.presto.spec.config.awsCredentialsSecretName }}"
+      name: "{{ .Values.presto.spec.config.awsCredentialsSecretName | default "presto-aws-credentials" }}"
       key: aws-secret-access-key
-      optional: true
 {{- end }}
-
+{{- end }}

--- a/charts/openshift-metering/templates/presto/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/hive-metastore-statefulset.yaml
@@ -99,8 +99,8 @@ spec:
           mountPath: /hive-config
         - name: hive-scripts
           mountPath: /hive-scripts
-{{- if .Values.presto.spec.hive.config.useHdfsConfigMap }}
-        - name: hdfs-config
+{{- if .Values.presto.spec.hive.config.useHadoopConfigMap }}
+        - name: hadoop-config
           mountPath: /hadoop-config
 {{- end }}
         - name: hive-jmx-config
@@ -117,10 +117,6 @@ spec:
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
         - name: hive-warehouse-data
           mountPath: {{ .Values.presto.spec.config.sharedVolume.mountPath }}
-{{- end }}
-{{- if or (not .Values.presto.spec.config.sharedVolume.enabled) (and .Values.presto.spec.config.sharedVolume.enabled (ne .Values.presto.spec.config.sharedVolume.mountPath "/user/hive/warehouse") ) }}
-        - name: hive-warehouse-empty
-          mountPath: /user/hive/warehouse
 {{- end }}
         resources:
 {{ toYaml .Values.presto.spec.hive.metastore.resources | indent 10 }}
@@ -140,18 +136,16 @@ spec:
         configMap:
           name: hive-scripts
           defaultMode: 0555
-{{- if .Values.presto.spec.hive.config.useHdfsConfigMap }}
-      - name: hdfs-config
+{{- if .Values.presto.spec.hive.config.useHadoopConfigMap }}
+      - name: hadoop-config
         configMap:
-          name: {{ .Values.presto.spec.hive.config.hdfsConfigMapName }}
+          name: {{ .Values.presto.spec.hive.config.hadoopConfigMapName }}
 {{- end }}
       - name: hive-jmx-config
         configMap:
           name: hive-jmx-config
       # these emptyDir volumes are necessary because Openshift requires VOLUMEs
       # in a Dockerfile have a corresponding volumeMount
-      - name: hive-warehouse-empty
-        emptyDir: {}
       - name: namenode-empty
         emptyDir: {}
       - name: datanode-empty
@@ -168,5 +162,5 @@ spec:
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
-          claimName: {{ .Values.presto.spec.config.sharedVolume.persistentVolumeClaimName }}
+          claimName: {{ .Values.presto.spec.config.sharedVolume.claimName }}
 {{- end}}

--- a/charts/openshift-metering/templates/presto/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/hive-server-statefulset.yaml
@@ -103,8 +103,8 @@ spec:
           mountPath: /hive-config
         - name: hive-scripts
           mountPath: /hive-scripts
-{{- if .Values.presto.spec.hive.config.useHdfsConfigMap }}
-        - name: hdfs-config
+{{- if .Values.presto.spec.hive.config.useHadoopConfigMap }}
+        - name: hadoop-config
           mountPath: /hadoop-config
 {{- end}}
         - name: hive-jmx-config
@@ -121,10 +121,6 @@ spec:
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
         - name: hive-warehouse-data
           mountPath: {{ .Values.presto.spec.config.sharedVolume.mountPath }}
-{{- end }}
-{{- if or (not .Values.presto.spec.config.sharedVolume.enabled) (and .Values.presto.spec.config.sharedVolume.enabled (ne .Values.presto.spec.config.sharedVolume.mountPath "/user/hive/warehouse") ) }}
-        - name: hive-warehouse-empty
-          mountPath: /user/hive/warehouse
 {{- end }}
         resources:
 {{ toYaml .Values.presto.spec.hive.server.resources | indent 10 }}
@@ -144,18 +140,16 @@ spec:
         configMap:
           name: hive-scripts
           defaultMode: 0555
-{{- if .Values.presto.spec.hive.config.useHdfsConfigMap }}
-      - name: hdfs-config
+{{- if .Values.presto.spec.hive.config.useHadoopConfigMap }}
+      - name: hadoop-config
         configMap:
-          name: {{ .Values.presto.spec.hive.config.hdfsConfigMapName }}
+          name: {{ .Values.presto.spec.hive.config.hadoopConfigMapName }}
 {{- end }}
       - name: hive-jmx-config
         configMap:
           name: hive-jmx-config
       # these emptyDir volumes are necessary because Openshift requires VOLUMEs
       # in a Dockerfile have a corresponding volumeMount
-      - name: hive-warehouse-empty
-        emptyDir: {}
       - name: namenode-empty
         emptyDir: {}
       - name: datanode-empty
@@ -167,5 +161,5 @@ spec:
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
-          claimName: {{ .Values.presto.spec.config.sharedVolume.persistentVolumeClaimName }}
+          claimName: {{ .Values.presto.spec.config.sharedVolume.claimName }}
 {{- end}}

--- a/charts/openshift-metering/templates/presto/hive-shared-volume-pvc.yaml
+++ b/charts/openshift-metering/templates/presto/hive-shared-volume-pvc.yaml
@@ -1,15 +1,15 @@
 {{- if and .Values.presto.spec.config.sharedVolume.enabled .Values.presto.spec.config.sharedVolume.createPVC }}
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
-  name: hive-warehouse-data
+  name: {{ .Values.presto.spec.config.sharedVolume.claimName }}
 spec:
   accessModes:
   - ReadWriteMany
-{{- if .Values.presto.spec.config.sharedVolume.storage.persistentVolumeClaimStorageClass }}
-  storageClassName: {{ .Values.presto.spec.config.sharedVolume.storage.persistentVolumeClaimStorageClass }}
+{{- if .Values.presto.spec.config.sharedVolume.storageClass }}
+  storageClassName: {{ .Values.presto.spec.config.sharedVolume.storageClass }}
 {{- end }}
   resources:
     requests:
-      storage: {{ .Values.presto.spec.config.sharedVolume.storage.persistentVolumeClaimSize }}
+      storage: {{ .Values.presto.spec.config.sharedVolume.size }}
 {{- end }}

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -175,7 +175,7 @@ spec:
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
-          claimName: {{ .Values.presto.spec.config.sharedVolume.persistentVolumeClaimName }}
+          claimName: {{ .Values.presto.spec.config.sharedVolume.claimName }}
 {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -175,7 +175,7 @@ spec:
 {{- if .Values.presto.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data
         persistentVolumeClaim:
-          claimName: {{ .Values.presto.spec.config.sharedVolume.persistentVolumeClaimName }}
+          claimName: {{ .Values.presto.spec.config.sharedVolume.claimName }}
 {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-aws-credentials-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-aws-credentials-secrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: reporting-operator-aws-credentials-secrets
+  name: reporting-operator-aws-credentials
   labels:
     app: reporting-operator
 type: Opaque

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -74,18 +74,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+{{- if or $operatorValues.spec.config.awsCredentialsSecretName $operatorValues.spec.config.createAwsCredentialsSecret }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              name: "{{ $operatorValues.spec.config.awsCredentialsSecretName }}"
+              name: "{{ $operatorValues.spec.config.awsCredentialsSecretName | default "reporting-operator-aws-credentials" }}"
               key: aws-access-key-id
-              optional: true
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: "{{ $operatorValues.spec.config.awsCredentialsSecretName }}"
+              name: "{{ $operatorValues.spec.config.awsCredentialsSecretName | default "reporting-operator-aws-credentials" }}"
               key: aws-secret-access-key
-              optional: true
+{{- end }}
         - name: REPORTING_OPERATOR_LOG_LEVEL
           valueFrom:
             configMapKeyRef:

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -1,14 +1,34 @@
 global:
   ownerReferences: []
 
-defaultStorage:
-  create: true
-  hive:
-    databaseName: default
-    unmanagedDatabase: true
-  isDefault: true
-  name: hive
-  type: hive
+unsupportedFeatures:
+  enableHDFS: false
+
+storage:
+  type: "hive"
+  hive: {}
+
+  # Below is an example of what configuring storage could look like:
+  #
+  # hive:
+  #   type: "hdfs"
+  #   hdfs:
+  #     namenode: "hdfs-namenode-0.hdfs-namenode:9820"
+
+  # hive:
+  #   type: "s3"
+  #   s3:
+  #     bucket: "bucketname/path/"
+  #     awsCredentialsSecretName: "my-aws-secret"
+
+  # hive:
+  #   type: "sharedPVC"
+  #   sharedPVC:
+  #     claimName: "metering-nfs"
+  #     createPVC: true
+  #     storageClass: null
+  #     size: 5Gi
+  #     mountPath: "/"
 
 permissions:
   meteringAdmins: []
@@ -25,8 +45,19 @@ monitoring:
 openshift-reporting:
   enabled: true
   spec:
+    defaultStorageLocation:
+      create: true
+      isDefault: true
+      name: hive
+      type: hive
+      hive:
+        databaseName: metering
+        unmanagedDatabase: false
+        location: ""
+
     awsBillingReportDataSource:
       enabled: false
+
     defaultReportDataSources:
       cluster-cpu-capacity-raw:
         spec:
@@ -209,9 +240,9 @@ reporting-operator:
     config:
       allNamespaces: false
       awsAccessKeyID: ""
-      awsCredentialsSecretName: reporting-operator-aws-credentials-secrets
+      awsCredentialsSecretName: ""
       awsSecretAccessKey: ""
-      createAwsCredentialsSecret: true
+      createAwsCredentialsSecret: false
       createClusterMonitoringViewRBAC: true
       disablePrometheusMetricsImporter: "false"
       enableFinalizers: "false"
@@ -321,17 +352,19 @@ presto:
   spec:
     config:
       awsAccessKeyID: ""
-      awsCredentialsSecretName: presto-aws-credentials
+      awsCredentialsSecretName: ""
       awsSecretAccessKey: ""
-      createAwsCredentialsSecret: true
+      createAwsCredentialsSecret: false
+
       sharedVolume:
-        createPVC: true
         enabled: false
         mountPath: /user/hive/warehouse
-        persistentVolumeClaimName: hive-warehouse-data
-        storage:
-          persistentVolumeClaimSize: 5Gi
-          persistentVolumeClaimStorageClass: null
+
+        createPVC: false
+        claimName: hive-warehouse-data
+        size: 5Gi
+        storageClass: null
+
     hive:
       annotations: {}
       config:
@@ -342,13 +375,12 @@ presto:
         dbConnectionUsername: null
         defaultCompression: zlib
         defaultFileFormat: orc
-        defaultfs: null
         enableMetastoreSchemaVerification: false
         metastoreClientSocketTimeout: null
         metastoreURIs: thrift://hive-metastore:9083
-        metastoreWarehouseDir: hdfs://hdfs-namenode-0.hdfs-namenode:9820/operator_metering/default_hive_warehouse/
-        hdfsConfigMapName: hadoop-config
-        useHdfsConfigMap: true
+        metastoreWarehouseDir: null
+        hadoopConfigMapName: hadoop-config
+        useHadoopConfigMap: true
       image:
         pullPolicy: Always
         repository: quay.io/openshift/origin-metering-hive
@@ -572,7 +604,7 @@ hadoop:
       pullSecrets: null
 
     hdfs:
-      enabled: true
+      enabled: false
       config:
         datanodeDataDirPerms: "775"
         replicationFactor: 3

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -7,6 +7,9 @@ meteringconfig_prune_namespace_label_key: 'metering.openshift.io/ns-prune'
 meteringconfig_default_values_file: "{{ meteringconfig_chart_path + '/values.yaml' }}"
 meteringconfig_default_values: "{{ lookup('file', meteringconfig_default_values_file) | from_yaml }}"
 
+# contains the users overrides
+meteringconfig_spec_overrides: "{{ _metering_openshift_io_meteringconfig.spec }}"
+
 # The default specs for each component
 _presto_default_spec: "{{ meteringconfig_default_values.presto.spec }}"
 _reporting_op_default_spec: "{{ meteringconfig_default_values['reporting-operator'].spec }}"
@@ -45,20 +48,75 @@ meteringconfig_default_image_overrides:
         repository: "{{ lookup('env','METERING_HADOOP_IMAGE').split(':')[0] | default(meteringconfig_hadoop_default_image_repo, true) }}"
         tag: "{{ lookup('env','METERING_HADOOP_IMAGE').split(':')[1] | default(meteringconfig_hadoop_default_image_tag, true) }}"
 
-# meteringconfig_spec_with_defaults comes first so that user's meteringconfig spec overrides defaults if the user specifies any image overrides.
-meteringconfig_spec: "{{ meteringconfig_default_image_overrides | combine(_metering_openshift_io_meteringconfig.spec , recursive=True) }}"
+_storage_overrides:
+  s3:
+    reporting-operator:
+      spec:
+        config:
+          awsCredentialsSecretName: "{{ meteringconfig_spec_overrides | json_query('storage.hive.s3.awsCredentialsSecretName') }}"
+          createAwsCredentialsSecret: false
+    presto:
+      spec:
+        config:
+          awsCredentialsSecretName: "{{ meteringconfig_spec_overrides | json_query('storage.hive.s3.awsCredentialsSecretName') }}"
+          createAwsCredentialsSecret: false
+        hive:
+          config:
+            metastoreWarehouseDir: "s3a://{{ meteringconfig_spec_overrides | json_query('storage.hive.s3.bucket') }}"
+    hadoop:
+      spec:
+        config:
+          defaultFS: "s3a://{{ meteringconfig_spec_overrides | json_query('storage.hive.s3.bucket') }}"
+        hdfs:
+          enabled: false
 
-# We need the combined user input + defaults so we can determine what resources/components are enabled/disabled after merging
-meteringconfig_spec_with_defaults: "{{ meteringconfig_default_values | combine(meteringconfig_spec, recursive=True) }}"
+  hdfs:
+    hadoop:
+      spec:
+        config:
+          defaultFS: "hdfs://{{ meteringconfig_spec_overrides | json_query('storage.hive.hdfs.namenode') | default('hdfs-namenode-0.hdfs-namenode:9820', true) }}"
+        hdfs:
+          enabled: "{{ meteringconfig_spec_overrides | json_query('unsupportedFeatures.enableHDFS') | default(false, true) }}"
+
+  sharedPVC:
+    presto:
+      spec:
+        config:
+          sharedVolume:
+            enabled: true
+            createPVC: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.createPVC') | default(false, true) }}"
+            mountPath: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
+            claimName: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.claimName') | default(_presto_default_spec.config.sharedVolume.claimName, true) }}"
+            size: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.size') | default(_presto_default_spec.config.sharedVolume.size, true) }}"
+            storageClass: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.storageClass') | default(_presto_default_spec.config.sharedVolume.storageClass, true) }}"
+        hive:
+          config:
+            metastoreWarehouseDir: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
+
+    hadoop:
+      spec:
+        config:
+          defaultFS: "file://{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
+        hdfs:
+          enabled: false
+
+
+meteringconfig_storage_overrides: "{{ _storage_overrides[meteringconfig_default_values | combine(meteringconfig_spec_overrides) | json_query('storage.hive.type')] | default({}, true) }}"
+
+meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_spec_overrides, recursive=True) }}"
+
+########################
+# All Variables below are setup to consume the result of merging the defaults, internal overrides, and user overrides.
+########################
 
 # Private variables to reduce boilerplate
-_monitoring_conf: "{{ meteringconfig_spec_with_defaults.monitoring }}"
-_openshift_reporting_spec: "{{ meteringconfig_spec_with_defaults['openshift-reporting'].spec }}"
-_presto_spec: "{{ meteringconfig_spec_with_defaults.presto.spec }}"
-_reporting_op_spec: "{{ meteringconfig_spec_with_defaults['reporting-operator'].spec }}"
-_hadoop_spec: "{{ meteringconfig_spec_with_defaults.hadoop.spec }}"
+_monitoring_conf: "{{ meteringconfig_spec.monitoring }}"
+_openshift_reporting_spec: "{{ meteringconfig_spec['openshift-reporting'].spec }}"
+_presto_spec: "{{ meteringconfig_spec.presto.spec }}"
+_reporting_op_spec: "{{ meteringconfig_spec['reporting-operator'].spec }}"
+_hadoop_spec: "{{ meteringconfig_spec.hadoop.spec }}"
 
-meteringconfig_create_metering_default_storage: "{{ meteringconfig_spec_with_defaults.defaultStorage.create | default(true) }}"
+meteringconfig_create_metering_default_storage: "{{ _openshift_reporting_spec.defaultStorageLocation.create | default(true) }}"
 
 meteringconfig_create_metering_monitoring_resources: "{{ _monitoring_conf.enabled | default(true) }}"
 meteringconfig_create_metering_monitoring_rbac: "{{ _monitoring_conf.enabled and _monitoring_conf.enabled and _monitoring_conf.createRBAC | default(true) }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/main.yml
@@ -6,9 +6,9 @@
   loop: "{{ vars | dict2items | to_json | from_json | json_query(query) | difference(filtered_vars) }}"
   vars:
     filtered_vars:
-      - meteringconfig_default_values
       - meteringconfig_spec
-      - meteringconfig_spec_with_defaults
+      - meteringconfig_spec_overrides
+      - meteringconfig_default_values
     query: "[?starts_with(@.key, `meteringconfig_`)].key"
 
 - include_tasks: reconcile.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -1,5 +1,17 @@
 ---
 
+- name: Validate storage configuration
+  fail:
+    msg: "Unsupported spec.storage.type, only 'hive' is  a supported option"
+  when: meteringconfig_spec | json_query('storage.type') != "hive"
+
+- name: Validate Hive storage configuration
+  fail:
+    msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of 's3', or 'sharedPVC'"
+  vars:
+    hiveStorageType: "{{ meteringconfig_spec_overrides | json_query('storage.hive.type') }}"
+  when: hiveStorageType is undefined or hiveStorageType not in ['s3', 'sharedPVC', 'hdfs']
+
 - name: Store MeteringConfig spec into values file
   copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
@@ -5,6 +5,11 @@
   vars:
     values_file: /tmp/metering-values.yaml
     resources:
+      - template_file: templates/hadoop/hadoop-configmap.yaml
+        apis: [ {kind: configmap} ]
+        prune_label_value: hadoop-configmap
+        # always create the hadoop-configmap
+        create: true
       - template_file: templates/hadoop/hadoop-aws-credentials.yaml
         apis: [ {kind: secret} ]
         prune_label_value: hadoop-aws-credentials
@@ -16,10 +21,6 @@
       - template_file: templates/hadoop/hdfs-jmx-config.yaml
         apis: [ {kind: configmap} ]
         prune_label_value: hdfs-jmx-config
-        create: "{{ meteringconfig_enable_hdfs }}"
-      - template_file: templates/hadoop/hadoop-configmap.yaml
-        apis: [ {kind: configmap} ]
-        prune_label_value: hadoop-configmap
         create: "{{ meteringconfig_enable_hdfs }}"
       - template_file: templates/hadoop/hdfs-serviceaccount.yaml
         apis: [ {kind: serviceaccount} ]

--- a/manifests/metering-config/default.yaml
+++ b/manifests/metering-config/default.yaml
@@ -2,4 +2,11 @@ apiVersion: metering.openshift.io/v1alpha1
 kind: MeteringConfig
 metadata:
   name: "operator-metering"
-spec: {}
+spec:
+  storage:
+    type: hive
+    # hive:
+    #   type: "s3"
+    #   s3:
+    #     bucket: "bucketname/path/"
+    #     awsCredentialsSecretName: "my-aws-secret"

--- a/manifests/metering-config/hdfs-storage.yaml
+++ b/manifests/metering-config/hdfs-storage.yaml
@@ -1,0 +1,30 @@
+apiVersion: metering.openshift.io/v1alpha1
+kind: MeteringConfig
+metadata:
+  name: "operator-metering"
+spec:
+  unsupportedFeatures:
+    enableHDFS: true
+
+  storage:
+    type: "hive"
+    hive:
+      type: "hdfs"
+      hdfs:
+        # Leave this value as-is.
+        namenode: "hdfs-namenode-0.hdfs-namenode:9820"
+
+  hdfs:
+    spec:
+      datanode:
+        storage:
+          # Default is null, which means using the default storage class if it exists.
+          # If you wish to use a different storage class, specify it here
+          class: null
+          # class: "fast-ssd"
+          size: "5Gi"
+      namenode:
+        storage:
+          class: null
+          # class: "fast-ssd"
+          size: "5Gi"

--- a/manifests/metering-config/metastore-storage.yaml
+++ b/manifests/metering-config/metastore-storage.yaml
@@ -13,17 +13,3 @@ spec:
             class: null
             # class: "fast-ssd"
             size: "5Gi"
-  hdfs:
-    spec:
-      datanode:
-        storage:
-          # Default is null, which means using the default storage class if it exists.
-          # If you wish to use a different storage class, specify it here
-          class: null
-          # class: "fast-ssd"
-          size: "5Gi"
-      namenode:
-        storage:
-          class: null
-          # class: "fast-ssd"
-          size: "5Gi"

--- a/manifests/metering-config/s3-storage.yaml
+++ b/manifests/metering-config/s3-storage.yaml
@@ -3,43 +3,10 @@ kind: MeteringConfig
 metadata:
   name: "operator-metering"
 spec:
-  # If you want to use S3 for storage of reports, and collected metrics, edit
-  # the hive metastoreWarehouseDir below, and set awsAccessKeyID and
-  # awsSecretAccessKey for reporting-operator and presto
-
-  defaultStorage:
+  storage:
     type: "hive"
     hive:
-      # unmanagedDatabase false indicates that this should be created by
-      # reporting-operator
-      unmanagedDatabase: false
-      # feel free to adjust the database name  and location
-      databaseName: "metering-s3"
-      # s3a:// must be used
-      location: "s3a://bucketName/pathInBucket"
-
-  reporting-operator:
-    spec:
-      config:
-        # Replace these with your own AWS credentials
-        awsAccessKeyID: "REPLACEME"
-        awsSecretAccessKey: "REPLACEME"
-
-  presto:
-    spec:
-      config:
-        # Replace these with your own AWS credentials
-        awsAccessKeyID: "REPLACEME"
-        awsSecretAccessKey: "REPLACEME"
-      hive:
-        config:
-          # set to false when spec.hadoop.spec.hdfs.enabled is false
-          useHdfsConfigMap: false
-          # Replace this with your bucket
-          metastoreWarehouseDir: "s3a://bucketName/pathInBucket"
-
-  hadoop:
-    spec:
-      hdfs:
-        # disable HDFS components when using S3 to avoid wasting resources.
-        enabled: false
+      type: "s3"
+      s3:
+        bucket: "bucketname/path/"
+        awsCredentialsSecretName: "my-aws-secret"

--- a/manifests/metering-config/shared-storage.yaml
+++ b/manifests/metering-config/shared-storage.yaml
@@ -3,34 +3,13 @@ kind: MeteringConfig
 metadata:
   name: "operator-metering"
 spec:
-  defaultStorage:
-    type: "hive"
+  storage:
     hive:
-      # instructs reporting-operator to create a new database in Hive
-      unmanagedDatabase: false
-      # feel free to adjust the database name  and location
-      databaseName: "metering-nfs"
-      location: "/user/hive/warehouse"
-
-  presto:
-    spec:
-      config:
-        sharedVolume:
-          enabled: true
-          storage:
-            # change REPLACEME to the name of your PVC
-            persistentVolumeClaimStorageClass: REPLACEME
-            # mountPath must match the value of the location specified above.
-            mountPath: "/user/hive/warehouse"
-      hive:
-        config:
-          # set to false when spec.hadoop.spec.hdfs.enabled is false
-          useHdfsConfigMap: false
-          # Replace this with your path
-          metastoreWarehouseDir: "/user/hive/warehouse"
-
-  hadoop:
-    spec:
-      hdfs:
-        # disable HDFS components when using S3 to avoid wasting resources.
-        enabled: false
+      type: "sharedPVC"
+      sharedPVC:
+        claimName: "metering-nfs"
+        # uncomment the lines below to provision a new PVC using the specified
+        # storageClass.
+        # createPVC: true
+        # storageClass: "my-nfs-storage-class"
+        # size: 5Gi

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -259,7 +259,7 @@ func TestMain(m *testing.M) {
 func TestReportingProducesCorrectDataForInput(t *testing.T) {
 	var queries []string
 	t.Logf("Waiting for ReportDataSources tables to be created")
-	_, err := testFramework.WaitForAllMeteringReportDataSourceTables(t, time.Second*5, 2*time.Minute)
+	_, err := testFramework.WaitForAllMeteringReportDataSourceTables(t, time.Second*5, 5*time.Minute)
 	require.NoError(t, err, "should not error when waiting for all ReportDataSource tables to be created")
 
 	for _, test := range testReportsProduceCorrectDataForInputTestCases {
@@ -269,7 +269,7 @@ func TestReportingProducesCorrectDataForInput(t *testing.T) {
 	// validate all ReportQueries and ReportDataSources that are
 	// used by the test cases are initialized
 	t.Logf("Waiting for ReportQueries tables to become ready")
-	testFramework.RequireReportQueriesReady(t, queries, time.Second*5, 2*time.Minute)
+	testFramework.RequireReportQueriesReady(t, queries, time.Second*5, 5*time.Minute)
 
 	var reportStart, reportEnd time.Time
 	dataSourcesSubmitted := make(map[string]struct{})
@@ -280,7 +280,7 @@ func TestReportingProducesCorrectDataForInput(t *testing.T) {
 		for _, dataSource := range test.dataSources {
 			if _, alreadySubmitted := dataSourcesSubmitted[dataSource.DatasourceName]; !alreadySubmitted {
 				// wait for the datasource table to exist
-				_, err := testFramework.WaitForMeteringReportDataSourceTable(t, dataSource.DatasourceName, time.Second*5, time.Minute)
+				_, err := testFramework.WaitForMeteringReportDataSourceTable(t, dataSource.DatasourceName, time.Second*5, 2*time.Minute)
 				require.NoError(t, err, "ReportDataSource table should exist before storing data into it")
 
 				metricsFile, err := os.Open(dataSource.FileName)


### PR DESCRIPTION
- Add new top-level storage config under spec.storage to centralize
  storage related configuration.
- openshift-reporting: move storageLocation into
  openshift-reporting.spec and rename to defaultStorageLocation. This
  move is to aligns with the new top-level storage option so that there
  isn't confusion between the two.
- hive: Don't create shared-pvc by default and stop creating empty
  warehouse volume. This has been removed from the hive image, and only
  makes it possible to start hive without storage which isn't wanted.
- *: Don't create awsCredentialsSecrets by default and don't make
  optional env var. Ensures that when the secret is missing that pods do
  not start.
- Rename hdfs-config to hadoop-config to generalize it more.
- Update installation documentation and configuration documentation to
  explicitly mention that storage is no longer configured by default,
  and that HDFS is an unsupported, developer only storage option.

Currently CI is still configured to use HDFS since we have no easily available alternative.