### PR TITLE
charts/openshift-metering: Add missing hive-metastore TLS secret volume

### DIFF
--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -197,3 +197,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.hive.spec.config.sharedVolume.claimName }}
 {{- end}}
+{{- if .Values.hive.spec.metastore.config.tls.enabled }}
+      - name: hive-metastore-tls-secret
+        secret:
+          secretName: {{ .Values.hive.spec.metastore.config.tls.secretName }}
+{{- end }}


### PR DESCRIPTION
Accidentally removed in #783