### PR TITLE
Support configuring hive-server with authentication via ghostunnel

### DIFF
--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -10,19 +10,26 @@ data:
   log-reports: {{ $operatorValues.spec.config.logReports | quote}}
   log-ddl-queries: {{ $operatorValues.spec.config.logDDLQueries | quote}}
   log-dml-queries: {{ $operatorValues.spec.config.logDMLQueries | quote}}
-  presto-host: {{ $operatorValues.spec.config.presto.host | quote }}
   hive-host: {{ $operatorValues.spec.config.hive.host | quote }}
-  prometheus-url: {{ required "a valid reporting-operator.spec.config.prometheusURL must be set" $operatorValues.spec.config.prometheus.url | quote}}
-  disable-prometheus-metrics-importer: {{ not $operatorValues.spec.config.prometheus.metricsImporter.enabled | quote}}
-  enable-finalizers: {{ $operatorValues.spec.config.enableFinalizers | quote}}
+{{- if $operatorValues.spec.config.hive.tls.enabled }}
+  hive-ca-file: "/var/run/secrets/hive-tls/ca.crt"
+{{- if $operatorValues.spec.config.hive.auth.enabled }}
+  hive-client-cert-file: "/var/run/secrets/hive-auth/tls.crt"
+  hive-client-key-file: "/var/run/secrets/hive-auth/tls.key"
+{{- end }}
+{{- end }}
+
+  presto-host: {{ $operatorValues.spec.config.presto.host | quote }}
 {{- if $operatorValues.spec.config.presto.tls.enabled }}
   presto-ca-file: "/var/run/secrets/presto-tls/ca.crt"
 {{- if $operatorValues.spec.config.presto.auth.enabled }}
   presto-client-cert-file: "/var/run/secrets/presto-auth/tls.crt"
   presto-client-key-file: "/var/run/secrets/presto-auth/tls.key"
-  presto-client-ca-cert-file: "/var/run/secrets/presto-auth/ca.crt"
 {{- end }}
 {{- end }}
+
+  prometheus-url: {{ required "a valid reporting-operator.spec.config.prometheusURL must be set" $operatorValues.spec.config.prometheus.url | quote}}
+  disable-prometheus-metrics-importer: {{ not $operatorValues.spec.config.prometheus.metricsImporter.enabled | quote}}
 {{- if $operatorValues.spec.config.prometheus.metricsImporter.config.pollInterval }}
   prometheus-metrics-importer-poll-interval: {{ $operatorValues.spec.config.prometheus.metricsImporter.config.pollInterval | quote}}
 {{- end }}
@@ -58,3 +65,4 @@ data:
 {{- if $operatorValues.spec.config.targetNamespaces }}
   target-namespaces: {{ $operatorValues.spec.config.targetNamespaces | join "," | quote }}
 {{- end }}
+  enable-finalizers: {{ $operatorValues.spec.config.enableFinalizers | quote}}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -38,8 +38,14 @@ spec:
 {{- if and $operatorValues.spec.config.presto.tls.enabled $operatorValues.spec.config.presto.tls.createSecret }}
         reporting-operator-presto-server-tls-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-presto-tls-secrets.yaml") . | sha256sum }}
 {{- end }}
+{{- if and $operatorValues.spec.config.hive.tls.enabled $operatorValues.spec.config.hive.tls.createSecret }}
+        reporting-operator-hive-server-tls-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-hive-tls-secrets.yaml") . | sha256sum }}
+{{- end }}
 {{- if and $operatorValues.spec.config.presto.auth.enabled $operatorValues.spec.config.presto.auth.createSecret }}
         reporting-operator-presto-client-tls-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-presto-auth-secrets.yaml") . | sha256sum }}
+{{- end }}
+{{- if and $operatorValues.spec.config.hive.auth.enabled $operatorValues.spec.config.hive.auth.createSecret }}
+        reporting-operator-hive-client-tls-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-hive-auth-secrets.yaml") . | sha256sum }}
 {{- end }}
 {{- if and $operatorValues.spec.authProxy.enabled $operatorValues.spec.authProxy.cookie.createSecret }}
         reporting-operator-auth-proxy-cookie-secrets-hash: {{ include (print $.Template.BasePath "/reporting-operator/reporting-operator-auth-proxy-cookie-secret.yaml") . | sha256sum }}
@@ -217,11 +223,6 @@ spec:
             configMapKeyRef:
               name: reporting-operator-config
               key: presto-client-key-file
-        - name: REPORTING_OPERATOR_PRESTO_CLIENT_CA_CERT_FILE
-          valueFrom:
-            configMapKeyRef:
-              name: reporting-operator-config
-              key: presto-client-ca-cert-file
 {{- else }}
         - name: REPORTING_OPERATOR_PRESTO_USE_AUTH
           value: "false"
@@ -231,6 +232,37 @@ spec:
             configMapKeyRef:
               name: reporting-operator-config
               key: hive-host
+
+{{- if $operatorValues.spec.config.hive.tls.enabled }}
+        - name: REPORTING_OPERATOR_HIVE_USE_TLS
+          value: "true"
+        - name: REPORTING_OPERATOR_HIVE_CA_FILE
+          valueFrom:
+            configMapKeyRef:
+              name: reporting-operator-config
+              key: hive-ca-file
+{{- else }}
+        - name: REPORTING_OPERATOR_HIVE_USE_TLS
+          value: "false"
+{{- end }}
+{{- if $operatorValues.spec.config.hive.auth.enabled }}
+        - name: REPORTING_OPERATOR_HIVE_USE_AUTH
+          value: "true"
+        - name: REPORTING_OPERATOR_HIVE_CLIENT_CERT_FILE
+          valueFrom:
+            configMapKeyRef:
+              name: reporting-operator-config
+              key: hive-client-cert-file
+        - name: REPORTING_OPERATOR_HIVE_CLIENT_KEY_FILE
+          valueFrom:
+            configMapKeyRef:
+              name: reporting-operator-config
+              key: hive-client-key-file
+{{- else }}
+        - name: REPORTING_OPERATOR_HIVE_USE_AUTH
+          value: "false"
+{{- end }}
+
         - name: REPORTING_OPERATOR_LEASE_DURATION
           valueFrom:
             configMapKeyRef:
@@ -295,6 +327,14 @@ spec:
 {{ toYaml $operatorValues.spec.livenessProbe | indent 10 }}
 {{- end }}
         volumeMounts:
+{{- if $operatorValues.spec.config.hive.tls.enabled }}
+        - name: hive-tls
+          mountPath: /var/run/secrets/hive-tls
+{{- if $operatorValues.spec.config.hive.auth.enabled }}
+        - name: hive-auth
+          mountPath: /var/run/secrets/hive-auth
+{{- end }}
+{{- end }}
 {{- if $operatorValues.spec.config.presto.tls.enabled }}
         - name: presto-tls
           mountPath: /var/run/secrets/presto-tls
@@ -386,6 +426,16 @@ spec:
 {{- end }}
 {{- end }}{{/* end of authProxy.enabled */}}
       volumes:
+{{- if $operatorValues.spec.config.hive.tls.enabled }}
+      - name: hive-tls
+        secret:
+          secretName: {{ $operatorValues.spec.config.hive.tls.secretName }}
+{{- if $operatorValues.spec.config.hive.auth.enabled }}
+      - name: hive-auth
+        secret:
+          secretName: {{ $operatorValues.spec.config.hive.auth.secretName }}
+{{- end }}
+{{- end }}
 {{- if $operatorValues.spec.config.presto.tls.enabled }}
       - name: presto-tls
         secret:

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-hive-auth-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-hive-auth-secrets.yaml
@@ -1,0 +1,13 @@
+{{- $operatorValues :=  index .Values "reporting-operator" -}}
+{{- if $operatorValues.spec.config.hive.auth.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $operatorValues.spec.config.hive.auth.secretName }}
+  labels:
+    app: reporting-operator
+type: Opaque
+data:
+  tls.crt: {{ $operatorValues.spec.config.hive.auth.certificate | b64enc | quote }}
+  tls.key: {{ $operatorValues.spec.config.hive.auth.key | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-hive-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-hive-tls-secrets.yaml
@@ -1,0 +1,12 @@
+{{- $operatorValues :=  index .Values "reporting-operator" -}}
+{{- if $operatorValues.spec.config.hive.tls.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $operatorValues.spec.config.hive.tls.secretName }}
+  labels:
+    app: reporting-operator
+type: Opaque
+data:
+  ca.crt: {{ $operatorValues.spec.config.hive.tls.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-auth-secrets.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-presto-auth-secrets.yaml
@@ -10,5 +10,4 @@ type: Opaque
 data:
   tls.crt: {{ $operatorValues.spec.config.presto.auth.certificate | b64enc | quote }}
   tls.key: {{ $operatorValues.spec.config.presto.auth.key | b64enc | quote }}
-  ca.crt: {{ $operatorValues.spec.config.presto.auth.caCertificate | b64enc | quote }}
 {{- end -}}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -258,17 +258,26 @@ reporting-operator:
       hive:
         # note this will contain more information once TLS/Auth is enabled w/ Hive
         host: hive-server:10000
-        # tls:
-        #   # client cert
-        #   certificate: ""
-        #   # client private key
-        #   key: ""
-        #   # CA for the client cert
-        #   caCertificate: ""
+        tls:
+          # client cert
+          certificate: ""
+          # client private key
+          key: ""
+          # CA for the client cert
+          caCertificate: ""
 
-        #   createSecret: false
-        #   enabled: false
-        #   secretName: ""
+          createSecret: false
+          enabled: false
+          secretName: ""
+        auth:
+          # client cert
+          certificate: ""
+          # client private key
+          key: ""
+
+          createSecret: false
+          enabled: false
+          secretName: ""
 
       presto:
         host: presto:8080
@@ -286,8 +295,6 @@ reporting-operator:
           certificate: ""
           # client private key
           key: ""
-          # CA for the client cert
-          caCertificate: ""
 
           createSecret: false
           enabled: false

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -75,7 +75,12 @@ func init() {
 
 	startCmd.Flags().StringVar(&cfg.HiveHost, "hive-host", defaultHiveHost, "the hostname:port for connecting to Hive")
 	startCmd.Flags().BoolVar(&cfg.HiveUseTLS, "hive-use-tls", false, "If true, enables TLS when connecting to Hive")
+	startCmd.Flags().BoolVar(&cfg.HiveTLSInsecureSkipVerify, "hive-tls-insecure-skip-verify", false, "If true, disables TLS verification when connecting to Hive.")
 	startCmd.Flags().StringVar(&cfg.HiveCAFile, "hive-ca-file", "", "The path to the certificate authority to use to connect to Hive. If empty, defaults to system CAs")
+
+	startCmd.Flags().BoolVar(&cfg.HiveUseClientCertAuth, "hive-use-auth", false, "If true, enables TLS client certificate authentication when hive-use-tls is also enabled.")
+	startCmd.Flags().StringVar(&cfg.HiveClientCertFile, "hive-client-cert-file", "", "The path to the client certificate to use to connect to Hive.")
+	startCmd.Flags().StringVar(&cfg.HiveClientKeyFile, "hive-client-key-file", "", "The path to the client private key to use to connect to Hive.")
 
 	startCmd.Flags().StringVar(&cfg.PrestoHost, "presto-host", defaultPrestoHost, "the hostname:port for connecting to Presto.")
 	startCmd.Flags().BoolVar(&cfg.PrestoUseTLS, "presto-use-tls", false, "If true, enables TLS when connecting to Presto.")
@@ -85,7 +90,6 @@ func init() {
 	startCmd.Flags().BoolVar(&cfg.PrestoUseClientCertAuth, "presto-use-auth", false, "If true, enables TLS client certificate authentication when presto-use-tls is also enabled.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientCertFile, "presto-client-cert-file", "", "The path to the client certificate to use to connect to Presto.")
 	startCmd.Flags().StringVar(&cfg.PrestoClientKeyFile, "presto-client-key-file", "", "The path to the client private key to use to connect to Presto.")
-	startCmd.Flags().StringVar(&cfg.PrestoClientCACertFile, "presto-client-ca-cert-file", "", "The path to the client certificate authority to use to connect to Presto.")
 
 	startCmd.Flags().StringVar(&cfg.PrometheusConfig.Address, "prometheus-host", defaultPromHost, "the URL string for connecting to Prometheus")
 	startCmd.Flags().BoolVar(&cfg.PrometheusConfig.SkipTLSVerify, "prometheus-skip-tls-verify", false, "Skip TLS verification")

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -131,7 +131,6 @@ _meteringconfig_reporting_operator_presto_server_secret_name: "reporting-operato
 
 _meteringconfig_reporting_operator_presto_client_secret_name: "reporting-operator-presto-client-tls"
 _meteringconfig_reporting_operator_client_cert: ""
-_meteringconfig_reporting_operator_presto_client_ca_certificate: ""
 _meteringconfig_reporting_operator_client_key: ""
 
 _meteringconfig_reporting_operator_auth_proxy_cookie_seed: ""
@@ -169,11 +168,11 @@ _tls_overrides:
           auth:
             certificate: "{{ _meteringconfig_reporting_operator_client_cert }}"
             key: "{{ _meteringconfig_reporting_operator_client_key }}"
-            caCertificate: "{{ _meteringconfig_reporting_operator_presto_client_ca_certificate }}"
 
             enabled: true
             createSecret: true
             secretName: "{{ _meteringconfig_reporting_operator_presto_client_secret_name }}"
+
       authProxy:
         enabled: true
 
@@ -275,6 +274,8 @@ meteringconfig_create_reporting_operator_prometheus_certificate_authority: "{{ _
 meteringconfig_create_reporting_operator_aws_credentials: "{{ _reporting_op_spec.config.aws.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_presto_tls_secrets: "{{ _reporting_op_spec.config.presto.tls.enabled and _reporting_op_spec.config.presto.tls.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_presto_auth_secrets: "{{ _reporting_op_spec.config.presto.auth.enabled and _reporting_op_spec.config.presto.auth.createSecret | default(false) }}"
+meteringconfig_create_reporting_operator_hive_tls_secrets: "{{ _reporting_op_spec.config.hive.tls.enabled and _reporting_op_spec.config.hive.tls.createSecret | default(false) }}"
+meteringconfig_create_reporting_operator_hive_auth_secrets: "{{ _reporting_op_spec.config.hive.auth.enabled and _reporting_op_spec.config.hive.auth.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_tls_secrets: "{{ _reporting_op_spec.config.tls.api.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_route: "{{ _reporting_op_spec.route.enabled | default(false) }}"
 meteringconfig_create_reporting_operator_cluster_monitoring_view_rbac: "{{ _reporting_op_spec.rbac.createClusterMonitoringViewRBAC | default(true) }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -34,7 +34,6 @@
 - name: Configure reporting-operator to use existing presto client TLS secret data
   set_fact:
     _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-    _meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
     _meteringconfig_reporting_operator_client_cert: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
     _meteringconfig_reporting_operator_client_key: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
   no_log: true

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
@@ -57,10 +57,18 @@
         apis: [ {kind: secrets} ]
         prune_label_value: reporting-operator-presto-tls-secrets
         create: "{{ meteringconfig_create_reporting_operator_presto_tls_secrets }}"
+      - template_file: templates/reporting-operator/reporting-operator-hive-tls-secrets.yaml
+        apis: [ {kind: secrets} ]
+        prune_label_value: reporting-operator-hive-tls-secrets
+        create: "{{ meteringconfig_create_reporting_operator_hive_tls_secrets }}"
       - template_file: templates/reporting-operator/reporting-operator-presto-auth-secrets.yaml
         apis: [ {kind: secrets} ]
         prune_label_value: reporting-operator-presto-auth-secrets
         create: "{{ meteringconfig_create_reporting_operator_presto_auth_secrets }}"
+      - template_file: templates/reporting-operator/reporting-operator-hive-auth-secrets.yaml
+        apis: [ {kind: secrets} ]
+        prune_label_value: reporting-operator-hive-auth-secrets
+        create: "{{ meteringconfig_create_reporting_operator_hive_auth_secrets }}"
       - template_file: templates/reporting-operator/reporting-operator-route.yaml
         apis: [ {kind: route, api_version: 'route.openshift.io/v1'} ]
         prune_label_value: reporting-operator-route


### PR DESCRIPTION
- Add support for configuring hive-server to use ghostunnel to handle TLS and authentication via client certificates for authenticating to Hive.
- Updates reporting-operator to support passing client certificates when connecting to Hive via TLS.
- Add support configuring reporting-operator to use TLS client certificates for authentication to hive server in MeteringConfig.