### PR TITLE
charts,roles/meterinconfig: Fix bucket configuration handling

### DIFF
--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -20,6 +20,8 @@ storage:
   #   s3:
   #     bucket: "bucketname/path/"
   #     awsCredentialsSecretName: "my-aws-secret"
+  #     createBucket: true
+  #     region: "us-west-1"
 
   # hive:
   #   type: "sharedPVC"

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -74,11 +74,13 @@ _storage_overrides:
           createAwsCredentialsSecret: false
         hive:
           config:
-            metastoreWarehouseDir: "s3a://{{ _storage_spec | json_query('hive.s3.bucket') }}"
+            # regex_replace to append a trailing slash if missing
+            metastoreWarehouseDir: "s3a://{{ _storage_spec | json_query('hive.s3.bucket') | regex_replace('\\/?$', '/') }}"
     hadoop:
       spec:
         config:
-          defaultFS: "s3a://{{ _storage_spec | json_query('hive.s3.bucket') }}"
+          # regex_replace to append a trailing slash if missing
+          defaultFS: "s3a://{{ _storage_spec | json_query('hive.s3.bucket') | regex_replace('\\/?$', '/') }}"
         hdfs:
           enabled: false
 
@@ -181,7 +183,7 @@ meteringconfig_tls_overrides: "{{ meteringconfig_tls_enabled | ternary(_tls_over
 meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_spec_overrides, meteringconfig_tls_overrides, recursive=True) }}"
 
 meteringconfig_storage_s3_create_bucket: "{{ meteringconfig_spec | json_query('storage.hive.s3.createBucket') }}"
-meteringconfig_storage_s3_bucket_name: "{{ (meteringconfig_spec | json_query('storage.hive.s3.bucket') ).split('/')[0] }}"
+meteringconfig_storage_s3_bucket_name: "{{ (meteringconfig_spec | json_query('storage.hive.s3.bucket') | default('', true)).split('/')[0] }}"
 meteringconfig_storage_s3_bucket_region: "{{ meteringconfig_spec | json_query('storage.hive.s3.region') }}"
 meteringconfig_storage_s3_aws_credentials_secret_name: "{{ meteringconfig_spec | json_query('storage.hive.s3.awsCredentialsSecretName') }}"
 

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -52,6 +52,16 @@ meteringconfig_default_image_overrides:
 
 _storage_overrides:
   s3:
+    storage:
+      hive:
+        # s3 storage defaults
+        s3:
+          # Intentionally an invalid default name to ensure that this is overridden, and obvious when it's not.
+          bucket: "-unconfigured-metering-bucket-name-"
+          awsCredentialsSecretName: ""
+          # create buckets by default
+          createBucket: true
+          region: ""
     reporting-operator:
       spec:
         config:
@@ -170,12 +180,10 @@ meteringconfig_tls_overrides: "{{ meteringconfig_tls_enabled | ternary(_tls_over
 # combine the meteringconfig_tls_overrides dictionary last to enforce when spec.tls.enabled is specified and set to true
 meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_spec_overrides, meteringconfig_tls_overrides, recursive=True) }}"
 
-meteringconfig_storage_s3_create_bucket: "{{ meteringconfig_spec | json_query('storage.hive.s3.createBucket') | default(true, true) }}"
-# Intentionally an invalid default name to ensure that this is overridden, and obvious when it's not.
-_default_metering_bucket_name: "-unconfigured-metering-bucket-name-"
-meteringconfig_storage_s3_bucket_name: "{{ (meteringconfig_spec | json_query('storage.hive.s3.bucket') | default(_default_metering_bucket_name, true)).split('/')[0] }}"
-meteringconfig_storage_s3_bucket_region: "{{ meteringconfig_spec | json_query('storage.hive.s3.region') | default(omit, true) }}"
-meteringconfig_storage_s3_aws_credentials_secret_name: "{{ meteringconfig_spec | json_query('storage.hive.s3.awsCredentialsSecretName') | default(omit, true) }}"
+meteringconfig_storage_s3_create_bucket: "{{ meteringconfig_spec | json_query('storage.hive.s3.createBucket') }}"
+meteringconfig_storage_s3_bucket_name: "{{ (meteringconfig_spec | json_query('storage.hive.s3.bucket') ).split('/')[0] }}"
+meteringconfig_storage_s3_bucket_region: "{{ meteringconfig_spec | json_query('storage.hive.s3.region') }}"
+meteringconfig_storage_s3_aws_credentials_secret_name: "{{ meteringconfig_spec | json_query('storage.hive.s3.awsCredentialsSecretName') }}"
 
 ########################
 # All Variables below are setup to consume the result of merging the defaults, internal overrides, and user overrides.


### PR DESCRIPTION
Fix not creating S3 bucket when spec.storage.hive.s3.createBucket is false.

The default() filter isn't correct to use here because it sets the value
to the default when false, or empty when the second argument is true.
This causes the default to be used when the user specifies false.

Fixes that by using _storage_overrides and merging that with the user
configuration to determine if createBucket is true instead. Also updates
other s3 storage fields to use this pattern instead of the default()
filter.

Also added a 2nd commit that fixes using a bucket without a sub-path.