### PR TITLE
roles/meteringconfig: Move namespace into separate label to shorten prune label value length

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -2,6 +2,7 @@
 
 meteringconfig_chart_path: "{{ lookup('env','HELM_CHART_PATH') }}"
 meteringconfig_prune_label_key: 'metering.openshift.io/prune'
+meteringconfig_prune_namespace_label_key: 'metering.openshift.io/ns-prune'
 
 meteringconfig_default_values_file: "{{ meteringconfig_chart_path + '/values.yaml' }}"
 meteringconfig_default_values: "{{ lookup('file', meteringconfig_default_values_file) | from_yaml }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
@@ -26,7 +26,7 @@
     # Finally, once we have a list of resources, use map to run
     # the combine function on each resource, which adds the prune label to
     # each item in the list, storing the result in new_resources
-    new_resources: "{{ template_result.stdout | from_yaml_all | list | difference([None]) | map('combine', {'metadata':{'labels':{meteringconfig_prune_label_key: resource.prune_label_value}}}, recursive=True) | list }}"
+    new_resources: "{{ template_result.stdout | from_yaml_all | list | difference([None]) | map('combine', {'metadata':{'labels':{meteringconfig_prune_label_key: resource.prune_label_value, meteringconfig_prune_namespace_label_key: meta.namespace}}}, recursive=True) | list }}"
   set_fact:
     # Create a new variable to contain the updated resources with prune
     # labels, and append the updated resources to it each iteration of this

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -9,7 +9,7 @@
   loop_control:
     loop_var: to_delete_item
   vars:
-    label_selector: "{{ meteringconfig_prune_label_key }}={{ resource.prune_label_value }}"
+    label_selector: "{{ meteringconfig_prune_label_key }}={{ resource.prune_label_value }},{{ meteringconfig_prune_namespace_label_key }}={{ namespace }}"
   register: to_delete
 
 - name: Delete {{ resource.apis | map(attribute='kind') | join(', ') }} resources with selector {{ label_selector}}

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
@@ -19,7 +19,7 @@
         create: "{{ meteringconfig_create_reporting_operator_auth_proxy_htpasswd_secret }}"
       - template_file: templates/reporting-operator/reporting-operator-auth-proxy-rbac.yaml
         apis: [ {kind: clusterrole, api_version: 'rbac.authorization.k8s.io/v1'}, {kind: clusterrolebinding, api_version: 'rbac.authorization.k8s.io/v1'} ]
-        prune_label_value: "{{ meta.namespace }}-reporting-operator-auth-proxy-rbac"
+        prune_label_value: "reporting-operator-auth-proxy-rbac"
         create: "{{ meteringconfig_create_reporting_operator_auth_proxy_rbac }}"
       - template_file: templates/reporting-operator/reporting-operator-prometheus-bearer-token-secrets.yaml
         apis: [ {kind: secrets} ]
@@ -38,7 +38,7 @@
         prune_label_value: reporting-operator-rbac
       - template_file: templates/reporting-operator/reporting-operator-cluster-monitoring-view-rbac.yaml
         apis: [ {kind: clusterrole, api_version: 'rbac.authorization.k8s.io/v1'}, {kind: clusterrolebinding, api_version: 'rbac.authorization.k8s.io/v1'} ]
-        prune_label_value: "{{ meta.namespace }}-cluster-monitoring-view-rbac"
+        prune_label_value: "cluster-monitoring-view-rbac"
         create: "{{ meteringconfig_create_reporting_operator_cluster_monitoring_view_rbac }}"
       - template_file: templates/reporting-operator/reporting-operator-config.yaml
         apis: [ {kind: config} ]


### PR DESCRIPTION
Currently as it is, sometimes labels are too long when combined with the namespace.