### PR TITLE
roles/meteringconfig: Add MeteringConfig option `spec.logHelmTemplate` to log helm template task

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -215,6 +215,9 @@ _hive_spec: "{{ meteringconfig_spec.hive.spec }}"
 _reporting_op_spec: "{{ meteringconfig_spec['reporting-operator'].spec }}"
 _hadoop_spec: "{{ meteringconfig_spec.hadoop.spec }}"
 
+
+meteringconfig_log_helm_template: "{{ meteringconfig_spec.logHelmTemplate | default(false) }}"
+
 meteringconfig_create_metering_default_storage: "{{ _openshift_reporting_spec.defaultStorageLocation.enabled }}"
 meteringconfig_create_metering_default_datasources: "{{ _openshift_reporting_spec.defaultReportDataSources.enabled }}"
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
@@ -7,7 +7,7 @@
     loop_var: resource
     label: "{{ resource.template_file }}"
   when: resource.create | default(true)
-  no_log: true
+  no_log: "{{ not meteringconfig_log_helm_template }}"
   register: template_results
 
 - name: Add prune label to resources


### PR DESCRIPTION
Setting spec.logHelmTemplate tot rue enables better debugging when helm
templates are failing. Defaults to false.