### PR TITLE
charts,images: Support using both pre/post-kubernetes 1.14 metrics

### DIFF
--- a/charts/metering-ci/templates/metering.yaml
+++ b/charts/metering-ci/templates/metering.yaml
@@ -27,6 +27,10 @@ spec:
         prefix: "{{ .Values.awsBillingBucketPrefix }}"
         region: "{{ .Values.awsBillingBucketRegion }}"
 
+      defaultReportDataSources:
+        postKube_1_14:
+          enabled: {{ .Values.useKube114Metrics }}
+
   reporting-operator:
     spec:
       replicas: "{{ .Values.reportingOperatorReplicas }}"

--- a/charts/metering-ci/values.yaml
+++ b/charts/metering-ci/values.yaml
@@ -25,3 +25,5 @@ prestoCpu: null
 reportingOperatorReplicas: 1
 reportingOperatorMemory: null
 reportingOperatorCpu: null
+
+useKube114Metrics: true

--- a/charts/openshift-metering/templates/openshift-reporting/datasources/default-datasources.yaml
+++ b/charts/openshift-metering/templates/openshift-reporting/datasources/default-datasources.yaml
@@ -1,7 +1,27 @@
 {{- $reportingValues :=  index .Values "openshift-reporting" -}}
-{{- if $reportingValues.spec.defaultReportDataSources.enabled }}
-{{- range $i, $body := $reportingValues.spec.defaultReportDataSources.items }}
+
+{{- if $reportingValues.spec.defaultReportDataSources.base.enabled }}
+# base reportDataSources
+{{- range $_, $body := $reportingValues.spec.defaultReportDataSources.base.items }}
 ---
 {{- include "new-report-datasource" $body -}}
-{{- end }}
-{{- end }}
+{{- end }}{{/* end range */}}
+{{- end }}{{/* end if */}}
+
+{{- if $reportingValues.spec.defaultReportDataSources.postKube_1_14.enabled }}
+
+# post-kubernetes 1.14 reportDataSources
+{{- range $_, $body := $reportingValues.spec.defaultReportDataSources.postKube_1_14.items }}
+---
+{{- include "new-report-datasource" $body -}}
+{{- end }}{{/* end range */}}
+
+{{- else }}
+
+# pre-kubernetes 1.14 reportDataSources
+{{- range $_, $body := $reportingValues.spec.defaultReportDataSources.preKube_1_14.items }}
+---
+{{- include "new-report-datasource" $body -}}
+{{- end }}{{/* end range */}}
+
+{{- end }}{{/* end if */}}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -67,151 +67,172 @@ openshift-reporting:
       enabled: false
 
     defaultReportDataSources:
-      enabled: true
-      items:
-        - name: cluster-cpu-capacity-raw
-          spec:
-            reportQueryView:
-              queryName: cluster-cpu-capacity-raw
-        - name: cluster-cpu-usage-raw
-          spec:
-            reportQueryView:
-              queryName: cluster-cpu-usage-raw
-        - name: cluster-memory-capacity-raw
-          spec:
-            reportQueryView:
-              queryName: cluster-memory-capacity-raw
-        - name: cluster-memory-usage-raw
-          spec:
-            reportQueryView:
-              queryName: cluster-memory-usage-raw
-        - name: node-allocatable-cpu-cores
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
-        - name: node-allocatable-memory-bytes
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
-        - name: node-capacity-cpu-cores
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
-        - name: node-capacity-memory-bytes
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
-        - name: node-cpu-allocatable-raw
-          spec:
-            reportQueryView:
-              queryName: node-cpu-allocatable-raw
-        - name: node-cpu-capacity-raw
-          spec:
-            reportQueryView:
-              queryName: node-cpu-capacity-raw
-        - name: node-memory-allocatable-raw
-          spec:
-            reportQueryView:
-              queryName: node-memory-allocatable-raw
-        - name: node-memory-capacity-raw
-          spec:
-            reportQueryView:
-              queryName: node-memory-capacity-raw
-        - name: persistentvolumeclaim-capacity-bytes
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                kubelet_volume_stats_capacity_bytes
-        - name: persistentvolumeclaim-capacity-raw
-          spec:
-            reportQueryView:
-              queryName: persistentvolumeclaim-capacity-raw
-        - name: persistentvolumeclaim-phase
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                kube_persistentvolumeclaim_status_phase
-        - name: persistentvolumeclaim-phase-raw
-          spec:
-            reportQueryView:
-              queryName: persistentvolumeclaim-phase-raw
-        - name: persistentvolumeclaim-request-bytes
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
-        - name: persistentvolumeclaim-request-raw
-          spec:
-            reportQueryView:
-              queryName: persistentvolumeclaim-request-raw
-        - name: persistentvolumeclaim-usage-bytes
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                kubelet_volume_stats_used_bytes
-        - name: persistentvolumeclaim-usage-raw
-          spec:
-            reportQueryView:
-              queryName: persistentvolumeclaim-usage-raw
-        - name: persistentvolumeclaim-usage-with-phase-raw
-          spec:
-            reportQueryView:
-              queryName: persistentvolumeclaim-usage-with-phase-raw
-        - name: pod-cpu-request-raw
-          spec:
-            reportQueryView:
-              queryName: pod-cpu-request-raw
-        - name: pod-cpu-usage-raw
-          spec:
-            reportQueryView:
-              queryName: pod-cpu-usage-raw
-        - name: pod-limit-cpu-cores
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                sum(kube_pod_container_resource_limits_cpu_cores) by (pod, namespace, node)
-        - name: pod-limit-memory-bytes
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                sum(kube_pod_container_resource_limits_memory_bytes) by (pod, namespace, node)
-        - name: pod-memory-request-raw
-          spec:
-            reportQueryView:
-              queryName: pod-memory-request-raw
-        - name: pod-memory-usage-raw
-          spec:
-            reportQueryView:
-              queryName: pod-memory-usage-raw
-        - name: pod-persistentvolumeclaim-request-info
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                kube_pod_spec_volumes_persistentvolumeclaims_info
-        - name: pod-request-cpu-cores
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                sum(kube_pod_container_resource_requests_cpu_cores) by (pod, namespace, node)
-        - name: pod-request-memory-bytes
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
-        - name: pod-usage-cpu-cores
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",container_name!="",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
-        - name: pod-usage-memory-bytes
-          spec:
-            prometheusMetricsImporter:
-              query: |
-                sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!="",pod_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
+      base:
+        enabled: true
+        items:
+          # views
+          - name: cluster-cpu-capacity-raw
+            spec:
+              reportQueryView:
+                queryName: cluster-cpu-capacity-raw
+          - name: cluster-cpu-usage-raw
+            spec:
+              reportQueryView:
+                queryName: cluster-cpu-usage-raw
+          - name: cluster-memory-capacity-raw
+            spec:
+              reportQueryView:
+                queryName: cluster-memory-capacity-raw
+          - name: cluster-memory-usage-raw
+            spec:
+              reportQueryView:
+                queryName: cluster-memory-usage-raw
+          - name: node-cpu-allocatable-raw
+            spec:
+              reportQueryView:
+                queryName: node-cpu-allocatable-raw
+          - name: node-cpu-capacity-raw
+            spec:
+              reportQueryView:
+                queryName: node-cpu-capacity-raw
+          - name: node-memory-allocatable-raw
+            spec:
+              reportQueryView:
+                queryName: node-memory-allocatable-raw
+          - name: node-memory-capacity-raw
+            spec:
+              reportQueryView:
+                queryName: node-memory-capacity-raw
+          - name: persistentvolumeclaim-capacity-raw
+            spec:
+              reportQueryView:
+                queryName: persistentvolumeclaim-capacity-raw
+          - name: persistentvolumeclaim-phase-raw
+            spec:
+              reportQueryView:
+                queryName: persistentvolumeclaim-phase-raw
+          - name: persistentvolumeclaim-request-raw
+            spec:
+              reportQueryView:
+                queryName: persistentvolumeclaim-request-raw
+          - name: persistentvolumeclaim-usage-raw
+            spec:
+              reportQueryView:
+                queryName: persistentvolumeclaim-usage-raw
+          - name: persistentvolumeclaim-usage-with-phase-raw
+            spec:
+              reportQueryView:
+                queryName: persistentvolumeclaim-usage-with-phase-raw
+          - name: pod-cpu-request-raw
+            spec:
+              reportQueryView:
+                queryName: pod-cpu-request-raw
+          - name: pod-cpu-usage-raw
+            spec:
+              reportQueryView:
+                queryName: pod-cpu-usage-raw
+          - name: pod-memory-request-raw
+            spec:
+              reportQueryView:
+                queryName: pod-memory-request-raw
+          - name: pod-memory-usage-raw
+            spec:
+              reportQueryView:
+                queryName: pod-memory-usage-raw
+
+          # metrics importers
+          - name: node-allocatable-cpu-cores
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+          - name: node-allocatable-memory-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+          - name: node-capacity-cpu-cores
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+          - name: node-capacity-memory-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+          - name: persistentvolumeclaim-capacity-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  kubelet_volume_stats_capacity_bytes
+          - name: persistentvolumeclaim-phase
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  kube_persistentvolumeclaim_status_phase
+          - name: persistentvolumeclaim-request-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
+          - name: persistentvolumeclaim-usage-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  kubelet_volume_stats_used_bytes
+          - name: pod-limit-cpu-cores
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  sum(kube_pod_container_resource_limits_cpu_cores) by (pod, namespace, node)
+          - name: pod-limit-memory-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  sum(kube_pod_container_resource_limits_memory_bytes) by (pod, namespace, node)
+          - name: pod-persistentvolumeclaim-request-info
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  kube_pod_spec_volumes_persistentvolumeclaims_info
+          - name: pod-request-cpu-cores
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  sum(kube_pod_container_resource_requests_cpu_cores) by (pod, namespace, node)
+          - name: pod-request-memory-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
+
+      postKube_1_14:
+        enabled: true
+        items:
+          - name: pod-usage-cpu-cores
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  sum(rate(container_cpu_usage_seconds_total{container_name!="POD",container_name!="",pod!=""}[1m])) BY (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
+          - name: pod-usage-memory-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  sum(container_memory_usage_bytes{container_name!="POD", container_name!="",pod!=""}) by (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
+
+      preKube_1_14:
+        items:
+          - name: pod-usage-cpu-cores
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  label_replace(sum(rate(container_cpu_usage_seconds_total{container_name!="POD",container_name!="",pod_name!=""}[1m])) BY (pod_name, namespace), "pod", "$1", "pod_name", "(.*)") + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
+          - name: pod-usage-memory-bytes
+            spec:
+              prometheusMetricsImporter:
+                query: |
+                  sum(label_replace(container_memory_usage_bytes{container_name!="POD", container_name!="",pod_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod, namespace) + on (pod, namespace) group_left(node) (sum(kube_pod_info{pod_ip!="",node!="",host_ip!=""}) by (pod, namespace, node) * 0)
 
 reporting-operator:
   spec:

--- a/hack/deploy-e2e.sh
+++ b/hack/deploy-e2e.sh
@@ -21,6 +21,7 @@ export DEPLOY_PLATFORM
 export METERING_PULL_SECRET_NAME
 export METERING_CREATE_PULL_SECRET
 
+: "${USE_KUBE_114_metrics:=true}"
 : "${ENABLE_AWS_BILLING:=false}"
 : "${DISABLE_PROMETHEUS_METRICS_IMPORTER:=false}"
 : "${AWS_ACCESS_KEY_ID:=}"
@@ -55,6 +56,7 @@ HELM_ARGS=(\
     --set "reportingOperatorReplicas=${REPORTING_OPERATOR_REPLICAS}" \
     --set "reportingOperatorDeployRepo=${REPORTING_OPERATOR_DEPLOY_REPO}" \
     --set "reportingOperatorDeployTag=${REPORTING_OPERATOR_DEPLOY_TAG}" \
+    --set "useKube114Metrics=${USE_KUBE_114_metrics}" \
     --set "enableAwsBilling=${ENABLE_AWS_BILLING}" \
     --set "disablePrometheusMetricsImporter=${DISABLE_PROMETHEUS_METRICS_IMPORTER}" \
     --set "awsAccessKeyId=${AWS_ACCESS_KEY_ID}" \

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -11,6 +11,7 @@ meteringconfig_default_values: "{{ lookup('file', meteringconfig_default_values_
 meteringconfig_spec_overrides: "{{ _metering_openshift_io_meteringconfig.spec }}"
 
 # The default specs for each component
+_openshift_reporting_default_spec: "{{ meteringconfig_default_values['openshift-reporting'].spec }}"
 _presto_default_spec: "{{ meteringconfig_default_values.presto.spec }}"
 _hive_default_spec: "{{ meteringconfig_default_values.hive.spec }}"
 _reporting_op_default_spec: "{{ meteringconfig_default_values['reporting-operator'].spec }}"
@@ -209,8 +210,18 @@ _tls_overrides:
 meteringconfig_tls_enabled: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides, recursive=True) | json_query('tls.enabled') }}"
 meteringconfig_tls_overrides: "{{ meteringconfig_tls_enabled | ternary(_tls_overrides, {}) }}"
 
-# combine the meteringconfig_tls_overrides dictionary last to enforce when spec.tls.enabled is specified and set to true
-meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_spec_overrides, meteringconfig_root_ca_overrides, meteringconfig_tls_overrides, recursive=True) }}"
+# openshift-reporting overrides
+meteringconfig_reporting_enable_post_kube_1_14_datasources: "{{ _openshift_reporting_default_spec.defaultReportDataSources.postKube_1_14.enabled }}"
+
+meteringconfig_reporting_overrides:
+  openshift-reporting:
+    spec:
+      defaultReportDataSources:
+        postKube_1_14:
+          enabled: "{{ meteringconfig_reporting_enable_post_kube_1_14_datasources }}"
+
+# combine the _meteringconfig_tls_overrides dictionary last to enforce when spec.tls.enabled is specified and set to true
+meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_reporting_overrides, meteringconfig_spec_overrides, meteringconfig_root_ca_overrides, meteringconfig_tls_overrides, recursive=True) }}"
 
 meteringconfig_storage_s3_create_bucket: "{{ meteringconfig_spec | json_query('storage.hive.s3.createBucket') }}"
 meteringconfig_storage_s3_bucket_name: "{{ (meteringconfig_spec | json_query('storage.hive.s3.bucket') | default('', true)).split('/')[0] }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -233,7 +233,6 @@ _hadoop_spec: "{{ meteringconfig_spec.hadoop.spec }}"
 meteringconfig_log_helm_template: "{{ meteringconfig_spec.logHelmTemplate | default(false) }}"
 
 meteringconfig_create_metering_default_storage: "{{ _openshift_reporting_spec.defaultStorageLocation.enabled }}"
-meteringconfig_create_metering_default_datasources: "{{ _openshift_reporting_spec.defaultReportDataSources.enabled }}"
 
 meteringconfig_create_metering_monitoring_resources: "{{ _monitoring_conf.enabled | default(true) }}"
 meteringconfig_create_metering_monitoring_rbac: "{{ _monitoring_conf.enabled and _monitoring_conf.enabled and _monitoring_conf.createRBAC | default(true) }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Query Kubernetes for API version
+  command: kubectl version -o json
+  register: kube_version
+
+- name: Set default ReportDataSources to use based on Kubernetes version
+  block:
+    - name: Log Kubernetes version
+      debug:
+        msg: |
+          Kubernetes Minor Version: {{ kube_minor_version }}
+          Kubernetes version at least 1.14: {{ kube_version_at_least_1_14 }}
+
+    - name: Set default ReportDataSources to use based on Kubernetes version
+      set_fact:
+        meteringconfig_reporting_enable_post_kube_1_14_datasources: "{{ kube_version_at_least_1_14 }}"
+  vars:
+    kube_minor_version: "{{ (kube_version.stdout | from_json | json_query('serverVersion.minor')).rstrip('+') }}"
+    kube_version_at_least_1_14: "{{ (kube_minor_version | int) >= 14 }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -15,11 +15,14 @@
 - name: Configure TLS
   include_tasks: configure_tls.yml
 
-- name: Store MeteringConfig spec into values file
-  copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml
+- name: Configure Reporting
+  include_tasks: configure_reporting.yml
 
 - name: Configure Storage
   include_tasks: configure_storage.yml
+
+- name: Store MeteringConfig spec into values file
+  copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml
 
 - include_tasks: "{{ item }}"
   loop:

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
@@ -12,7 +12,6 @@
       - template_file: templates/openshift-reporting/datasources/default-datasources.yaml
         apis: [ {kind: reportdatasource, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: default-datasources
-        create: "{{ meteringconfig_create_metering_default_datasources }}"
       - template_file: templates/openshift-reporting/report-queries/cluster-capacity.yaml
         apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-cluster-capacity


### PR DESCRIPTION
Updates our Prometheus queries to be prepared for https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md.
Sometime in the future the old metric labels will be removed, so switch
our queries to use the new metric labels.

To support existing users on Kubernetes versions prior to 1.14, they can
set `spec.openshift-reporting.spec.defaultReportDataSources.postKube_1_14`
to false.

Ex:

```
spec:
  openshift-reporting:
    spec:
      defaultReportDataSources:
        postKube_1_14:
          enabled: false
```