### PR TITLE
images/metering-ansible-operator: Prefix TLS-related default variables with an underscore.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -126,33 +126,33 @@ meteringconfig_storage_overrides: "{{ _storage_overrides[meteringconfig_storage_
 #
 # Override the default values with _tls_overrides when spec.tls.enabled is set to true, else use values.yaml and meteringconfig_spec_overrides
 #
-meteringconfig_reporting_operator_presto_server_ca_certificate: ""
-meteringconfig_reporting_operator_presto_server_secret_name: "reporting-operator-presto-server-tls"
+_meteringconfig_reporting_operator_presto_server_ca_certificate: ""
+_meteringconfig_reporting_operator_presto_server_secret_name: "reporting-operator-presto-server-tls"
 
-meteringconfig_reporting_operator_presto_client_secret_name: "reporting-operator-presto-client-tls"
-meteringconfig_reporting_operator_client_cert: ""
-meteringconfig_reporting_operator_presto_client_ca_certificate: ""
-meteringconfig_reporting_operator_client_key: ""
+_meteringconfig_reporting_operator_presto_client_secret_name: "reporting-operator-presto-client-tls"
+_meteringconfig_reporting_operator_client_cert: ""
+_meteringconfig_reporting_operator_presto_client_ca_certificate: ""
+_meteringconfig_reporting_operator_client_key: ""
 
 _meteringconfig_reporting_operator_auth_proxy_cookie_seed: ""
 
-meteringconfig_presto_server_secret_name: "presto-server-tls"
-meteringconfig_presto_server_ca_certificate: ""
-meteringconfig_presto_server_certificate: ""
-meteringconfig_presto_server_key: ""
+_meteringconfig_presto_server_secret_name: "presto-server-tls"
+_meteringconfig_presto_server_ca_certificate: ""
+_meteringconfig_presto_server_certificate: ""
+_meteringconfig_presto_server_key: ""
 
-meteringconfig_presto_client_secret_name: "presto-client-tls"
-meteringconfig_presto_client_ca_certificate: ""
-meteringconfig_presto_client_certificate: ""
-meteringconfig_presto_client_key: ""
+_meteringconfig_presto_client_secret_name: "presto-client-tls"
+_meteringconfig_presto_client_ca_certificate: ""
+_meteringconfig_presto_client_certificate: ""
+_meteringconfig_presto_client_key: ""
 
-meteringconfig_tls_root_ca_certificate: ""
-meteringconfig_tls_root_ca_key: ""
+_meteringconfig_tls_root_ca_certificate: ""
+_meteringconfig_tls_root_ca_key: ""
 
 meteringconfig_root_ca_overrides:
   tls:
-    certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
-    key: "{{ meteringconfig_tls_root_ca_key }}"
+    certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+    key: "{{ _meteringconfig_tls_root_ca_key }}"
 
 _tls_overrides:
   reporting-operator:
@@ -160,20 +160,20 @@ _tls_overrides:
       config:
         presto:
           tls:
-            caCertificate: "{{ meteringconfig_reporting_operator_presto_server_ca_certificate }}"
+            caCertificate: "{{ _meteringconfig_reporting_operator_presto_server_ca_certificate }}"
 
             enabled: true
             createSecret: true
-            secretName: "{{ meteringconfig_reporting_operator_presto_server_secret_name }}"
+            secretName: "{{ _meteringconfig_reporting_operator_presto_server_secret_name }}"
 
           auth:
-            certificate: "{{ meteringconfig_reporting_operator_client_cert }}"
-            key: "{{ meteringconfig_reporting_operator_client_key }}"
-            caCertificate: "{{ meteringconfig_reporting_operator_presto_client_ca_certificate }}"
+            certificate: "{{ _meteringconfig_reporting_operator_client_cert }}"
+            key: "{{ _meteringconfig_reporting_operator_client_key }}"
+            caCertificate: "{{ _meteringconfig_reporting_operator_presto_client_ca_certificate }}"
 
             enabled: true
             createSecret: true
-            secretName: "{{ meteringconfig_reporting_operator_presto_client_secret_name }}"
+            secretName: "{{ _meteringconfig_reporting_operator_presto_client_secret_name }}"
       authProxy:
         enabled: true
 
@@ -190,21 +190,21 @@ _tls_overrides:
     spec:
       config:
         tls:
-          certificate: "{{  meteringconfig_presto_server_certificate }}"
-          key: "{{ meteringconfig_presto_server_key }}"
-          caCertificate: "{{ meteringconfig_presto_server_ca_certificate }}"
+          certificate: "{{  _meteringconfig_presto_server_certificate }}"
+          key: "{{ _meteringconfig_presto_server_key }}"
+          caCertificate: "{{ _meteringconfig_presto_server_ca_certificate }}"
 
           enabled: true
           createSecret: true
-          secretName: "{{ meteringconfig_presto_server_secret_name }}"
+          secretName: "{{ _meteringconfig_presto_server_secret_name }}"
         auth:
-          certificate: "{{  meteringconfig_presto_client_certificate }}"
-          key: "{{ meteringconfig_presto_client_key }}"
-          caCertificate: "{{ meteringconfig_presto_client_ca_certificate }}"
+          certificate: "{{  _meteringconfig_presto_client_certificate }}"
+          key: "{{ _meteringconfig_presto_client_key }}"
+          caCertificate: "{{ _meteringconfig_presto_client_ca_certificate }}"
 
           enabled: true
           createSecret: true
-          secretName: "{{ meteringconfig_presto_client_secret_name }}"
+          secretName: "{{ _meteringconfig_presto_client_secret_name }}"
 
 # check if the user's spec contains the top-level tls.enabled field. if true, use the value stored in that field, else default to the value stored in values.yaml
 meteringconfig_tls_enabled: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides, recursive=True) | json_query('tls.enabled') }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -37,19 +37,19 @@
 
   - name: Configure Presto to use generated TLS files
     set_fact:
-      meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
 
-      meteringconfig_presto_server_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
-      meteringconfig_presto_server_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_server.crt') + '\n' }}"
-      meteringconfig_presto_server_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_server.key') + '\n' }}"
+      _meteringconfig_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_presto_server_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_server.crt') + '\n' }}"
+      _meteringconfig_presto_server_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_server.key') + '\n' }}"
 
-      meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
-      meteringconfig_reporting_operator_client_cert: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.crt') + '\n' }}"
-      meteringconfig_reporting_operator_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.key') + '\n' }}"
+      _meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_reporting_operator_client_cert: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.crt') + '\n' }}"
+      _meteringconfig_reporting_operator_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.key') + '\n' }}"
 
-      meteringconfig_presto_client_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
-      meteringconfig_presto_client_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.crt') + '\n' }}"
-      meteringconfig_presto_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.key') + '\n' }}"
+      _meteringconfig_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_presto_client_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.crt') + '\n' }}"
+      _meteringconfig_presto_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.key') + '\n' }}"
     no_log: true
   when: meteringconfig_tls_enabled and (presto_secret_tls_buf.resources | length == 0 or presto_secret_auth_buf.resources | length == 0)
 
@@ -58,16 +58,16 @@
 #
 - name: Configure Presto to use existing server TLS secret data
   set_fact:
-    meteringconfig_presto_server_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
-    meteringconfig_presto_server_certificate: "{{ presto_secret_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
-    meteringconfig_presto_server_key: "{{ presto_secret_tls_buf.resources[0].data['tls.key'] | b64decode }}"
+    _meteringconfig_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+    _meteringconfig_presto_server_certificate: "{{ presto_secret_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
+    _meteringconfig_presto_server_key: "{{ presto_secret_tls_buf.resources[0].data['tls.key'] | b64decode }}"
   no_log: true
   when: meteringconfig_tls_enabled and presto_secret_tls_buf.resources | length > 0
 
 - name: Configure Presto to use existing client TLS secret data
   set_fact:
-    meteringconfig_presto_client_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
-    meteringconfig_presto_client_certificate: "{{ presto_secret_auth_buf.resources[0].data['tls.crt'] | b64decode }}"
-    meteringconfig_presto_client_key: "{{ presto_secret_auth_buf.resources[0].data['tls.key'] | b64decode }}"
+    _meteringconfig_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+    _meteringconfig_presto_client_certificate: "{{ presto_secret_auth_buf.resources[0].data['tls.crt'] | b64decode }}"
+    _meteringconfig_presto_client_key: "{{ presto_secret_auth_buf.resources[0].data['tls.key'] | b64decode }}"
   no_log: true
   when: meteringconfig_tls_enabled and presto_secret_auth_buf.resources | length > 0

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -25,7 +25,7 @@
 
 - name: Configure reporting-operator to use existing presto server TLS secret data
   set_fact:
-    meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
+    _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
   no_log: true
   vars:
     reporting_operator_tls_secret_exists: "{{ reporting_operator_tls_secret_buf.resources is defined and reporting_operator_tls_secret_buf.resources | length > 0 }}"
@@ -33,10 +33,10 @@
 
 - name: Configure reporting-operator to use existing presto client TLS secret data
   set_fact:
-    meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
-    meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ meteringconfig_tls_root_ca_certificate }}"
-    meteringconfig_reporting_operator_client_cert: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
-    meteringconfig_reporting_operator_client_key: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
+    _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+    _meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+    _meteringconfig_reporting_operator_client_cert: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
+    _meteringconfig_reporting_operator_client_key: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
   no_log: true
   vars:
     reporting_operator_auth_secret_exists: "{{ reporting_operator_auth_secret_buf.resources is defined and reporting_operator_auth_secret_buf.resources | length > 0 }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
@@ -40,8 +40,8 @@
 
   - name: Use generate cert/key when secret doesn't already exist
     set_fact:
-      meteringconfig_tls_root_ca_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/ca.crt') + '\n' }}"
-      meteringconfig_tls_root_ca_key: "{{ lookup('file', '{{ certificates_dir.path }}/ca.key') + '\n' }}"
+      _meteringconfig_tls_root_ca_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/ca.crt') + '\n' }}"
+      _meteringconfig_tls_root_ca_key: "{{ lookup('file', '{{ certificates_dir.path }}/ca.key') + '\n' }}"
 
   vars:
     root_ca_secret_exists: "{{ root_ca_secret_buf.resources is defined and root_ca_secret_buf.resources | length > 0 }}"
@@ -50,18 +50,18 @@
 - name: Use pre-existing CA secret cert/key when secret already exists
   block:
   - set_fact:
-      meteringconfig_tls_root_ca_certificate: "{{ root_ca_secret_buf.resources[0].data['ca.crt'] | b64decode }}"
-      meteringconfig_tls_root_ca_key: "{{ root_ca_secret_buf.resources[0].data['ca.key'] | b64decode }}"
+      _meteringconfig_tls_root_ca_certificate: "{{ root_ca_secret_buf.resources[0].data['ca.crt'] | b64decode }}"
+      _meteringconfig_tls_root_ca_key: "{{ root_ca_secret_buf.resources[0].data['ca.key'] | b64decode }}"
 
   - name: Add root CA certificate to certificates directory
     copy:
-      content: "{{ meteringconfig_tls_root_ca_certificate }}"
+      content: "{{ _meteringconfig_tls_root_ca_certificate }}"
       dest: "{{ certificates_dir.path }}/ca.crt"
     when: meteringconfig_tls_enabled
 
   - name: Add root CA private key to certificates directory
     copy:
-      content: "{{ meteringconfig_tls_root_ca_key }}"
+      content: "{{ _meteringconfig_tls_root_ca_key }}"
       dest: "{{ certificates_dir.path }}/ca.key"
     when: meteringconfig_tls_enabled
 


### PR DESCRIPTION
This is based on #787 

~This would still print things like `meteringconfig_tls_enabled`, `meteringconfig_tls_overrides`, `meteringconfig_root_ca_overrides`, but they won't contain any useful information.~