### PR TITLE
images/metering-ansible-operator: Rename TLS override variables to avoid being printed.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -149,7 +149,7 @@ _meteringconfig_presto_client_key: ""
 _meteringconfig_tls_root_ca_certificate: ""
 _meteringconfig_tls_root_ca_key: ""
 
-meteringconfig_root_ca_overrides:
+_meteringconfig_root_ca_overrides:
   tls:
     certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
     key: "{{ _meteringconfig_tls_root_ca_key }}"
@@ -208,7 +208,7 @@ _tls_overrides:
 
 # check if the user's spec contains the top-level tls.enabled field. if true, use the value stored in that field, else default to the value stored in values.yaml
 meteringconfig_tls_enabled: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides, recursive=True) | json_query('tls.enabled') }}"
-meteringconfig_tls_overrides: "{{ meteringconfig_tls_enabled | ternary(_tls_overrides, {}) }}"
+_meteringconfig_tls_overrides: "{{ meteringconfig_tls_enabled | ternary(_tls_overrides, {}) }}"
 
 # openshift-reporting overrides
 meteringconfig_reporting_enable_post_kube_1_14_datasources: "{{ _openshift_reporting_default_spec.defaultReportDataSources.postKube_1_14.enabled }}"
@@ -221,7 +221,7 @@ meteringconfig_reporting_overrides:
           enabled: "{{ meteringconfig_reporting_enable_post_kube_1_14_datasources }}"
 
 # combine the _meteringconfig_tls_overrides dictionary last to enforce when spec.tls.enabled is specified and set to true
-meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_reporting_overrides, meteringconfig_spec_overrides, meteringconfig_root_ca_overrides, meteringconfig_tls_overrides, recursive=True) }}"
+meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_reporting_overrides, meteringconfig_spec_overrides, _meteringconfig_root_ca_overrides, _meteringconfig_tls_overrides, recursive=True) }}"
 
 meteringconfig_storage_s3_create_bucket: "{{ meteringconfig_spec | json_query('storage.hive.s3.createBucket') }}"
 meteringconfig_storage_s3_bucket_name: "{{ (meteringconfig_spec | json_query('storage.hive.s3.bucket') | default('', true)).split('/')[0] }}"


### PR DESCRIPTION
This somehow was reverted when I rebased my original PR to pull in merged master changes.