### PR TITLE
Add hadoop-starting-config to hive, presto, hadoop

### DIFF
--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -53,6 +53,8 @@ data:
         fi
     fi
 
+    cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/
+
     # symlink our configuration files to the correct location
     ln -s -f /hadoop-config/core-site.xml /etc/hadoop/core-site.xml
     ln -s -f /hadoop-config/hdfs-site.xml /etc/hadoop/hdfs-site.xml

--- a/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
@@ -130,6 +130,18 @@ spec:
         # required for openshift
         - name: namenode-empty
           mountPath: /hadoop/dfs/name
+      - name: copy-starter-hadoop
+        image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
+        imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
+        command:
+        - '/bin/bash'
+        - '-c'
+        - 'cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/'
+        volumeMounts:
+        - name: hadoop-config
+          mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
       containers:
       - name: hdfs-datanode
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
@@ -197,6 +209,8 @@ spec:
         volumeMounts:
         - name: hadoop-config
           mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
         - name: hadoop-scripts
           mountPath: /hadoop-scripts
         - name: hdfs-jmx-config
@@ -227,6 +241,8 @@ spec:
 {{- end }}
       volumes:
       - name: hadoop-config
+        emptyDir: {}
+      - name: hadoop-starting-config
         secret:
           secretName: "{{ .Values.hadoop.spec.configSecretName }}"
           defaultMode: 0555

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -96,6 +96,19 @@ spec:
       tolerations:
 {{ toYaml .Values.hadoop.spec.hdfs.namenode.tolerations | indent 8 }}
 {{- end }}
+      initContainers:
+      - name: copy-starter-hadoop
+        image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
+        imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
+        command:
+        - '/bin/bash'
+        - '-c'
+        - 'cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/'
+        volumeMounts:
+        - name: hadoop-config
+          mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
       containers:
       - name: hdfs-namenode
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
@@ -163,6 +176,8 @@ spec:
         volumeMounts:
         - name: hadoop-config
           mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
         - name: hadoop-scripts
           mountPath: /hadoop-scripts
         - name: hdfs-jmx-config
@@ -186,6 +201,8 @@ spec:
 {{- end }}
       volumes:
       - name: hadoop-config
+        emptyDir: {}
+      - name: hadoop-starting-config
         secret:
           secretName: "{{ .Values.hadoop.spec.configSecretName }}"
           defaultMode: 0555

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -48,6 +48,19 @@ spec:
       affinity:
 {{ toYaml .Values.hive.spec.metastore.affinity | indent 8 }}
 {{- end }}
+      initContainers:
+      - name: copy-starter-hive
+        image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
+        imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
+        command:
+        - '/bin/bash'
+        - '-c'
+        - 'cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/'
+        volumeMounts:
+        - name: hadoop-config
+          mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
       containers:
       - name: metastore
         command: ["/hive-scripts/entrypoint.sh"]
@@ -102,6 +115,8 @@ spec:
 {{- if .Values.hive.spec.config.useHadoopConfig }}
         - name: hadoop-config
           mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
 {{- end }}
         - name: hive-jmx-config
           mountPath: /opt/jmx_exporter/config
@@ -177,8 +192,10 @@ spec:
           defaultMode: 0555
 {{- if .Values.hive.spec.config.useHadoopConfig }}
       - name: hadoop-config
+        emptyDir: {}
+      - name: hadoop-starting-config
         secret:
-          secretName: {{ .Values.hive.spec.config.hadoopConfigSecretName }}
+          secretName: {{ .Values.hive.spec.config.hadoopConfigSecretName  }}
 {{- end }}
       - name: hive-jmx-config
         configMap:

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -74,6 +74,19 @@ spec:
         - name: hive-metastore-auth-tls-secrets
           mountPath: /hive-metastore-auth-tls-secrets
 {{- end }}
+      initContainers:
+      - name: copy-starter-hive
+        image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
+        imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
+        command:
+        - '/bin/bash'
+        - '-c'
+        - 'cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/'
+        volumeMounts:
+        - name: hadoop-config
+          mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
       containers:
       - name: hiveserver2
         command: ["/hive-scripts/entrypoint.sh"]
@@ -134,6 +147,8 @@ spec:
 {{- if .Values.hive.spec.config.useHadoopConfig }}
         - name: hadoop-config
           mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
 {{- end}}
         - name: hive-jmx-config
           mountPath: /opt/jmx_exporter/config
@@ -231,6 +246,8 @@ spec:
           defaultMode: 0555
 {{- if .Values.hive.spec.config.useHadoopConfig }}
       - name: hadoop-config
+        emptyDir: {}
+      - name: hadoop-starting-config
         secret:
           secretName: {{ .Values.hive.spec.config.hadoopConfigSecretName }}
 {{- end }}

--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -22,6 +22,7 @@ data:
 {{- end }}
 
     cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/
+    cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/
 
   entrypoint.sh: |
     #!/bin/bash

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -109,6 +109,10 @@ spec:
           mountPath: /var/presto/data
         - name: presto-common-config
           mountPath: /presto-common
+        - name: hadoop-config
+          mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
 {{- if .Values.presto.spec.config.tls.enabled }}
         - name: presto-tls
           mountPath: /opt/presto/tls
@@ -161,6 +165,8 @@ spec:
 {{- if .Values.presto.spec.config.connectors.hive.useHadoopConfig }}
         - name: hadoop-config
           mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
 {{- end }}
 {{- if .Values.presto.spec.config.tls.enabled }}
         - name: presto-tls
@@ -218,6 +224,8 @@ spec:
         emptyDir: {}
 {{- if .Values.presto.spec.config.connectors.hive.useHadoopConfig }}
       - name: hadoop-config
+        emptyDir: {}
+      - name: hadoop-starting-config
         secret:
           secretName: {{ .Values.presto.spec.config.connectors.hive.hadoopConfigSecretName }}
 {{- end }}

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -142,6 +142,8 @@ spec:
 {{- if .Values.presto.spec.config.connectors.hive.useHadoopConfig }}
         - name: hadoop-config
           mountPath: /hadoop-config
+        - name: hadoop-starting-config
+          mountPath: /hadoop-starting-config
 {{- end }}
 {{- if .Values.presto.spec.config.tls.enabled }}
         - name: presto-tls
@@ -175,6 +177,8 @@ spec:
         emptyDir: {}
 {{- if .Values.presto.spec.config.connectors.hive.useHadoopConfig }}
       - name: hadoop-config
+        emptyDir: {}
+      - name: hadoop-starting-config
         secret:
           secretName: {{ .Values.presto.spec.config.connectors.hive.hadoopConfigSecretName }}
 {{- end }}


### PR DESCRIPTION
added hadoop-starting-config to hive, presto, and hadoop, this allow the copied core-site.xml from hadoop-starting-config to be editable, allowing us to inject azure secrets with an init-container.