### PR TITLE
charts/openshift-metering: Auto-configure default hive-host for reporting-operator

### DIFF
--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -10,13 +10,17 @@ data:
   log-reports: {{ $operatorValues.spec.config.logReports | quote}}
   log-ddl-queries: {{ $operatorValues.spec.config.logDDLQueries | quote}}
   log-dml-queries: {{ $operatorValues.spec.config.logDMLQueries | quote}}
+{{- if $operatorValues.spec.config.hive.host }}
   hive-host: {{ $operatorValues.spec.config.hive.host | quote }}
-{{- if $operatorValues.spec.config.hive.tls.enabled }}
+{{- else if $operatorValues.spec.config.hive.tls.enabled }}
+  hive-host: "hive-server:10001"
   hive-ca-file: "/var/run/secrets/hive-tls/ca.crt"
 {{- if $operatorValues.spec.config.hive.auth.enabled }}
   hive-client-cert-file: "/var/run/secrets/hive-auth/tls.crt"
   hive-client-key-file: "/var/run/secrets/hive-auth/tls.key"
 {{- end }}
+{{- else }}
+  hive-host: "hive-server:10000"
 {{- end }}
 
   presto-host: {{ $operatorValues.spec.config.presto.host | quote }}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -256,8 +256,7 @@ reporting-operator:
         secretName: ""
 
       hive:
-        # note this will contain more information once TLS/Auth is enabled w/ Hive
-        host: hive-server:10000
+        host: null
         tls:
           # client cert
           certificate: ""


### PR DESCRIPTION
If spec.reporting-operator.spec.config.hive.host is it takes precedence
over other options.  Default to hive-server:10000 unless
spec.reporting-operator.spec.config.hive.tls.enabled, then use
hive-server:10001.