### PR TITLE
Allow running reporting-operator locally against TLS secured Presto

### DIFF
--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -79,9 +79,10 @@ func init() {
 
 	startCmd.Flags().StringVar(&cfg.PrestoHost, "presto-host", defaultPrestoHost, "the hostname:port for connecting to Presto.")
 	startCmd.Flags().BoolVar(&cfg.PrestoUseTLS, "presto-use-tls", false, "If true, enables TLS when connecting to Presto.")
-	startCmd.Flags().BoolVar(&cfg.PrestoUseClientCertAuth, "presto-use-auth", false, "If true, enables TLS client certificate authentication when presto-use-tls is also enabled.")
 	startCmd.Flags().BoolVar(&cfg.PrestoTLSInsecureSkipVerify, "presto-tls-insecure-skip-verify", false, "If true, disables TLS verification when connecting to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoCAFile, "presto-ca-file", "", "The path to the certificate authority to use to connect to Presto.")
+
+	startCmd.Flags().BoolVar(&cfg.PrestoUseClientCertAuth, "presto-use-auth", false, "If true, enables TLS client certificate authentication when presto-use-tls is also enabled.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientCertFile, "presto-client-cert-file", "", "The path to the client certificate to use to connect to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientKeyFile, "presto-client-key-file", "", "The path to the client private key to use to connect to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientCACertFile, "presto-client-ca-cert-file", "", "The path to the client certificate authority to use to connect to Presto.")

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -80,6 +80,7 @@ func init() {
 	startCmd.Flags().StringVar(&cfg.PrestoHost, "presto-host", defaultPrestoHost, "the hostname:port for connecting to Presto.")
 	startCmd.Flags().BoolVar(&cfg.PrestoUseTLS, "presto-use-tls", false, "If true, enables TLS when connecting to Presto.")
 	startCmd.Flags().BoolVar(&cfg.PrestoUseClientCertAuth, "presto-use-auth", false, "If true, enables TLS client certificate authentication when presto-use-tls is also enabled.")
+	startCmd.Flags().BoolVar(&cfg.PrestoTLSInsecureSkipVerify, "presto-tls-insecure-skip-verify", false, "If true, disables TLS verification when connecting to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoCAFile, "presto-ca-file", "", "The path to the certificate authority to use to connect to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientCertFile, "presto-client-cert-file", "", "The path to the client certificate to use to connect to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientKeyFile, "presto-client-key-file", "", "The path to the client private key to use to connect to Presto.")

--- a/hack/run-reporting-operator-local.sh
+++ b/hack/run-reporting-operator-local.sh
@@ -22,8 +22,31 @@ source "${ROOT_DIR}/hack/common.sh"
 : "${METERING_HIVE_HOST:="127.0.0.1:${METERING_HIVE_PORT_FORWARD_PORT}"}"
 : "${METERING_PROMETHEUS_HOST:="127.0.0.1:${METERING_PROMETHEUS_PORT_FORWARD_PORT}"}"
 
+: "${METERING_PRESTO_USE_TLS:=true}"
+
+TMPDIR="$(mktemp -d)"
+
+function cleanup() {
+    set +e +o pipefail
+    exit_status=$?
+
+    echo "Performing cleanup"
+
+    echo "Stopping background jobs"
+    # kill any background jobs, such as stern
+    jobs -p | xargs kill
+    # Wait for any jobs
+    wait 2>/dev/null
+
+    # delete tempfiles
+    rm -rf "$TMPDIR"
+
+    echo "Exiting $0"
+    exit "$exit_status"
+}
+
 set -e -o pipefail
-trap 'jobs -p | xargs kill' EXIT
+trap cleanup EXIT
 
 echo Starting presto port-forward
 kubectl -n "$METERING_NAMESPACE" \
@@ -40,6 +63,44 @@ if [ "$METERING_PROMETHEUS_PORT_FORWARD" == "true" ]; then
         "${METERING_PROMETHEUS_PORT_FORWARD_PORT}":"${METERING_PROMETHEUS_SVC_PORT}" &
 else
     echo Skipping Prometheus port-forward
+fi
+
+if [ "$METERING_PRESTO_USE_TLS" == "true" ]; then
+    maxTries=50
+    tries=0
+    echo "Getting reporting-operator presto server TLS secrets"
+    until kubectl -n "$METERING_NAMESPACE" get secrets reporting-operator-presto-server-tls -o json > "$TMPDIR/reporting-operator-presto-server-tls.json"; do
+        if [ "$tries" -gt "$maxTries" ]; then
+            echo "Timed out waiting for secret reporting-operator-presto-server-tls"
+            exit 1
+        fi
+        tries+=1
+        echo 'Waiting for secret reporting-operator-presto-server-tls'
+        sleep 5
+    done
+    echo "Getting reporting-operator presto client TLS secrets"
+    until kubectl -n "$METERING_NAMESPACE" get secrets reporting-operator-presto-client-tls -o json > "$TMPDIR/reporting-operator-presto-client-tls.json"; do
+        if [ "$tries" -gt "$maxTries" ]; then
+            echo "Timed out waiting for secret reporting-operator-presto-client-tls"
+            exit 1
+        fi
+        tries+=1
+        echo 'Waiting for secret reporting-operator-presto-client-tls'
+        sleep 5
+    done
+
+    export REPORTING_OPERATOR_PRESTO_USE_TLS=true
+    export REPORTING_OPERATOR_PRESTO_CA_FILE="$TMPDIR/reporting-operator-presto-server-ca.crt"
+    export REPORTING_OPERATOR_PRESTO_USE_AUTH=true
+    export REPORTING_OPERATOR_PRESTO_CLIENT_CERT_FILE="$TMPDIR/reporting-operator-presto-client-tls.crt"
+    export REPORTING_OPERATOR_PRESTO_CLIENT_KEY_FILE="$TMPDIR/reporting-operator-presto-client-tls.key"
+    export REPORTING_OPERATOR_PRESTO_CLIENT_CA_CERT_FILE="$TMPDIR/reporting-operator-presto-client-ca.crt"
+    export REPORTING_OPERATOR_PRESTO_TLS_INSECURE_SKIP_VERIFY=true
+
+    jq -Mcr '.data["ca.crt"] | @base64d' "$TMPDIR/reporting-operator-presto-server-tls.json" > "$REPORTING_OPERATOR_PRESTO_CA_FILE"
+    jq -Mcr '.data["tls.crt"] | @base64d' "$TMPDIR/reporting-operator-presto-client-tls.json" > "$REPORTING_OPERATOR_PRESTO_CLIENT_CERT_FILE"
+    jq -Mcr '.data["tls.key"] | @base64d' "$TMPDIR/reporting-operator-presto-client-tls.json" > "$REPORTING_OPERATOR_PRESTO_CLIENT_KEY_FILE"
+    jq -Mcr '.data["ca.crt"] | @base64d' "$TMPDIR/reporting-operator-presto-client-tls.json" > "$REPORTING_OPERATOR_PRESTO_CLIENT_CA_CERT_FILE"
 fi
 
 sleep 6

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -105,13 +105,14 @@ type Config struct {
 	HiveUseTLS bool
 	HiveCAFile string
 
-	PrestoHost              string
-	PrestoUseTLS            bool
-	PrestoUseClientCertAuth bool
-	PrestoCAFile            string
-	PrestoClientCertFile    string
-	PrestoClientKeyFile     string
-	PrestoClientCACertFile  string
+	PrestoHost                  string
+	PrestoUseTLS                bool
+	PrestoUseClientCertAuth     bool
+	PrestoTLSInsecureSkipVerify bool
+	PrestoCAFile                string
+	PrestoClientCertFile        string
+	PrestoClientKeyFile         string
+	PrestoClientCACertFile      string
 
 	PrestoMaxQueryLength int
 
@@ -458,7 +459,8 @@ func (op *Reporting) Run(ctx context.Context) error {
 		rootCertPool.AppendCertsFromPEM(rootCert)
 
 		prestoTLSConfig := &tls.Config{
-			RootCAs: rootCertPool,
+			RootCAs:            rootCertPool,
+			InsecureSkipVerify: op.cfg.PrestoTLSInsecureSkipVerify,
 		}
 
 		if op.cfg.PrestoUseClientCertAuth {


### PR DESCRIPTION
Necessary for running e2e/integration tests locally with reporting-operator.