### PR TITLE
Update openshift-reporting MeteringConfig schema

### DIFF
--- a/charts/openshift-metering/templates/metering/default-storage-location.yaml
+++ b/charts/openshift-metering/templates/metering/default-storage-location.yaml
@@ -1,5 +1,5 @@
 {{- $reportingValues :=  index .Values "openshift-reporting" -}}
-{{- if $reportingValues.spec.defaultStorageLocation.create -}}
+{{- if $reportingValues.spec.defaultStorageLocation.enabled -}}
 apiVersion: metering.openshift.io/v1
 kind: StorageLocation
 metadata:

--- a/charts/openshift-metering/templates/openshift-reporting/_reporting_helpers.tpl
+++ b/charts/openshift-metering/templates/openshift-reporting/_reporting_helpers.tpl
@@ -1,0 +1,10 @@
+{{- define "new-report-datasource" }}
+apiVersion: metering.openshift.io/v1
+kind: ReportDataSource
+metadata:
+  name: "{{ .name }}"
+  labels:
+    operator-metering: "true"
+spec:
+{{ toYaml .spec | indent 2 }}
+{{- end }}

--- a/charts/openshift-metering/templates/openshift-reporting/datasources/default-datasources.yaml
+++ b/charts/openshift-metering/templates/openshift-reporting/datasources/default-datasources.yaml
@@ -1,12 +1,7 @@
 {{- $reportingValues :=  index .Values "openshift-reporting" -}}
-{{- range $name, $body := $reportingValues.spec.defaultReportDataSources }}
+{{- if $reportingValues.spec.defaultReportDataSources.enabled }}
+{{- range $i, $body := $reportingValues.spec.defaultReportDataSources.items }}
 ---
-apiVersion: metering.openshift.io/v1
-kind: ReportDataSource
-metadata:
-  name: "{{ $name }}"
-  labels:
-    operator-metering: "true"
-spec:
-{{ toYaml $body.spec | indent 2 }}
+{{- include "new-report-datasource" $body -}}
+{{- end }}
 {{- end }}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -52,10 +52,9 @@ monitoring:
   namespace: openshift-monitoring
 
 openshift-reporting:
-  enabled: true
   spec:
     defaultStorageLocation:
-      create: true
+      enabled: true
       isDefault: true
       name: hive
       type: hive
@@ -68,149 +67,151 @@ openshift-reporting:
       enabled: false
 
     defaultReportDataSources:
-      cluster-cpu-capacity-raw:
-        spec:
-          reportQueryView:
-            queryName: cluster-cpu-capacity-raw
-      cluster-cpu-usage-raw:
-        spec:
-          reportQueryView:
-            queryName: cluster-cpu-usage-raw
-      cluster-memory-capacity-raw:
-        spec:
-          reportQueryView:
-            queryName: cluster-memory-capacity-raw
-      cluster-memory-usage-raw:
-        spec:
-          reportQueryView:
-            queryName: cluster-memory-usage-raw
-      node-allocatable-cpu-cores:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
-      node-allocatable-memory-bytes:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
-      node-capacity-cpu-cores:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
-      node-capacity-memory-bytes:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
-      node-cpu-allocatable-raw:
-        spec:
-          reportQueryView:
-            queryName: node-cpu-allocatable-raw
-      node-cpu-capacity-raw:
-        spec:
-          reportQueryView:
-            queryName: node-cpu-capacity-raw
-      node-memory-allocatable-raw:
-        spec:
-          reportQueryView:
-            queryName: node-memory-allocatable-raw
-      node-memory-capacity-raw:
-        spec:
-          reportQueryView:
-            queryName: node-memory-capacity-raw
-      persistentvolumeclaim-capacity-bytes:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              kubelet_volume_stats_capacity_bytes
-      persistentvolumeclaim-capacity-raw:
-        spec:
-          reportQueryView:
-            queryName: persistentvolumeclaim-capacity-raw
-      persistentvolumeclaim-phase:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              kube_persistentvolumeclaim_status_phase
-      persistentvolumeclaim-phase-raw:
-        spec:
-          reportQueryView:
-            queryName: persistentvolumeclaim-phase-raw
-      persistentvolumeclaim-request-bytes:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
-      persistentvolumeclaim-request-raw:
-        spec:
-          reportQueryView:
-            queryName: persistentvolumeclaim-request-raw
-      persistentvolumeclaim-usage-bytes:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              kubelet_volume_stats_used_bytes
-      persistentvolumeclaim-usage-raw:
-        spec:
-          reportQueryView:
-            queryName: persistentvolumeclaim-usage-raw
-      persistentvolumeclaim-usage-with-phase-raw:
-        spec:
-          reportQueryView:
-            queryName: persistentvolumeclaim-usage-with-phase-raw
-      pod-cpu-request-raw:
-        spec:
-          reportQueryView:
-            queryName: pod-cpu-request-raw
-      pod-cpu-usage-raw:
-        spec:
-          reportQueryView:
-            queryName: pod-cpu-usage-raw
-      pod-limit-cpu-cores:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              sum(kube_pod_container_resource_limits_cpu_cores) by (pod, namespace, node)
-      pod-limit-memory-bytes:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              sum(kube_pod_container_resource_limits_memory_bytes) by (pod, namespace, node)
-      pod-memory-request-raw:
-        spec:
-          reportQueryView:
-            queryName: pod-memory-request-raw
-      pod-memory-usage-raw:
-        spec:
-          reportQueryView:
-            queryName: pod-memory-usage-raw
-      pod-persistentvolumeclaim-request-info:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              kube_pod_spec_volumes_persistentvolumeclaims_info
-      pod-request-cpu-cores:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              sum(kube_pod_container_resource_requests_cpu_cores) by (pod, namespace, node)
-      pod-request-memory-bytes:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
-      pod-usage-cpu-cores:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",container_name!="",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
-      pod-usage-memory-bytes:
-        spec:
-          prometheusMetricsImporter:
-            query: |
-              sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!="",pod_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
+      enabled: true
+      items:
+        - name: cluster-cpu-capacity-raw
+          spec:
+            reportQueryView:
+              queryName: cluster-cpu-capacity-raw
+        - name: cluster-cpu-usage-raw
+          spec:
+            reportQueryView:
+              queryName: cluster-cpu-usage-raw
+        - name: cluster-memory-capacity-raw
+          spec:
+            reportQueryView:
+              queryName: cluster-memory-capacity-raw
+        - name: cluster-memory-usage-raw
+          spec:
+            reportQueryView:
+              queryName: cluster-memory-usage-raw
+        - name: node-allocatable-cpu-cores
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+        - name: node-allocatable-memory-bytes
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+        - name: node-capacity-cpu-cores
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+        - name: node-capacity-memory-bytes
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+        - name: node-cpu-allocatable-raw
+          spec:
+            reportQueryView:
+              queryName: node-cpu-allocatable-raw
+        - name: node-cpu-capacity-raw
+          spec:
+            reportQueryView:
+              queryName: node-cpu-capacity-raw
+        - name: node-memory-allocatable-raw
+          spec:
+            reportQueryView:
+              queryName: node-memory-allocatable-raw
+        - name: node-memory-capacity-raw
+          spec:
+            reportQueryView:
+              queryName: node-memory-capacity-raw
+        - name: persistentvolumeclaim-capacity-bytes
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                kubelet_volume_stats_capacity_bytes
+        - name: persistentvolumeclaim-capacity-raw
+          spec:
+            reportQueryView:
+              queryName: persistentvolumeclaim-capacity-raw
+        - name: persistentvolumeclaim-phase
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                kube_persistentvolumeclaim_status_phase
+        - name: persistentvolumeclaim-phase-raw
+          spec:
+            reportQueryView:
+              queryName: persistentvolumeclaim-phase-raw
+        - name: persistentvolumeclaim-request-bytes
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
+        - name: persistentvolumeclaim-request-raw
+          spec:
+            reportQueryView:
+              queryName: persistentvolumeclaim-request-raw
+        - name: persistentvolumeclaim-usage-bytes
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                kubelet_volume_stats_used_bytes
+        - name: persistentvolumeclaim-usage-raw
+          spec:
+            reportQueryView:
+              queryName: persistentvolumeclaim-usage-raw
+        - name: persistentvolumeclaim-usage-with-phase-raw
+          spec:
+            reportQueryView:
+              queryName: persistentvolumeclaim-usage-with-phase-raw
+        - name: pod-cpu-request-raw
+          spec:
+            reportQueryView:
+              queryName: pod-cpu-request-raw
+        - name: pod-cpu-usage-raw
+          spec:
+            reportQueryView:
+              queryName: pod-cpu-usage-raw
+        - name: pod-limit-cpu-cores
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                sum(kube_pod_container_resource_limits_cpu_cores) by (pod, namespace, node)
+        - name: pod-limit-memory-bytes
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                sum(kube_pod_container_resource_limits_memory_bytes) by (pod, namespace, node)
+        - name: pod-memory-request-raw
+          spec:
+            reportQueryView:
+              queryName: pod-memory-request-raw
+        - name: pod-memory-usage-raw
+          spec:
+            reportQueryView:
+              queryName: pod-memory-usage-raw
+        - name: pod-persistentvolumeclaim-request-info
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                kube_pod_spec_volumes_persistentvolumeclaims_info
+        - name: pod-request-cpu-cores
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                sum(kube_pod_container_resource_requests_cpu_cores) by (pod, namespace, node)
+        - name: pod-request-memory-bytes
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
+        - name: pod-usage-cpu-cores
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",container_name!="",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
+        - name: pod-usage-memory-bytes
+          spec:
+            prometheusMetricsImporter:
+              query: |
+                sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!="",pod_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
 
 reporting-operator:
   spec:

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -210,7 +210,8 @@ _presto_spec: "{{ meteringconfig_spec.presto.spec }}"
 _reporting_op_spec: "{{ meteringconfig_spec['reporting-operator'].spec }}"
 _hadoop_spec: "{{ meteringconfig_spec.hadoop.spec }}"
 
-meteringconfig_create_metering_default_storage: "{{ _openshift_reporting_spec.defaultStorageLocation.create | default(true) }}"
+meteringconfig_create_metering_default_storage: "{{ _openshift_reporting_spec.defaultStorageLocation.enabled }}"
+meteringconfig_create_metering_default_datasources: "{{ _openshift_reporting_spec.defaultReportDataSources.enabled }}"
 
 meteringconfig_create_metering_monitoring_resources: "{{ _monitoring_conf.enabled | default(true) }}"
 meteringconfig_create_metering_monitoring_rbac: "{{ _monitoring_conf.enabled and _monitoring_conf.enabled and _monitoring_conf.createRBAC | default(true) }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -15,7 +15,8 @@
 - name: Delete {{ resource.apis | map(attribute='kind') | join(', ') }} resources with selector {{ label_selector}}
   k8s:
     state: absent
-    definition: "{{ to_delete.results | map(attribute='resources') | flatten }}"
+    definition: "{{ to_delete_results }}"
   vars:
-    label_selector: "{{ meteringconfig_prune_label_key }}={{ resource.prune_label_value }}"
-  when: to_delete.changed
+    to_delete_results: "{{ to_delete.results | map(attribute='resources') | flatten }}"
+    label_selector: "{{ meteringconfig_prune_label_key }}={{ resource.prune_label_value }},{{ meteringconfig_prune_namespace_label_key }}={{ namespace }}"
+  when: to_delete_results | length > 0

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
@@ -12,6 +12,7 @@
       - template_file: templates/openshift-reporting/datasources/default-datasources.yaml
         apis: [ {kind: reportdatasource, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: default-datasources
+        create: "{{ meteringconfig_create_metering_default_datasources }}"
       - template_file: templates/openshift-reporting/report-queries/cluster-capacity.yaml
         apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-cluster-capacity

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
@@ -6,55 +6,55 @@
     values_file: /tmp/metering-values.yaml
     resources:
       - template_file: templates/metering/default-storage-location.yaml
-        apis: [ {kind: storagelocation} ]
+        apis: [ {kind: storagelocation, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: openshift-metering-default-storage-location
         create: "{{ meteringconfig_create_metering_default_storage }}"
       - template_file: templates/openshift-reporting/datasources/default-datasources.yaml
-        apis: [ {kind: datasource} ]
+        apis: [ {kind: reportdatasource, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: default-datasources
       - template_file: templates/openshift-reporting/report-queries/cluster-capacity.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-cluster-capacity
       - template_file: templates/openshift-reporting/report-queries/cluster-usage.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-cluster-usage
       - template_file: templates/openshift-reporting/report-queries/cluster-utilization.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-cluster-utilization
       - template_file: templates/openshift-reporting/report-queries/node-cpu.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-node-cpu
       - template_file: templates/openshift-reporting/report-queries/node-memory.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-node-memory
       - template_file: templates/openshift-reporting/report-queries/persistentvolumeclaim-capacity.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-persistentvolumeclaim-capacity
       - template_file: templates/openshift-reporting/report-queries/persistentvolumeclaim-request.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-persistentvolumeclaim-request
       - template_file: templates/openshift-reporting/report-queries/persistentvolumeclaim-usage.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-persistentvolumeclaim-usage
       - template_file: templates/openshift-reporting/report-queries/pod-cpu.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-pod-cpu
       - template_file: templates/openshift-reporting/report-queries/pod-memory.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-pod-memory
       - template_file: templates/openshift-reporting/datasources/aws-datasources.yaml
-        apis: [ {kind: datasources} ]
+        apis: [ {kind: reportdatasource, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: aws-datasources
         create: "{{ meteringconfig_enable_reporting_aws_billing }}"
       - template_file: templates/openshift-reporting/report-queries/aws-billing.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-aws-billing
         create: "{{ meteringconfig_enable_reporting_aws_billing }}"
       - template_file: templates/openshift-reporting/report-queries/pod-cpu-aws.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-pod-cpu-aws
         create: "{{ meteringconfig_enable_reporting_aws_billing }}"
       - template_file: templates/openshift-reporting/report-queries/pod-memory-aws.yaml
-        apis: [ {kind: reportqueries} ]
+        apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-pod-memory-aws
         create: "{{ meteringconfig_enable_reporting_aws_billing }}"


### PR DESCRIPTION
Primarily moves defaultReportDataSources into a list, and supports disabling
the creation of these resources.

Additionally, the first two commits fix issues with pruning resources I
discovered while testing this.