### PR TITLE
charts/openshift-metering: Update the annotations used in the Presto coordinator/worker statefulsets to use the secret template hashes.

### DIFF
--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -28,6 +28,12 @@ spec:
         presto-common-config-hash: {{ include (print $.Template.BasePath "/presto/presto-common-config.yaml") . | sha256sum }}
         presto-catalog-config-hash: {{ include (print $.Template.BasePath "/presto/presto-catalog-config-secret.yaml") . | sha256sum }}
         presto-jmx-config-hash: {{ include (print $.Template.BasePath "/presto/presto-jmx-config.yaml") . | sha256sum }}
+{{- if and .Values.presto.spec.presto.config.tls.enabled .Values.presto.spec.presto.config.tls.createSecret }}
+        presto-server-tls-hash: {{ include (print $.Template.BasePath "/presto/presto-tls-secrets.yaml") . | sha256sum }}
+{{- if and .Values.presto.spec.presto.config.auth.enabled .Values.presto.spec.presto.config.auth.createSecret}}
+        presto-client-tls-hash: {{ include (print $.Template.BasePath "/presto/presto-auth-secrets.yaml") . | sha256sum }}
+{{- end }}
+{{- end }}
 {{- if .Values.presto.spec.presto.annotations }}
 {{ toYaml .Values.presto.spec.presto.annotations | indent 8 }}
 {{- end }}

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -28,6 +28,12 @@ spec:
         presto-common-config-hash: {{ include (print $.Template.BasePath "/presto/presto-common-config.yaml") . | sha256sum }}
         presto-catalog-config-hash: {{ include (print $.Template.BasePath "/presto/presto-catalog-config-secret.yaml") . | sha256sum }}
         presto-jmx-config-hash: {{ include (print $.Template.BasePath "/presto/presto-jmx-config.yaml") . | sha256sum }}
+{{- if and .Values.presto.spec.presto.config.tls.enabled .Values.presto.spec.presto.config.tls.createSecret }}
+        presto-server-tls-hash: {{ include (print $.Template.BasePath "/presto/presto-tls-secrets.yaml") . | sha256sum }}
+{{- if and .Values.presto.spec.presto.config.auth.enabled .Values.presto.spec.presto.config.auth.createSecret}}
+        presto-client-tls-hash: {{ include (print $.Template.BasePath "/presto/presto-auth-secrets.yaml") . | sha256sum }}
+{{- end }}
+{{- end }}
 {{- if .Values.presto.spec.presto.annotations }}
 {{ toYaml .Values.presto.spec.presto.annotations | indent 8 }}
 {{- end }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -36,7 +36,10 @@ spec:
         reporting-operator-tls-secrets-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-tls-secrets.yaml") . | sha256sum }}
 {{- end }}
 {{- if and $operatorValues.spec.config.prestoTLS.enabled $operatorValues.spec.config.prestoTLS.createSecret }}
-        reporting-operator-presto-tls-secrets-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-presto-tls-secrets.yaml") . | sha256sum }}
+        reporting-operator-presto-server-tls-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-presto-tls-secrets.yaml") . | sha256sum }}
+{{- end }}
+{{- if and $operatorValues.spec.config.prestoAuth.enabled $operatorValues.spec.config.prestoAuth.createSecret }}
+        reporting-operator-presto-client-tls-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-presto-auth-secrets.yaml") . | sha256sum }}
 {{- end }}
 {{- if and $operatorValues.spec.authProxy.enabled $operatorValues.spec.authProxy.createCookieSecret }}
         reporting-operator-auth-proxy-cookie-secrets-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-auth-proxy-cookie-secret.yaml") . | sha256sum }}


### PR DESCRIPTION
This was left out after we made the switch from deployments to statefulsets.