### PR TITLE
charts/openshift-metering: Set Presto property hive.collect-column-statistics-on-write=true

### DIFF
--- a/charts/openshift-metering/templates/presto/_presto_helpers.tpl
+++ b/charts/openshift-metering/templates/presto/_presto_helpers.tpl
@@ -12,6 +12,7 @@ hive.metastore-timeout={{ .Values.presto.spec.config.connectors.hive.metastoreTi
 {{- end }}
 {{- if .Values.presto.spec.config.useHadoopConfig}}
 hive.config.resources=/hadoop-config/core-site.xml
+hive.collect-column-statistics-on-write=true
 {{- end }}
 
 {{ end }}


### PR DESCRIPTION
Enables automatic column level statistics collection on write.
https://prestosql.io/docs/current/connector/hive.html#table-statistics

Ensures our Presto tables have stats populated so we can view them using
`SHOW STATS FOR table_name;`.