### PR TITLE
Disable unauthenticated Hive ports when TLS is enabled

### DIFF
--- a/charts/openshift-metering/templates/hive/hive-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-configmap.yaml
@@ -32,7 +32,7 @@ data:
       <property>
         <name>hive.metastore.uris</name>
 {{- if .Values.hive.spec.metastore.config.tls.enabled }}
-        <value>thrift://localhost:8443</value>
+        <value>thrift://localhost:9083</value>
 {{- else }}
         <value>thrift://hive-metastore:9083</value>
 {{- end }}

--- a/charts/openshift-metering/templates/hive/hive-metastore-service.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-service.yaml
@@ -9,10 +9,13 @@ spec:
   ports:
   - name: meta
     port: 9083
+{{- if .Values.hive.spec.metastore.config.tls.enabled }}
+    targetPort: ghostunnel
+{{- else }}
+    targetPort: meta
+{{- end }}
   - name: metrics
     port: 8082
-  - name: ghostunnel
-    port: 8443
   selector:
     app: hive
     hive: metastore

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -68,9 +68,10 @@ spec:
         image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         ports:
+{{- if not .Values.hive.spec.metastore.config.tls.enabled }}
         - name: meta
           containerPort: 9083
-          protocol: TCP
+{{- end }}
         - containerPort: 8082
           name: metrics
 {{- if .Values.hive.spec.metastore.readinessProbe }}
@@ -150,7 +151,7 @@ spec:
         args:
         - server
         - --listen
-        - 0.0.0.0:8443
+        - 0.0.0.0:9084
         - --target
         - localhost:9083
         - --key
@@ -169,7 +170,7 @@ spec:
 {{- end }}
         ports:
         - name: ghostunnel
-          containerPort: 8443
+          containerPort: 9084
         volumeMounts:
         - name: hive-metastore-tls-secret
           mountPath: /opt/hive/tls

--- a/charts/openshift-metering/templates/hive/hive-server-service.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-service.yaml
@@ -9,12 +9,15 @@ spec:
   ports:
   - name: thrift
     port: 10000
+{{- if .Values.hive.spec.server.config.tls.enabled }}
+    targetPort: ghostunnel
+{{- else }}
+    targetPort: thrift
+{{- end }}
   - name: ui
     port: 10002
   - name: metrics
     port: 8082
-  - name: ghostunnel
-    port: 10001
   selector:
     app: hive
     hive: server

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -223,7 +223,7 @@ spec:
 {{- end }}
         ports:
         - name: ghostunnel
-          containerPort: 8443
+          containerPort: 100001
         volumeMounts:
         - name: hive-server-tls-secret
           mountPath: /opt/hive/server-tls

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -94,16 +94,14 @@ spec:
         image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         ports:
+{{- if not .Values.hive.spec.server.config.tls.enabled }}
         - name: thrift
           containerPort: 10000
-          protocol: TCP
         - name: ui
           containerPort: 10002
-          protocol: TCP
+{{- end }}
         - containerPort: 8082
           name: metrics
-        - containerPort: 10004
-          name: metastore
 {{- if .Values.hive.spec.server.readinessProbe }}
         readinessProbe:
 {{ toYaml .Values.hive.spec.server.readinessProbe | indent 10 }}
@@ -223,7 +221,7 @@ spec:
 {{- end }}
         ports:
         - name: ghostunnel
-          containerPort: 100001
+          containerPort: 10001
         volumeMounts:
         - name: hive-server-tls-secret
           mountPath: /opt/hive/server-tls

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -180,9 +180,9 @@ spec:
         args:
         - client
         - --listen
-        - localhost:8443
+        - localhost:9083
         - --target
-        - hive-metastore:8443
+        - hive-metastore:9083
         - --keystore
         -  $(GHOSTUNNEL_CLIENT_KEYSTORE)
         - --cacert

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -193,7 +193,7 @@ spec:
         - --listen
         - localhost:9083
         - --target
-        - hive-metastore:8443
+        - hive-metastore:9083
         - --keystore
         -  $(GHOSTUNNEL_CLIENT_KEYSTORE)
         - --cacert

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-config.yaml
@@ -10,17 +10,19 @@ data:
   log-reports: {{ $operatorValues.spec.config.logReports | quote}}
   log-ddl-queries: {{ $operatorValues.spec.config.logDDLQueries | quote}}
   log-dml-queries: {{ $operatorValues.spec.config.logDMLQueries | quote}}
+
 {{- if $operatorValues.spec.config.hive.host }}
   hive-host: {{ $operatorValues.spec.config.hive.host | quote }}
-{{- else if $operatorValues.spec.config.hive.tls.enabled }}
-  hive-host: "hive-server:10001"
+{{- else }}
+  hive-host: "hive-server:10000"
+{{- end }}
+
+{{- if $operatorValues.spec.config.hive.tls.enabled }}
   hive-ca-file: "/var/run/secrets/hive-tls/ca.crt"
 {{- if $operatorValues.spec.config.hive.auth.enabled }}
   hive-client-cert-file: "/var/run/secrets/hive-auth/tls.crt"
   hive-client-key-file: "/var/run/secrets/hive-auth/tls.key"
 {{- end }}
-{{- else }}
-  hive-host: "hive-server:10000"
 {{- end }}
 
   presto-host: {{ $operatorValues.spec.config.presto.host | quote }}


### PR DESCRIPTION
Currently this isn't enough because our pods still listen on 0.0.0.0 which means these ports are still accessible.
The config option for setting the bind address for hiveserver2 exists, but doesn't seem to work, and the option for hive-metastore doesn't exist except for in the master branch/hive 4.0 for hive.