### PR TITLE
charts,images: Support for configuring Presto to use ghostunnel to authenticate to hive metastore

### DIFF
--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -147,6 +147,8 @@ spec:
 {{- if .Values.hive.spec.metastore.config.auth.enabled }}
         - --allow-cn
         - hive-server
+        - --allow-cn
+        - presto-clients
 {{- else }}
         - --disable-authentication
 {{- end }}

--- a/charts/openshift-metering/templates/presto/_presto_helpers.tpl
+++ b/charts/openshift-metering/templates/presto/_presto_helpers.tpl
@@ -6,7 +6,14 @@ hive.storage-format={{ .Values.hive.spec.config.defaultFileFormat | upper }}
 hive.compression-codec=SNAPPY
 hive.hdfs.authentication.type=NONE
 hive.metastore.authentication.type=NONE
+
+{{- if .Values.presto.spec.config.connectors.hive.metastoreURI }}
 hive.metastore.uri={{ .Values.presto.spec.config.connectors.hive.metastoreURI }}
+{{- else if .Values.presto.spec.config.connectors.hive.tls.enabled }}
+hive.metastore.uri=thrift://localhost:9083
+{{- else }}
+hive.metastore.uri=thrift://hive-metastore:9083
+{{- end }}
 {{- if .Values.presto.spec.config.connectors.hive.metastoreTimeout }}
 hive.metastore-timeout={{ .Values.presto.spec.config.connectors.hive.metastoreTimeout }}
 {{- end }}

--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   initialize_presto.sh: |
     #!/bin/bash
-    set -e
+    set -ex
 
 {{- if .Values.presto.spec.config.auth.enabled }}
     cat $PRESTO_CLIENT_KEYFILE $PRESTO_CLIENT_CRTFILE $PRESTO_CLIENT_CA_CRTFILE > $PRESTO_TRUSTSTORE_PEM
@@ -14,6 +14,11 @@ data:
     # copy all necessary tls.crt/tls.key from read-only secret volumes - append server bundle and CA cert to truststore
     cat $PRESTO_SERVER_KEYFILE $PRESTO_SERVER_CRTFILE $PRESTO_CA_CRTFILE > $PRESTO_KEYSTORE_PEM
     cat $PRESTO_SERVER_KEYFILE $PRESTO_SERVER_CRTFILE $PRESTO_CA_CRTFILE >> $PRESTO_TRUSTSTORE_PEM
+{{- end }}
+
+{{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
+    cp /hive-metastore-auth-tls-secrets/* /opt/ghostunnel/tls
+    cat $GHOSTUNNEL_CLIENT_TLS_CERT $GHOSTUNNEL_CLIENT_TLS_KEY > $GHOSTUNNEL_CLIENT_KEYSTORE
 {{- end }}
 
     cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/
@@ -41,8 +46,8 @@ data:
       echo "hive.s3.aws-access-key=$AWS_ACCESS_KEY_ID" >> "$HIVE_CATALOG_CONFIG"
       echo "hive.s3.aws-secret-key=$AWS_SECRET_ACCESS_KEY" >> "$HIVE_CATALOG_CONFIG"
     fi
-  
- 
+
+
 
     # add UID to /etc/passwd if missing
     if ! whoami &> /dev/null; then

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -33,9 +33,12 @@ spec:
 {{- end }}
 {{- if and .Values.presto.spec.config.tls.enabled .Values.presto.spec.config.tls.createSecret }}
         presto-server-tls-hash: {{ include (print $.Template.BasePath "/presto/presto-tls-secrets.yaml") . | sha256sum }}
-{{- if and .Values.presto.spec.config.auth.enabled .Values.presto.spec.config.auth.createSecret}}
+{{- if and .Values.presto.spec.config.auth.enabled .Values.presto.spec.config.auth.createSecret }}
         presto-client-tls-hash: {{ include (print $.Template.BasePath "/presto/presto-auth-secrets.yaml") . | sha256sum }}
 {{- end }}
+{{- end }}
+{{- if and .Values.presto.spec.config.connectors.hive.tls.enabled .Values.presto.spec.config.connectors.hive.tls.createSecret }}
+        presto-hive-metastore-tls-hash: {{ include (print $.Template.BasePath "/presto/presto-hive-metastore-tls-secrets.yaml") . | sha256sum }}
 {{- end }}
 {{- if .Values.presto.spec.annotations }}
 {{ toYaml .Values.presto.spec.annotations | indent 8 }}
@@ -84,6 +87,16 @@ spec:
           value: /presto-client/ca.crt
 {{- end }}
 {{- end }}
+{{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
+        - name: GHOSTUNNEL_CLIENT_CA_CRTFILE
+          value: /opt/ghostunnel/tls/ca.crt
+        - name: GHOSTUNNEL_CLIENT_TLS_CERT
+          value: /opt/ghostunnel/tls/tls.crt
+        - name: GHOSTUNNEL_CLIENT_TLS_KEY
+          value: /opt/ghostunnel/tls/tls.key
+        - name: GHOSTUNNEL_CLIENT_KEYSTORE
+          value: /opt/ghostunnel/tls/keystore-combined.pem
+{{- end }}
 {{- include "presto-common-env" . | indent 8 }}
         volumeMounts:
         - name: presto-etc
@@ -105,6 +118,12 @@ spec:
         - name: presto-client-pem
           mountPath: /presto-client
 {{- end }}
+{{- end }}
+{{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
+        - name: hive-metastore-auth-tls
+          mountPath: /opt/ghostunnel/tls
+        - name: hive-metastore-auth-tls-secrets
+          mountPath: /hive-metastore-auth-tls-secrets
 {{- end }}
         resources:
           limits:
@@ -153,6 +172,30 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.presto.spec.coordinator.resources | indent 10 }}
+{{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
+      - name: ghostunnel-client
+        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
+        env:
+        - name: GHOSTUNNEL_CLIENT_CA_CRTFILE
+          value: /opt/ghostunnel/tls/ca.crt
+        - name: GHOSTUNNEL_CLIENT_KEYSTORE
+          value: /opt/ghostunnel/tls/keystore-combined.pem
+        command: ["ghostunnel"]
+        args:
+        - client
+        - --listen
+        - localhost:9083
+        - --target
+        - hive-metastore:8443
+        - --keystore
+        -  $(GHOSTUNNEL_CLIENT_KEYSTORE)
+        - --cacert
+        -  $(GHOSTUNNEL_CLIENT_CA_CRTFILE)
+        volumeMounts:
+        - name: hive-metastore-auth-tls
+          mountPath: /opt/ghostunnel/tls
+{{- end }}
       volumes:
       - name: presto-coordinator-config
         configMap:
@@ -189,6 +232,13 @@ spec:
         secret:
           secretName: {{ .Values.presto.spec.config.auth.secretName }}
 {{- end }}
+{{- end }}
+{{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
+      - name: hive-metastore-auth-tls
+        emptyDir: {}
+      - name: hive-metastore-auth-tls-secrets
+        secret:
+          secretName: {{ .Values.presto.spec.config.connectors.hive.tls.secretName }}
 {{- end }}
 {{- if .Values.hive.spec.config.sharedVolume.enabled }}
       - name: hive-warehouse-data

--- a/charts/openshift-metering/templates/presto/presto-hive-metastore-tls-secrets.yaml
+++ b/charts/openshift-metering/templates/presto/presto-hive-metastore-tls-secrets.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.presto.spec.config.connectors.hive.tls.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.presto.spec.config.connectors.hive.tls.secretName }}
+  labels:
+    app: presto
+type: Opaque
+data:
+  tls.crt: {{ .Values.presto.spec.config.connectors.hive.tls.certificate | b64enc | quote }}
+  tls.key: {{ .Values.presto.spec.config.connectors.hive.tls.key | b64enc | quote }}
+  ca.crt: {{.Values.presto.spec.config.connectors.hive.tls.caCertificate | b64enc | quote }}
+{{- end -}}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -467,8 +467,20 @@ presto:
           hadoopConfigSecretName: hadoop-config
           useHadoopConfig: true
 
-          metastoreURI: thrift://hive-metastore:9083
+          metastoreURI: null
           metastoreTimeout: null
+
+          tls:
+            # client cert
+            certificate: ""
+            # client private key
+            key: ""
+            # CA for metastore
+            caCertificate: ""
+
+            createSecret: false
+            enabled: false
+            secretName: ""
 
         extraConnectorFiles: []
 

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -254,6 +254,7 @@ meteringconfig_create_hive_server_metastore_tls_secrets: "{{ _hive_spec.server.c
 meteringconfig_create_hive_server_tls_secrets: "{{ _hive_spec.server.config.tls.enabled and _hive_spec.server.config.tls.createSecret | default(false) }}"
 
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.aws.createSecret | default(false) }}"
+meteringconfig_create_presto_hive_metastore_tls_secrets: "{{ _presto_spec.config.connectors.hive.tls.createSecret | default(false) }}"
 
 #
 # Enabling Presto TLS/Auth by Default

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
@@ -17,6 +17,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: presto-auth-secrets
         create: "{{ meteringconfig_create_presto_auth_secrets }}"
+      - template_file: templates/presto/presto-hive-metastore-tls-secrets.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: presto-hive-metastore-tls-secrets
+        create: "{{ meteringconfig_create_presto_hive_metastore_tls_secrets }}"
       - template_file: templates/presto/presto-catalog-config-secret.yaml
         apis: [ {kind: secret} ]
         prune_label_value: presto-catalog-config-secret


### PR DESCRIPTION
Enables Presto to be configured to use ghostunnel to connect to hive-metastore using TLS client certificate authentication.