### PR TITLE
fixed input  names

### DIFF
--- a/manifests/reports/cluster-usage-daily.yaml
+++ b/manifests/reports/cluster-usage-daily.yaml
@@ -6,7 +6,7 @@ spec:
   query: "cluster-cpu-usage"
   # this configures the this report to aggregate the hourly one
   inputs:
-  - name: ClusterCpuusageReportName
+  - name: ClusterCpuUsageReportName
     value: cluster-cpu-usage-hourly
   schedule:
     period: "daily"
@@ -21,7 +21,7 @@ spec:
   query: "cluster-memory-usage"
   # this configures the this report to aggregate the hourly one
   inputs:
-  - name: ClusterMemoryusageReportName
+  - name: ClusterMemoryUsageReportName
     value: cluster-memory-usage-hourly
   schedule:
     period: "daily"


### PR DESCRIPTION
Fixes the following:

```
    message: 'failed to resolve ReportQuery dependencies cluster-cpu-usage: invalid
      input "ClusterCpuusageReportName", supported inputs: ReportingStart ,ReportingEnd
      ,ClusterCpuUsageReportName ,ClusterCpuUsageRawDataSourceName'

    message: 'failed to resolve ReportQuery dependencies cluster-memory-usage: invalid
      input "ClusterMemoryusageReportName", supported inputs: ReportingStart ,ReportingEnd
      ,ClusterMemoryUsageReportName ,ClusterMemoryUsageRawDataSourceName'
```
