### PR TITLE
Fix ansible failures using /.ansible instead of $HOME

### DIFF
--- a/images/metering-ansible-operator/ansible.cfg
+++ b/images/metering-ansible-operator/ansible.cfg
@@ -3,3 +3,6 @@ roles_path = /opt/ansible/roles
 library = /usr/share/ansible/openshift
 
 callback_whitelist = timer, profile_roles
+
+remote_tmp = /tmp/.ansible-${USER}/tmp
+


### PR DESCRIPTION
Work around for https://bugzilla.redhat.com/show_bug.cgi?id=1726326