### PR TITLE
Enable TLS and client-side authentication in Presto and reporting-operator by default.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -23,6 +23,7 @@ RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 
 RUN pip install --no-cache-dir --upgrade openshift
 RUN pip install boto3
+RUN pip install pyOpenSSL
 
 USER 1001
 ENV HOME /opt/ansible

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -17,6 +17,7 @@ COPY --from=cli /usr/bin/oc /usr/bin/oc
 RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 
 RUN yum -y update python-openshift
+RUN yum install pyOpenSSL
 
 USER 1001
 ENV HOME /opt/ansible

--- a/charts/metering-ci/templates/metering.yaml
+++ b/charts/metering-ci/templates/metering.yaml
@@ -9,6 +9,9 @@ spec:
   unsupportedFeatures:
     enableHDFS: true
 
+  tls:
+    enabled: true
+
   storage:
     type: "hive"
     hive:

--- a/charts/openshift-metering/templates/presto/presto-auth-secrets.yaml
+++ b/charts/openshift-metering/templates/presto/presto-auth-secrets.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ .Values.presto.spec.presto.config.auth.secretName }}
   labels:
     app: presto
-type: kubernetes.io/tls
+type: Opaque
 data:
   tls.crt: {{ .Values.presto.spec.presto.config.auth.certificate | b64enc | quote }}
   tls.key: {{ .Values.presto.spec.presto.config.auth.key | b64enc | quote }}
-  ca.crt: {{.Values.presto.spec.presto.config.auth.caCertificate | b64enc | quote }}
+  ca.crt: {{ .Values.presto.spec.presto.config.auth.caCertificate | b64enc | quote }}
 {{- end -}}

--- a/charts/openshift-metering/templates/presto/presto-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/presto/presto-tls-secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.presto.spec.presto.config.tls.secretName }}
   labels:
     app: presto
-type: kubernetes.io/tls
+type: Opaque
 data:
   tls.crt: {{ .Values.presto.spec.presto.config.tls.certificate | b64enc | quote }}
   tls.key: {{ .Values.presto.spec.presto.config.tls.key | b64enc | quote }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-auth-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-auth-secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ $operatorValues.spec.config.prestoAuth.secretName }}
   labels:
     app: reporting-operator
-type: kubernetes.io/tls
+type: Opaque
 data:
   tls.crt: {{ $operatorValues.spec.config.prestoAuth.certificate | b64enc | quote }}
   tls.key: {{ $operatorValues.spec.config.prestoAuth.key | b64enc | quote }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-tls-secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ $operatorValues.spec.config.tls.secretName }}
   labels:
     app: reporting-operator
-type: kubernetes.io/tls
+type: Opaque
 data:
   tls.crt: {{ $operatorValues.spec.config.tls.certificateData | b64enc | quote }}
   tls.key: {{ $operatorValues.spec.config.tls.privateKeyData | b64enc | quote }}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -30,6 +30,9 @@ storage:
   #     size: 5Gi
   #     mountPath: "/"
 
+tls:
+  enabled: false
+
 permissions:
   meteringAdmins: []
   meteringViewers: []

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -104,7 +104,70 @@ _storage_overrides:
 meteringconfig_storage_hive_storage_type: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides, recursive=True) | json_query('storage.hive.type') }}"
 meteringconfig_storage_overrides: "{{ _storage_overrides[meteringconfig_storage_hive_storage_type] | default({}, true) }}"
 
-meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_spec_overrides, recursive=True) }}"
+#
+# Override the default values with _tls_overrides when spec.tls.enabled is set to true, else use values.yaml and meteringconfig_spec_overrides
+#
+meteringconfig_reporting_operator_presto_server_ca_certificate: ""
+meteringconfig_reporting_operator_presto_server_secret_name: "reporting-operator-presto-server-tls"
+
+meteringconfig_reporting_operator_presto_client_secret_name: "reporting-operator-presto-client-tls"
+meteringconfig_reporting_operator_client_cert: ""
+meteringconfig_reporting_operator_presto_client_ca_certificate: ""
+meteringconfig_reporting_operator_client_key: ""
+
+meteringconfig_presto_server_secret_name: "presto-server-tls"
+meteringconfig_presto_server_ca_certificate: ""
+meteringconfig_presto_server_certificate: ""
+meteringconfig_presto_server_key: ""
+
+meteringconfig_presto_client_secret_name: "presto-client-tls"
+meteringconfig_presto_client_ca_certificate: ""
+meteringconfig_presto_client_certificate: ""
+meteringconfig_presto_client_key: ""
+
+_tls_overrides:
+  reporting-operator:
+    spec:
+      config:
+        prestoTLS:
+          enabled: true
+          createSecret: true
+          secretName: "{{ meteringconfig_reporting_operator_presto_server_secret_name }}"
+          caCertificate: "{{ meteringconfig_reporting_operator_presto_server_ca_certificate }}"
+
+        prestoAuth:
+          enabled: true
+          createSecret: true
+          secretName: "{{ meteringconfig_reporting_operator_presto_client_secret_name }}"
+          certificate: "{{ meteringconfig_reporting_operator_client_cert }}"
+          key: "{{ meteringconfig_reporting_operator_client_key }}"
+          caCertificate: "{{ meteringconfig_reporting_operator_presto_client_ca_certificate }}"
+  presto:
+    spec:
+      presto:
+        config:
+          tls:
+            certificate: "{{  meteringconfig_presto_server_certificate }}"
+            key: "{{ meteringconfig_presto_server_key }}"
+            caCertificate: "{{ meteringconfig_presto_server_ca_certificate }}"
+
+            enabled: true
+            createSecret: true
+            secretName: "{{ meteringconfig_presto_server_secret_name }}"
+          auth:
+            certificate: "{{  meteringconfig_presto_client_certificate }}"
+            key: "{{ meteringconfig_presto_client_key }}"
+            caCertificate: "{{ meteringconfig_presto_client_ca_certificate }}"
+
+            enabled: true
+            createSecret: true
+            secretName: "{{ meteringconfig_presto_client_secret_name }}"
+
+# check if the user's spec contains the top-level tls.enabled field. if true, use the value stored in that field, else default to the value stored in values.yaml
+meteringconfig_tls_enabled: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides, recursive=True) | json_query('tls.enabled') }}"
+meteringconfig_tls_overrides: "{{ meteringconfig_tls_enabled | ternary(_tls_overrides, {}) }}"
+# combine the meteringconfig_tls_overrides dictionary last to enforce when spec.tls.enabled is specified and set to true
+meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_spec_overrides, meteringconfig_tls_overrides, recursive=True) }}"
 
 meteringconfig_storage_s3_create_bucket: "{{ meteringconfig_spec | json_query('storage.hive.s3.createBucket') | default(true, true) }}"
 # Intentionally an invalid default name to ensure that this is overridden, and obvious when it's not.
@@ -137,9 +200,18 @@ meteringconfig_create_hadoop_aws_credentials: "{{ _hadoop_spec.config.aws.create
 meteringconfig_create_hive_metastore_pvc: "{{ _presto_spec.hive.metastore.storage.create | default(true) }}"
 meteringconfig_create_presto_shared_volume_pvc: "{{ _presto_spec.config.sharedVolume.enabled and _presto_spec.config.sharedVolume.createPVC | default(false) }}"
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.createAwsCredentialsSecret | default(false) }}"
+
+#
+# Enabling Presto TLS/Auth by Default
+#
+meteringconfig_template_presto_tls_secret: "{{ _presto_spec.presto.config.tls.enabled and _presto_spec.presto.config.tls.createSecret and _presto_spec.presto.config.tls.secretName != 'presto-server-tls' }}"
+meteringconfig_template_presto_auth_secret: "{{ _presto_spec.presto.config.auth.enabled and _presto_spec.presto.config.auth.createSecret and _presto_spec.presto.config.auth.secretName != 'presto-client-tls' }}"
 meteringconfig_create_presto_tls_secrets: "{{ _presto_spec.presto.config.tls.enabled and _presto_spec.presto.config.tls.createSecret | default(false) }}"
 meteringconfig_create_presto_auth_secrets: "{{ _presto_spec.presto.config.auth.enabled and _presto_spec.presto.config.auth.createSecret | default(false) }}"
 
+#
+# Reporting Operator
+#
 meteringconfig_create_reporting_operator_auth_proxy_cookie_secret: "{{ _reporting_op_spec.authProxy.enabled and _reporting_op_spec.authProxy.createCookieSecret | default(true) }}"
 meteringconfig_create_reporting_operator_auth_proxy_htpasswd_secret: "{{ _reporting_op_spec.authProxy.enabled and _reporting_op_spec.authProxy.createHtpasswdSecret | default(true) }}"
 meteringconfig_create_reporting_operator_auth_proxy_authenticated_emails_secret: "{{ _reporting_op_spec.authProxy.enabled and _reporting_op_spec.authProxy.createAuthenticatedEmailsSecret | default(true) }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_openssl.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_openssl.yml
@@ -1,0 +1,100 @@
+---
+
+#
+# Generate a Root Certificate Authority
+#
+- name: Setup the root certificate authority
+  block:
+  - name: Generate a RSA private key for the CA
+    openssl_privatekey:
+      size: 2048
+      type: RSA
+      path: "{{ certificates_dir.path }}/ca.key"
+
+  - name: Generate a CSR for the CA
+    openssl_csr:
+      path: "{{ certificates_dir.path }}/ca.csr"
+      privatekey_path: "{{ certificates_dir.path }}/ca.key"
+      common_name: Presto Root CA
+      basicConstraints:
+      - 'CA:TRUE'
+      basicConstraints_critical: true
+
+  - name: Generate a certificate for the CA
+    openssl_certificate:
+      path: "{{ certificates_dir.path }}/ca.crt"
+      privatekey_path: "{{ certificates_dir.path }}/ca.key"
+      csr_path: "{{ certificates_dir.path }}/ca.csr"
+      provider: selfsigned
+      selfsigned_digest: sha256
+
+#
+# Generate a Server cert/key
+#
+- name: Setup the server certificate/key
+  block:
+  - name: Generate an RSA private key for Presto
+    openssl_privatekey:
+      size: 2048
+      type: RSA
+      path: "{{ certificates_dir.path }}/server.key"
+
+  - name: Generate the Presto server CSR
+    openssl_csr:
+      path: "{{ certificates_dir.path }}/server.csr"
+      privatekey_path: "{{ certificates_dir.path }}/server.key"
+      common_name: "*.presto-nodes"
+      subject_alt_name: "DNS:*.presto-nodes.{{ meta.namespace }}.svc.cluster.local,DNS:presto,DNS:*.presto-nodes"
+      basicConstraints:
+      - 'CA:FALSE'
+      basicConstraints_critical: false
+      key_usage:
+      - digitalSignature
+      - keyEncipherment
+      extended_key_usage:
+      - serverAuth
+
+  - name: Generate the Presto server certificate
+    openssl_certificate:
+      path: "{{ certificates_dir.path }}/server.crt"
+      privatekey_path: "{{ certificates_dir.path }}/server.key"
+      csr_path: "{{ certificates_dir.path }}/server.csr"
+      provider: ownca
+      ownca_path: "{{ certificates_dir.path }}/ca.crt"
+      ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
+      selfsigned_digest: sha256
+
+#
+# Generate the Client cert/key to enable client-side authentication
+#
+- name: Setup the client certificate/key
+  block:
+  - name: Generate an RSA private key for the Presto client
+    openssl_privatekey:
+      size: 2048
+      type: RSA
+      path: "{{ certificates_dir.path }}/client.key"
+
+  - name: Generate the Presto client CSR
+    openssl_csr:
+      path: "{{ certificates_dir.path }}/client.csr"
+      privatekey_path: "{{ certificates_dir.path }}/client.key"
+      common_name: "presto-clients"
+      basicConstraints:
+      - 'CA:FALSE'
+      basicConstraints_critical: false
+      key_usage:
+      - digitalSignature
+      - keyEncipherment
+      extended_key_usage:
+      - clientAuth
+
+  - name: Generate the Presto client certificate
+    openssl_certificate:
+      path: "{{ certificates_dir.path }}/client.crt"
+      privatekey_path: "{{ certificates_dir.path }}/client.key"
+      csr_path: "{{ certificates_dir.path }}/client.csr"
+      provider: ownca
+      ownca_path: "{{ certificates_dir.path }}/ca.crt"
+      ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
+      selfsigned_digest: sha256

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -1,0 +1,84 @@
+---
+
+- name: Validate user's Presto TLS configuration
+  include_tasks: validate_presto_tls.yml
+  when: not meteringconfig_tls_enabled
+
+#
+# Check for Presto TLS and auth secret existence (to avoid re-generating/overwriting the secret data if that secret name already exists)
+#
+- name: Check for the existence of the Presto TLS secret
+  k8s_facts:
+    api_version: v1
+    kind: Secret
+    name: "{{ meteringconfig_spec.presto.spec.presto.config.tls.secretName }}"
+    namespace: "{{ meta.namespace }}"
+  no_log: true
+  register: presto_secret_tls_buf
+  when: meteringconfig_tls_enabled
+
+- name: Check for the existence of the Presto Auth secret
+  k8s_facts:
+    api_version: v1
+    kind: Secret
+    name: "{{ meteringconfig_spec.presto.spec.presto.config.auth.secretName }}"
+    namespace: "{{ meta.namespace }}"
+  no_log: true
+  register: presto_secret_auth_buf
+  when: meteringconfig_tls_enabled
+
+#
+# Generate server and client certificates using the Ansible OpenSSL modules when top-level spec.tls.enabled is set to true
+#
+- name: Configure TLS and client-side authentication for Presto and reporting-operator
+  block:
+  - name: Create temporary directory to store all the necessary certificates/keys
+    tempfile:
+      suffix: certificates
+      state: directory
+    register: certificates_dir
+
+  - name: Generate presto server and client TLS certificates and keys
+    include_tasks: configure_presto_openssl.yml
+
+  - name: Configure Presto to use generated TLS files
+    set_fact:
+      meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/ca.crt') + '\n' }}"
+
+      meteringconfig_presto_server_ca_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/ca.crt') + '\n' }}"
+      meteringconfig_presto_server_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/server.crt') + '\n' }}"
+      meteringconfig_presto_server_key: "{{ lookup('file', '{{ certificates_dir.path }}/server.key') + '\n' }}"
+
+      meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/ca.crt') + '\n' }}"
+      meteringconfig_reporting_operator_client_cert: "{{ lookup('file', '{{ certificates_dir.path }}/client.crt') + '\n' }}"
+      meteringconfig_reporting_operator_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/client.key') + '\n' }}"
+
+      meteringconfig_presto_client_ca_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/ca.crt') + '\n' }}"
+      meteringconfig_presto_client_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/client.crt') + '\n' }}"
+      meteringconfig_presto_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/client.key') + '\n' }}"
+    no_log: true
+  always:
+  - name: Cleanup the temporary directory which held the certificates and keys
+    file:
+      path: "{{ certificates_dir.path }}"
+      state: absent
+  when: meteringconfig_tls_enabled and (presto_secret_tls_buf.resources | length == 0 or presto_secret_auth_buf.resources | length == 0)
+
+#
+# Update the MeteringConfig values to use the pre-existing Presto TLS/auth secret data (when the secret already exists)
+#
+- name: Configure Presto to use existing server TLS secret data
+  set_fact:
+    meteringconfig_presto_server_ca_certificate: "{{ presto_secret_tls_buf.resources[0].data['ca.crt'] | b64decode }}"
+    meteringconfig_presto_server_certificate: "{{ presto_secret_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
+    meteringconfig_presto_server_key: "{{ presto_secret_tls_buf.resources[0].data['tls.key'] | b64decode }}"
+  no_log: true
+  when: meteringconfig_tls_enabled and presto_secret_tls_buf.resources | length > 0
+
+- name: Configure Presto to use existing client TLS secret data
+  set_fact:
+    meteringconfig_presto_client_ca_certificate: "{{ presto_secret_auth_buf.resources[0].data['ca.crt'] | b64decode }}"
+    meteringconfig_presto_client_certificate: "{{ presto_secret_auth_buf.resources[0].data['tls.crt'] | b64decode }}"
+    meteringconfig_presto_client_key: "{{ presto_secret_auth_buf.resources[0].data['tls.key'] | b64decode }}"
+  no_log: true
+  when: meteringconfig_tls_enabled and presto_secret_auth_buf.resources | length > 0

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -1,0 +1,39 @@
+---
+
+#
+# Presto and reporting-operator TLS
+#
+- name: Check for the existence of the reporting-operator prestoTLS.secretName
+  k8s_facts:
+    api_version: v1
+    kind: Secret
+    name: "{{ meteringconfig_spec['reporting-operator'].spec.config.prestoTLS.secretName }}"
+    namespace: "{{ meta.namespace }}"
+  no_log: true
+  register: reporting_operator_tls_secret_buf
+  when: meteringconfig_tls_enabled
+
+- name: Check for the existence of the reporting-operator prestoAuth.secretName
+  k8s_facts:
+    api_version: v1
+    kind: Secret
+    name: "{{ meteringconfig_spec['reporting-operator'].spec.config.prestoAuth.secretName }}"
+    namespace: "{{ meta.namespace }}"
+  no_log: true
+  register: reporting_operator_auth_secret_buf
+  when: meteringconfig_tls_enabled
+
+- name: Configure reporting-operator to use existing presto server TLS secret data
+  set_fact:
+    meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ reporting_operator_tls_secret_buf.resources[0].data['ca.crt'] | b64decode }}"
+  no_log: true
+  when: meteringconfig_tls_enabled and reporting_operator_tls_secret_buf.resources | length > 0
+
+- name: Configure reporting-operator to use existing presto client TLS secret data
+  set_fact:
+    meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ reporting_operator_auth_secret_buf.resources[0].data['ca.crt'] | b64decode }}"
+    meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ reporting_operator_auth_secret_buf.resources[0].data['ca.crt'] | b64decode }}"
+    meteringconfig_reporting_operator_client_cert: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
+    meteringconfig_reporting_operator_client_key: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
+  no_log: true
+  when: meteringconfig_tls_enabled and reporting_operator_auth_secret_buf.resources | length > 0

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Configure TLS and client-side authentication in Presto
+  include_tasks: configure_presto_tls.yml
+
+- name: Configure TLS and authentication in the reporting-operator
+  include_tasks: configure_reporting_operator_tls.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -12,6 +12,9 @@
     hiveStorageType: "{{ meteringconfig_spec_overrides | json_query('storage.hive.type') }}"
   when: hiveStorageType is undefined or hiveStorageType not in ['s3', 'sharedPVC', 'hdfs']
 
+- name: Configure TLS
+  include_tasks: configure_tls.yml
+
 - name: Store MeteringConfig spec into values file
   copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
@@ -1,0 +1,45 @@
+---
+
+#
+# Validate the user-provided cert/key/caCert fields are non-empty when top-level spec.tls.enabled is false
+#
+- name: Validate that the user-provided Presto server TLS fields are not empty
+  block:
+  - name: Validate that the user provided a non-empty TLS certificate value
+    fail:
+      msg: "presto.spec.presto.config.tls.certificate cannot be empty if createSecret: true and secretName != ''"
+    when: meteringconfig_spec.presto.spec.presto.config.tls.certificate == ""
+
+  - name: Validate that the user provided a non-empty TLS CA certificate value
+    fail:
+      msg: "presto.spec.presto.config.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
+    when: meteringconfig_spec.presto.spec.presto.config.tls.caCertificate == ""
+
+  - name: Validate that the user provided a non-empty TLS key value
+    fail:
+      msg: "presto.spec.presto.config.tls.key cannot be empty if createSecret: true and secretName != ''"
+    when: meteringconfig_spec.presto.spec.presto.config.tls.key == ""
+  when: meteringconfig_template_presto_tls_secret
+
+- name: Validate that the user-provided Presto client Auth fields are not empty
+  block:
+  - name: Validate that the user provided a non-empty auth certificate value
+    fail:
+      msg: "presto.spec.presto.config.auth.certificate cannot be empty if createSecret: true and secretName != ''"
+    when: meteringconfig_spec.presto.spec.presto.config.auth.certificate == ""
+
+  - name: Validate that the user provided a non-empty auth CA certificate value
+    fail:
+      msg: "presto.spec.presto.config.auth.caCertificate cannot be empty if createSecret: true and secretName != ''"
+    when: meteringconfig_spec.presto.spec.presto.config.auth.caCertificate == ""
+
+  - name: Validate that the user provided a non-empty auth key value
+    fail:
+      msg: "presto.spec.presto.config.auth.key cannot be empty if createSecret: true and secretName != ''"
+    when: meteringconfig_spec.presto.spec.presto.config.auth.key == ""
+
+  - name: Validate that TLS is enabled when auth is enabled
+    fail:
+      msg: "Invalid configuration passed: you cannot enable auth but disable TLS."
+    when: not meteringconfig_spec.presto.spec.presto.config.tls.enabled and meteringconfig_spec.presto.spec.presto.config.auth.enabled
+  when: meteringconfig_template_presto_auth_secret


### PR DESCRIPTION
Currently seeing if the images build correctly.

This needs to add some more validation of relevant fields and clarify some of the behavior we want. 