### PR TITLE
charts/openshift-metering: Enable the metering route by default.

### DIFF
--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -377,7 +377,7 @@ reporting-operator:
       type: ClusterIP
 
     route:
-      enabled: false
+      enabled: true
       name: metering
 
     authProxy:


### PR DESCRIPTION
This could potentially be done by in the metering-ansible-operator by modifying the variable, `meteringconfig_create_reporting_operator_route: "{{ _reporting_op_spec.route.enabled | default(false) }}"`.