### PR TITLE
test/e2e: Fix race condition on Reporting resources being created

### DIFF
--- a/test/e2e/report_test.go
+++ b/test/e2e/report_test.go
@@ -35,7 +35,7 @@ func testReportsProduceData(t *testing.T, testFramework *framework.Framework, te
 				t.Parallel()
 			}
 
-			query, err := testFramework.GetMeteringReportQuery(test.queryName)
+			query, err := testFramework.WaitForMeteringReportQuery(t, test.queryName, 5*time.Second, 5*time.Minute)
 			require.NoError(t, err, "report query for report should exist")
 
 			dsGetter := reporting.NewReportDataSourceClientGetter(testFramework.MeteringClient)


### PR DESCRIPTION
Instead of failing if a ReportQuery is missing during e2e, retry up to a
timeout waiting for the ReportQuery to be created.