### PR TITLE
metering-ansible-operator: Support provisioning metering storage S3 bucket

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -22,6 +22,7 @@ COPY --from=cli /usr/bin/oc /usr/bin/oc
 RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 
 RUN pip install --no-cache-dir --upgrade openshift
+RUN pip install boto3
 
 USER 1001
 ENV HOME /opt/ansible

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -6,7 +6,7 @@ FROM openshift/ose-cli:latest as cli
 FROM openshift/ose-ansible-operator:latest
 
 USER root
-RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini" \
+RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-boto3" \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \

--- a/Documentation/aws/read-write-create.json
+++ b/Documentation/aws/read-write-create.json
@@ -1,0 +1,24 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "1",
+            "Effect": "Allow",
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:HeadBucket",
+                "s3:ListBucket",
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::operator-metering-data/*",
+                "arn:aws:s3:::operator-metering-data"
+            ]
+        }
+    ]
+}

--- a/Documentation/configuring-storage.md
+++ b/Documentation/configuring-storage.md
@@ -10,8 +10,9 @@ Additionally, Hive metastore requires storage for it's database containing metad
 By default, metering has no stored configured but can be configured to store data in S3.
 
 To use S3 for storage, edit the `spec.storage` section in the example [s3-storage.yaml][s3-storage-config] configuration.
-Set the `spec.storage.hive.s3.bucket` and `spec.storage.hive.s3.awsCredentialsSecretName`.
-The `bucket` should be the name and optionally the path within the bucket you wish to store metering data at.
+Set the `spec.storage.hive.s3.bucket`, `spec.storage.hive.s3.region` and `spec.storage.hive.s3.awsCredentialsSecretName` values.
+The `bucket` should be the name and optionally the path within the bucket you wish to store metering data at, and the `region` should be the region to create your bucket in.
+If you wish to provide an existing bucket, or do not want to provide IAM credentials that have CreateBucket permissions, set `spec.storage.hive.s3.createBucket` to `false` and provide the name of a pre-existing bucket for `spec.storage.hive.s3.bucket`.
 The `awsCredentialsSecretName` should be the name of a secret in the metering namespace containing AWS credentials in the `data.aws-access-key-id` and `data.aws-secret-access-key` fields.
 
 For example:
@@ -28,7 +29,7 @@ data:
 
 To store data in S3, the `aws-access-key-id` and `aws-secret-access-key` credentials must have read and write access to the bucket.
 For an example of an IAM policy granting the required permissions see the [aws/read-write.json](aws/read-write.json) file.
-Replace `bucketname/path` with the name of the bucket and the path in the bucket you want to store metering data within.
+If you left `spec.storage.hive.s3.createBucket` set to true, or unset, then you should use [aws/read-write-create.json](aws/read-write-create.json) which contains permissions for creating and deleting buckets.
 
 Please note that this must be done before installation.
 Changing these settings after installation will result in broken and unexpected behavior.

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -11,6 +11,7 @@ meteringconfig_default_values: "{{ lookup('file', meteringconfig_default_values_
 meteringconfig_spec_overrides: "{{ _metering_openshift_io_meteringconfig.spec }}"
 
 # The default specs for each component
+_storage_defaults: "{{ meteringconfig_default_values.storage }}"
 _presto_default_spec: "{{ meteringconfig_default_values.presto.spec }}"
 _reporting_op_default_spec: "{{ meteringconfig_default_values['reporting-operator'].spec }}"
 _hadoop_default_spec: "{{ meteringconfig_default_values.hadoop.spec }}"
@@ -53,20 +54,20 @@ _storage_overrides:
     reporting-operator:
       spec:
         config:
-          awsCredentialsSecretName: "{{ meteringconfig_spec_overrides | json_query('storage.hive.s3.awsCredentialsSecretName') }}"
+          awsCredentialsSecretName: "{{ _storage_defaults | json_query('hive.s3.awsCredentialsSecretName') }}"
           createAwsCredentialsSecret: false
     presto:
       spec:
         config:
-          awsCredentialsSecretName: "{{ meteringconfig_spec_overrides | json_query('storage.hive.s3.awsCredentialsSecretName') }}"
+          awsCredentialsSecretName: "{{ _storage_defaults | json_query('hive.s3.awsCredentialsSecretName') }}"
           createAwsCredentialsSecret: false
         hive:
           config:
-            metastoreWarehouseDir: "s3a://{{ meteringconfig_spec_overrides | json_query('storage.hive.s3.bucket') }}"
+            metastoreWarehouseDir: "s3a://{{ _storage_defaults | json_query('hive.s3.bucket') }}"
     hadoop:
       spec:
         config:
-          defaultFS: "s3a://{{ meteringconfig_spec_overrides | json_query('storage.hive.s3.bucket') }}"
+          defaultFS: "s3a://{{ _storage_defaults | json_query('hive.s3.bucket') }}"
         hdfs:
           enabled: false
 
@@ -74,7 +75,7 @@ _storage_overrides:
     hadoop:
       spec:
         config:
-          defaultFS: "hdfs://{{ meteringconfig_spec_overrides | json_query('storage.hive.hdfs.namenode') | default('hdfs-namenode-0.hdfs-namenode:9820', true) }}"
+          defaultFS: "hdfs://{{ _storage_defaults | json_query('hive.hdfs.namenode') | default('hdfs-namenode-0.hdfs-namenode:9820', true) }}"
         hdfs:
           enabled: "{{ meteringconfig_spec_overrides | json_query('unsupportedFeatures.enableHDFS') | default(false, true) }}"
 
@@ -84,26 +85,33 @@ _storage_overrides:
         config:
           sharedVolume:
             enabled: true
-            createPVC: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.createPVC') | default(false, true) }}"
-            mountPath: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
-            claimName: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.claimName') | default(_presto_default_spec.config.sharedVolume.claimName, true) }}"
-            size: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.size') | default(_presto_default_spec.config.sharedVolume.size, true) }}"
-            storageClass: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.storageClass') | default(_presto_default_spec.config.sharedVolume.storageClass, true) }}"
+            createPVC: "{{ _storage_defaults | json_query('hive.sharedPVC.createPVC') | default(false, true) }}"
+            mountPath: "{{ _storage_defaults | json_query('hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
+            claimName: "{{ _storage_defaults | json_query('hive.sharedPVC.claimName') | default(_presto_default_spec.config.sharedVolume.claimName, true) }}"
+            size: "{{ _storage_defaults | json_query('hive.sharedPVC.size') | default(_presto_default_spec.config.sharedVolume.size, true) }}"
+            storageClass: "{{ _storage_defaults | json_query('hive.sharedPVC.storageClass') | default(_presto_default_spec.config.sharedVolume.storageClass, true) }}"
         hive:
           config:
-            metastoreWarehouseDir: "{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
+            metastoreWarehouseDir: "{{ _storage_defaults | json_query('hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
 
     hadoop:
       spec:
         config:
-          defaultFS: "file://{{ meteringconfig_spec_overrides | json_query('storage.hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
+          defaultFS: "file://{{ _storage_defaults | json_query('hive.sharedPVC.mountPath') | default('/user/hive/warehouse', true) }}"
         hdfs:
           enabled: false
 
-
-meteringconfig_storage_overrides: "{{ _storage_overrides[meteringconfig_default_values | combine(meteringconfig_spec_overrides) | json_query('storage.hive.type')] | default({}, true) }}"
+meteringconfig_storage_hive_store_type: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides) | json_query('storage.hive.type') }}"
+meteringconfig_storage_overrides: "{{ _storage_overrides[meteringconfig_storage_hive_store_type] | default({}, true) }}"
 
 meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_spec_overrides, recursive=True) }}"
+
+meteringconfig_storage_s3_create_bucket: "{{ meteringconfig_spec | json_query('storage.hive.s3.createBucket') | default(true, true) }}"
+# Intentionally an invalid default name to ensure that this is overridden, and obvious when it's not.
+_default_metering_bucket_name: "-unconfigured-metering-bucket-name-"
+meteringconfig_storage_s3_bucket_name: "{{ (meteringconfig_spec | json_query('storage.hive.s3.bucket') | default(_default_metering_bucket_name, true)).split('/')[0] }}"
+meteringconfig_storage_s3_bucket_region: "{{ meteringconfig_spec | json_query('storage.hive.s3.region') | default(omit, true) }}"
+meteringconfig_storage_s3_aws_credentials_secret_name: "{{ meteringconfig_spec | json_query('storage.hive.s3.awsCredentialsSecretName') | default(omit, true) }}"
 
 ########################
 # All Variables below are setup to consume the result of merging the defaults, internal overrides, and user overrides.

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Configure S3 Storage
+  block:
+    - name: Validate Metering S3 bucket name
+      fail:
+        msg: "storage.hive.s3.bucket and storage.hive.s3.region cannot be empty, got bucket: '{{ meteringconfig_storage_s3_bucket_name }}', and region: '{{ meteringconfig_storage_s3_bucket_region }}'"
+      when: meteringconfig_storage_s3_bucket_name == "" or meteringconfig_storage_s3_bucket_region == ""
+
+    - name: Validate Metering S3 credentials
+      fail:
+        msg: "storage.hive.s3.awsCredentialsSecretName cannot be empty"
+      when: meteringconfig_storage_s3_aws_credentials_secret_name == ""
+
+    - name: Obtaining AWS credentials to configure S3 bucket
+      k8s_facts:
+        api_version: v1
+        kind: Secret
+        name: "{{ meteringconfig_storage_s3_aws_credentials_secret_name }}"
+        namespace: "{{ meta.namespace }}"
+      no_log: true
+      register: operator_s3_credentials_secret
+
+    - name: Create Metering S3 bucket
+      s3_bucket:
+        state: present
+        name: "{{ meteringconfig_storage_s3_bucket_name }}"
+        region: "{{ meteringconfig_storage_s3_bucket_region }}"
+        aws_access_key: "{{ operator_s3_credentials_secret.resources[0].data['aws-access-key-id'] | b64decode | default(omit) }}"
+        aws_secret_key: "{{ operator_s3_credentials_secret.resources[0].data['aws-secret-access-key'] | b64decode | default(omit) }}"
+      when: operator_s3_credentials_secret.resources | length > 0
+
+  when: meteringconfig_storage_hive_store_type == 's3' and meteringconfig_storage_s3_create_bucket

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -15,6 +15,9 @@
 - name: Store MeteringConfig spec into values file
   copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml
 
+- name: Configure Storage
+  include_tasks: configure_storage.yml
+
 - include_tasks: "{{ item }}"
   loop:
     - reconcile_monitoring.yml

--- a/manifests/metering-config/s3-storage.yaml
+++ b/manifests/metering-config/s3-storage.yaml
@@ -9,4 +9,8 @@ spec:
       type: "s3"
       s3:
         bucket: "bucketname/path/"
+        region: "us-west-1"
         awsCredentialsSecretName: "my-aws-secret"
+        # Set to false if you want to provide an existing bucket, instead of
+        # having Metering create the bucket on your behalf.
+        createBucket: true


### PR DESCRIPTION
If `spec.storage.hive.s3.createBucket` is true, then the
metering-ansible-operator will attempt to create the bucket
`spec.storage.hive.s3.bucket`.

The bucket name is the first portion of the path segment, and we use the
credentials defined in `spec.storage.hive.s3.awsCredentialsSecretName`.