### PR TITLE
Support TLS from Hive Server to Hive metastore using ghostunnel

### DIFF
--- a/charts/openshift-metering/templates/hive/hive-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-configmap.yaml
@@ -31,7 +31,11 @@ data:
       </property>
       <property>
         <name>hive.metastore.uris</name>
-        <value>{{ .Values.hive.spec.config.metastoreURIs }}</value>
+{{- if .Values.hive.spec.metastore.config.tls.enabled }}
+        <value>thrift://localhost:8443</value>
+{{- else }}
+        <value>thrift://hive-metastore:9083</value>
+{{- end }}
       </property>
       <property>
         <name>javax.jdo.option.ConnectionURL</name>
@@ -169,4 +173,3 @@ data:
     rootLogger.level = ${sys:hive.log.level}
     rootLogger.appenderRefs = root
     rootLogger.appenderRef.root.ref = ${sys:hive.root.logger}
-

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -135,7 +135,7 @@ spec:
         args:
         - server
         - --listen
-        - localhost:8443
+        - 0.0.0.0:8443
         - --target
         - localhost:9083
         - --key
@@ -144,8 +144,12 @@ spec:
         - $(HIVE_METASTORE_CRTFILE)
         - --cacert
         -  $(HIVE_METASTORE_CA_CRTFILE)
+{{- if .Values.hive.spec.metastore.config.auth.enabled }}
         - --allow-cn
-        - Any
+        - hive-server
+{{- else }}
+        - --disable-authentication
+{{- end }}
         ports:
         - name: ghostunnel
           containerPort: 8443

--- a/charts/openshift-metering/templates/hive/hive-metastore-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-tls-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.hive.spec.metastore.config.tls.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.hive.spec.metastore.config.tls.secretName }}
+  labels:
+    app: hive
+    hive: metastore
+type: Opaque
+data:
+  tls.crt: {{ .Values.hive.spec.metastore.config.tls.certificate | b64enc | quote }}
+  tls.key: {{ .Values.hive.spec.metastore.config.tls.key | b64enc | quote }}
+  ca.crt: {{.Values.hive.spec.metastore.config.tls.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/templates/hive/hive-server-metastore-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-metastore-tls-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.hive.spec.server.config.metastoreTLS.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.hive.spec.server.config.metastoreTLS.secretName }}
+  labels:
+    app: hive
+    hive: metastore
+type: Opaque
+data:
+  tls.crt: {{ .Values.hive.spec.server.config.metastoreTLS.certificate | b64enc | quote }}
+  tls.key: {{ .Values.hive.spec.server.config.metastoreTLS.key | b64enc | quote }}
+  ca.crt: {{.Values.hive.spec.server.config.metastoreTLS.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/templates/hive/hive-server-service.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-service.yaml
@@ -13,6 +13,8 @@ spec:
     port: 10002
   - name: metrics
     port: 8082
+  - name: ghostunnel
+    port: 10001
   selector:
     app: hive
     hive: server

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -48,6 +48,32 @@ spec:
       affinity:
 {{ toYaml .Values.hive.spec.server.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.hive.spec.server.config.metastoreTLS.enabled }}
+      initContainers:
+      - name: copy-hive-tls
+        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
+        env:
+        - name: GHOSTUNNEL_CLIENT_CA_CRTFILE
+          value: /opt/hive/tls/ca.crt
+        - name: GHOSTUNNEL_CLIENT_TLS_CERT
+          value: /opt/hive/tls/tls.crt
+        - name: GHOSTUNNEL_CLIENT_TLS_KEY
+          value: /opt/hive/tls/tls.key
+        - name: GHOSTUNNEL_CLIENT_KEYSTORE
+          value: /opt/hive/tls/keystore-combined.pem
+        command:
+        - /bin/bash
+        - -c
+        - |
+            cp /hive-metastore-auth-tls-secrets/* /opt/hive/tls
+            cat $(GHOSTUNNEL_CLIENT_TLS_CERT) $(GHOSTUNNEL_CLIENT_TLS_KEY) > $(GHOSTUNNEL_CLIENT_KEYSTORE)
+        volumeMounts:
+        - name: hive-metastore-auth-tls
+          mountPath: /opt/hive/tls
+        - name: hive-metastore-auth-tls-secrets
+          mountPath: /hive-metastore-auth-tls-secrets
+{{- end }}
       containers:
       - name: hiveserver2
         command: ["/hive-scripts/entrypoint.sh"]
@@ -131,10 +157,10 @@ spec:
         image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
-        - name: HIVE_SERVER_CA_CRTFILE
+        - name: GHOSTUNNEL_CLIENT_CA_CRTFILE
           value: /opt/hive/tls/ca.crt
-        - name: HIVE_SERVER_COMBINED_PEM
-          value: /opt/hive/tls/tls.pem
+        - name: GHOSTUNNEL_CLIENT_KEYSTORE
+          value: /opt/hive/tls/keystore-combined.pem
         command: ["ghostunnel"]
         args:
         - client
@@ -143,11 +169,11 @@ spec:
         - --target
         - hive-metastore:8443
         - --keystore
-        -  $(HIVE_SERVER_COMBINED_PEM)
+        -  $(GHOSTUNNEL_CLIENT_KEYSTORE)
         - --cacert
-        -  $(HIVE_SERVER_CA_CRTFILE)
+        -  $(GHOSTUNNEL_CLIENT_CA_CRTFILE)
         volumeMounts:
-        - name: hive-server-tls-secret
+        - name: hive-metastore-auth-tls
           mountPath: /opt/hive/tls
 {{- end }}
       dnsPolicy: ClusterFirst
@@ -190,7 +216,9 @@ spec:
           claimName: {{ .Values.hive.spec.config.sharedVolume.claimName }}
 {{- end}}
 {{- if .Values.hive.spec.server.config.metastoreTLS.enabled }}
-      - name: hive-server-tls-secret
+      - name: hive-metastore-auth-tls
+        emptyDir: {}
+      - name: hive-metastore-auth-tls-secrets
         secret:
           secretName: {{ .Values.hive.spec.server.config.metastoreTLS.secretName }}
 {{- end }}

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -63,6 +63,8 @@ spec:
           protocol: TCP
         - containerPort: 8082
           name: metrics
+        - containerPort: 10004
+          name: metastore
 {{- if .Values.hive.spec.server.readinessProbe }}
         readinessProbe:
 {{ toYaml .Values.hive.spec.server.readinessProbe | indent 10 }}
@@ -124,6 +126,30 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.hive.spec.server.resources | indent 10 }}
+{{- if .Values.hive.spec.server.config.metastoreTLS.enabled }}
+      - name: ghostunnel-client
+        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
+        env:
+        - name: HIVE_SERVER_CA_CRTFILE
+          value: /opt/hive/tls/ca.crt
+        - name: HIVE_SERVER_COMBINED_PEM
+          value: /opt/hive/tls/tls.pem
+        command: ["ghostunnel"]
+        args:
+        - client
+        - --listen
+        - localhost:8443
+        - --target
+        - hive-metastore:8443
+        - --keystore
+        -  $(HIVE_SERVER_COMBINED_PEM)
+        - --cacert
+        -  $(HIVE_SERVER_CA_CRTFILE)
+        volumeMounts:
+        - name: hive-server-tls-secret
+          mountPath: /opt/hive/tls
+{{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: {{ .Values.hive.spec.terminationGracePeriodSeconds }}
@@ -163,3 +189,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.hive.spec.config.sharedVolume.claimName }}
 {{- end}}
+{{- if .Values.hive.spec.server.config.metastoreTLS.enabled }}
+      - name: hive-server-tls-secret
+        secret:
+          secretName: {{ .Values.hive.spec.server.config.metastoreTLS.secretName }}
+{{- end }}

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -176,6 +176,43 @@ spec:
         - name: hive-metastore-auth-tls
           mountPath: /opt/hive/tls
 {{- end }}
+{{- if .Values.hive.spec.server.config.tls.enabled }}
+      - name: ghostunnel-server
+        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
+        env:
+        - name: GHOSTUNNEL_SERVER_CA_CRTFILE
+          value: /opt/hive/server-tls/ca.crt
+        - name: GHOSTUNNEL_SERVER_KEYFILE
+          value: /opt/hive/server-tls/tls.key
+        - name: GHOSTUNNEL_SERVER_CRTFILE
+          value: /opt/hive/server-tls/tls.crt
+        command: ["ghostunnel"]
+        args:
+        - server
+        - --listen
+        - 0.0.0.0:10001
+        - --target
+        - localhost:10000
+        - --key
+        -  $(GHOSTUNNEL_SERVER_KEYFILE)
+        - --cert
+        - $(GHOSTUNNEL_SERVER_CRTFILE)
+        - --cacert
+        -  $(GHOSTUNNEL_SERVER_CA_CRTFILE)
+{{- if .Values.hive.spec.server.config.auth.enabled }}
+        - --allow-cn
+        - reporting-operator
+{{- else }}
+        - --disable-authentication
+{{- end }}
+        ports:
+        - name: ghostunnel
+          containerPort: 8443
+        volumeMounts:
+        - name: hive-server-tls-secret
+          mountPath: /opt/hive/server-tls
+{{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: {{ .Values.hive.spec.terminationGracePeriodSeconds }}
@@ -221,4 +258,9 @@ spec:
       - name: hive-metastore-auth-tls-secrets
         secret:
           secretName: {{ .Values.hive.spec.server.config.metastoreTLS.secretName }}
+{{- end }}
+{{- if .Values.hive.spec.server.config.tls.enabled }}
+      - name: hive-server-tls-secret
+        secret:
+          secretName: {{ .Values.hive.spec.server.config.tls.secretName }}
 {{- end }}

--- a/charts/openshift-metering/templates/hive/hive-server-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-tls-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.hive.spec.server.config.tls.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.hive.spec.server.config.tls.secretName }}
+  labels:
+    app: hive
+    hive: server
+type: Opaque
+data:
+  tls.crt: {{ .Values.hive.spec.server.config.tls.certificate | b64enc | quote }}
+  tls.key: {{ .Values.hive.spec.server.config.tls.key | b64enc | quote }}
+  ca.crt: {{.Values.hive.spec.server.config.tls.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -623,6 +623,13 @@ hive:
           minRAMPercentage: null
 
         tls:
+          # server cert
+          certificate: ""
+          # server private key
+          key: ""
+          # CA for the server cert
+          caCertificate: ""
+
           enabled: false
           createSecret: false
           secretName: ""

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -678,6 +678,21 @@ hive:
           maxRAMPercentage: null
           minRAMPercentage: null
 
+        tls:
+          # server cert
+          certificate: ""
+          # server private key
+          key: ""
+          # CA for the server cert
+          caCertificate: ""
+
+          enabled: false
+          createSecret: false
+          secretName: ""
+
+        auth:
+          enabled: false
+
         metastoreTLS:
           # TLS options for connecting to hive-metastore from hive-server
           # client cert

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -572,7 +572,6 @@ hive:
 
     config:
       metastoreClientSocketTimeout: null
-      metastoreURIs: thrift://hive-metastore:9083
       metastoreWarehouseDir: null
 
       defaultCompression: zlib
@@ -628,6 +627,9 @@ hive:
           createSecret: false
           secretName: ""
 
+        auth:
+          enabled: false
+
       resources:
         limits:
           cpu: 4
@@ -668,6 +670,12 @@ hive:
           initialRAMPercentage: null
           maxRAMPercentage: null
           minRAMPercentage: null
+
+        metastoreTLS:
+          # TLS options for connecting to hive-metastore from hive-server
+          enabled: false
+          createSecret: false
+          secretName: ""
 
       resources:
         limits:

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -680,6 +680,13 @@ hive:
 
         metastoreTLS:
           # TLS options for connecting to hive-metastore from hive-server
+          # client cert
+          certificate: ""
+          # client private key
+          key: ""
+          # CA for the client cert
+          caCertificate: ""
+
           enabled: false
           createSecret: false
           secretName: ""

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -209,6 +209,7 @@ _tls_overrides:
 # check if the user's spec contains the top-level tls.enabled field. if true, use the value stored in that field, else default to the value stored in values.yaml
 meteringconfig_tls_enabled: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides, recursive=True) | json_query('tls.enabled') }}"
 meteringconfig_tls_overrides: "{{ meteringconfig_tls_enabled | ternary(_tls_overrides, {}) }}"
+
 # combine the meteringconfig_tls_overrides dictionary last to enforce when spec.tls.enabled is specified and set to true
 meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_spec_overrides, meteringconfig_root_ca_overrides, meteringconfig_tls_overrides, recursive=True) }}"
 
@@ -247,6 +248,8 @@ meteringconfig_create_hadoop_aws_credentials: "{{ _hadoop_spec.config.aws.create
 meteringconfig_create_hive_metastore_pvc: "{{ _hive_spec.metastore.storage.create | default(true) }}"
 meteringconfig_create_hive_shared_volume_pvc: "{{ _hive_spec.config.sharedVolume.enabled and _hive_spec.config.sharedVolume.createPVC | default(false) }}"
 meteringconfig_create_hive_aws_credentials: "{{ _hive_spec.config.createAwsCredentialsSecret | default(false) }}"
+
+meteringconfig_create_hive_metastore_tls_secrets: "{{ _hive_spec.metastore.config.tls.enabled and _hive_spec.metastore.config.tls.createSecret | default(false) }}"
 
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.aws.createSecret | default(false) }}"
 

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -251,6 +251,7 @@ meteringconfig_create_hive_aws_credentials: "{{ _hive_spec.config.createAwsCrede
 
 meteringconfig_create_hive_metastore_tls_secrets: "{{ _hive_spec.metastore.config.tls.enabled and _hive_spec.metastore.config.tls.createSecret | default(false) }}"
 meteringconfig_create_hive_server_metastore_tls_secrets: "{{ _hive_spec.server.config.metastoreTLS.enabled and _hive_spec.server.config.metastoreTLS.createSecret | default(false) }}"
+meteringconfig_create_hive_server_tls_secrets: "{{ _hive_spec.server.config.tls.enabled and _hive_spec.server.config.tls.createSecret | default(false) }}"
 
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.aws.createSecret | default(false) }}"
 

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -250,6 +250,7 @@ meteringconfig_create_hive_shared_volume_pvc: "{{ _hive_spec.config.sharedVolume
 meteringconfig_create_hive_aws_credentials: "{{ _hive_spec.config.createAwsCredentialsSecret | default(false) }}"
 
 meteringconfig_create_hive_metastore_tls_secrets: "{{ _hive_spec.metastore.config.tls.enabled and _hive_spec.metastore.config.tls.createSecret | default(false) }}"
+meteringconfig_create_hive_server_metastore_tls_secrets: "{{ _hive_spec.server.config.metastoreTLS.enabled and _hive_spec.server.config.metastoreTLS.createSecret | default(false) }}"
 
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.aws.createSecret | default(false) }}"
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -21,6 +21,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: hive-metastore-tls-secrets
         create: "{{ meteringconfig_create_hive_metastore_tls_secrets }}"
+      - template_file: templates/hive/hive-server-metastore-tls-secrets.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: hive-server-metastore-tls-secrets
+        create: "{{ meteringconfig_create_hive_server_metastore_tls_secrets }}"
       - template_file: templates/hive/hive-configmap.yaml
         apis: [ {kind: configmap} ]
         prune_label_value: hive-configmap

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -25,6 +25,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: hive-server-metastore-tls-secrets
         create: "{{ meteringconfig_create_hive_server_metastore_tls_secrets }}"
+      - template_file: templates/hive/hive-server-tls-secrets.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: hive-server-tls-secrets
+        create: "{{ meteringconfig_create_hive_server_tls_secrets }}"
       - template_file: templates/hive/hive-configmap.yaml
         apis: [ {kind: configmap} ]
         prune_label_value: hive-configmap

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -17,6 +17,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: hive-aws-credentials-secret
         create: "{{ meteringconfig_create_hive_aws_credentials }}"
+      - template_file: templates/hive/hive-metastore-tls-secrets.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: hive-metastore-tls-secrets
+        create: "{{ meteringconfig_create_hive_metastore_tls_secrets }}"
       - template_file: templates/hive/hive-configmap.yaml
         apis: [ {kind: configmap} ]
         prune_label_value: hive-configmap


### PR DESCRIPTION
Supercedes #795

This adds support for hive-server to communicate with hive-metastore using ghostunnel to provide a secured TLS connection to communicate over.
Also adds the ability to create the hive TLS secrets by providing configuration in your MeteringConfig.