### PR TITLE
core-site.xml credentials injection

### DIFF
--- a/charts/openshift-metering/templates/hadoop/_hadoop_config_helpers.tpl
+++ b/charts/openshift-metering/templates/hadoop/_hadoop_config_helpers.tpl
@@ -60,5 +60,9 @@
       <name>fs.defaultFS</name>
       <value>{{ .Values.hadoop.spec.config.defaultFS }}</value>
   </property>
+  <property>
+      <name>fs.AbstractFileSystem.wasb.Impl</name>
+      <value>org.apache.hadoop.fs.azure.Wasb</value>
+  </property>
 </configuration>
 {{- end }}

--- a/charts/openshift-metering/templates/hadoop/hadoop-azure-credentials.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-azure-credentials.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.hadoop.spec.config.azure.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hadoop-azure-credentials
+data:
+{{- if .Values.hadoop.spec.config.azure.storageAccountName }}
+  azure-storage-account-name: {{ .Values.hadoop.spec.config.azure.storageAccountName | b64enc | quote}}
+{{- end}}
+{{- if .Values.hadoop.spec.config.azure.secretAccessKey }}
+  azure-secret-access-key: {{ .Values.hadoop.spec.config.azure.secretAccessKey | b64enc | quote}}
+{{- end}}
+{{- end -}}

--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -3,6 +3,14 @@ kind: ConfigMap
 metadata:
   name: hadoop-scripts
 data:
+  copy-hadoop-config.sh: |
+    #!/bin/bash
+    set -ex
+    cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/
+    cd /hadoop-config/
+    faq '.configuration.property+=[{name: ("fs.azure.account.key." + env.AZURE_STORAGE_ACCOUNT_NAME + ".blob.core.windows.net"), value: env.AZURE_SECRET_ACCESS_KEY }]' core-site.xml > core-site.xml.temp
+    cp core-site.xml.temp core-site.xml
+
   entrypoint.sh: |
     #!/bin/bash
     set -e
@@ -52,8 +60,6 @@ data:
             rm /tmp/passwd
         fi
     fi
-
-    cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/
 
     # symlink our configuration files to the correct location
     ln -s -f /hadoop-config/core-site.xml /etc/hadoop/core-site.xml

--- a/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
@@ -133,15 +133,32 @@ spec:
       - name: copy-starter-hadoop
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
-        command:
-        - '/bin/bash'
-        - '-c'
-        - 'cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/'
+        command: ["/hadoop-scripts/copy-hadoop-config.sh"]
+{{- if or .Values.hadoop.spec.config.azure.secretName .Values.hadoop.spec.config.azure.createSecret }}
+        env:
+        - name: AZURE_STORAGE_ACCOUNT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.hadoop.spec.config.azure.secretName | default "hadoop-azure-credentials" }}"
+              key: azure-storage-account-name
+        - name: AZURE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.hadoop.spec.config.azure.secretName | default "hadoop-azure-credentials" }}"
+              key: azure-secret-access-key
+{{- end }}
         volumeMounts:
         - name: hadoop-config
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+        - name: hadoop-scripts
+          mountPath: /hadoop-scripts
+      volumes:
+      - name: hadoop-scripts
+        configMap:
+          name: hadoop-scripts
+          defaultMode: 0775
       containers:
       - name: hdfs-datanode
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
@@ -245,11 +262,11 @@ spec:
       - name: hadoop-starting-config
         secret:
           secretName: "{{ .Values.hadoop.spec.configSecretName }}"
-          defaultMode: 0555
+          defaultMode: 0775
       - name: hadoop-scripts
         configMap:
           name: hadoop-scripts
-          defaultMode: 0555
+          defaultMode: 0775
       - name: hdfs-jmx-config
         configMap:
           name: hdfs-jmx-config

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -100,15 +100,32 @@ spec:
       - name: copy-starter-hadoop
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
-        command:
-        - '/bin/bash'
-        - '-c'
-        - 'cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/'
+        command: ["/hadoop-scripts/copy-hadoop-config.sh"]
+{{- if or .Values.hadoop.spec.config.azure.secretName .Values.hadoop.spec.config.azure.createSecret }}
+        env:
+        - name: AZURE_STORAGE_ACCOUNT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.hadoop.spec.config.azure.secretName | default "hadoop-azure-credentials" }}"
+              key: azure-storage-account-name
+        - name: AZURE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.hadoop.spec.config.azure.secretName | default "hadoop-azure-credentials" }}"
+              key: azure-secret-access-key
+{{- end }}
         volumeMounts:
         - name: hadoop-config
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+        - name: hadoop-scripts
+          mountPath: /hadoop-scripts
+      volumes:
+      - name: hadoop-scripts
+        configMap:
+          name: hadoop-scripts
+          defaultMode: 0775
       containers:
       - name: hdfs-namenode
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
@@ -205,11 +222,11 @@ spec:
       - name: hadoop-starting-config
         secret:
           secretName: "{{ .Values.hadoop.spec.configSecretName }}"
-          defaultMode: 0555
+          defaultMode: 0775
       - name: hadoop-scripts
         configMap:
           name: hadoop-scripts
-          defaultMode: 0555
+          defaultMode: 0775
       - name: hdfs-jmx-config
         configMap:
           name: hdfs-jmx-config

--- a/charts/openshift-metering/templates/hive/hive-azure-credentials-secret.yaml
+++ b/charts/openshift-metering/templates/hive/hive-azure-credentials-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.hive.spec.config.azure.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hive-azure-credentials
+data:
+{{- if .Values.hive.spec.config.azure.storageAccountName }}
+  azure-storage-account-name: {{ .Values.hive.spec.config.azure.storageAccountName | b64enc | quote}}
+{{- end}}
+{{- if .Values.hive.spec.config.azure.secretAccessKey }}
+  azure-secret-access-key: {{ .Values.hive.spec.config.azure.secretAccessKey | b64enc | quote}}
+{{- end}}
+{{- end -}}

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -30,6 +30,7 @@ spec:
         hive-scripts-hash: {{ include (print $.Template.BasePath "/hive/hive-scripts-configmap.yaml") . | sha256sum }}
         hive-jmx-config-hash: {{ include (print $.Template.BasePath "/hive/hive-jmx-config.yaml") . | sha256sum }}
         hive-aws-credentials-secret-hash: {{ include (print $.Template.BasePath "/hive/hive-aws-credentials-secret.yaml") . | sha256sum }}
+        hive-azure-credentials-secret-hash: {{ include (print $.Template.BasePath "/hive/hive-azure-credentials-secret.yaml") . | sha256sum }}
 {{- if .Values.hive.spec.annotations }}
 {{ toYaml .Values.hive.spec.annotations | indent 8 }}
 {{- end }}
@@ -52,15 +53,32 @@ spec:
       - name: copy-starter-hive
         image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
-        command:
-        - '/bin/bash'
-        - '-c'
-        - 'cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/'
+        command: ["/hive-scripts/copy-hadoop-config.sh"]
+{{- if or .Values.hive.spec.config.azure.secretName .Values.hive.spec.config.azure.createSecret }}
+        env:
+        - name: AZURE_STORAGE_ACCOUNT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.hive.spec.config.azure.secretName | default "hive-azure-credentials" }}"
+              key: azure-storage-account-name
+        - name: AZURE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.hive.spec.config.azure.secretName | default "hive-azure-credentials" }}"
+              key: azure-secret-access-key
+{{- end }}
         volumeMounts:
         - name: hadoop-config
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+        - name: hive-scripts
+          mountPath: /hive-scripts
+      volumes:
+      - name: hive-scripts
+        configMap:
+          name: hive-scripts
+          defaultMode: 0555
       containers:
       - name: metastore
         command: ["/hive-scripts/entrypoint.sh"]

--- a/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
@@ -3,6 +3,14 @@ kind: ConfigMap
 metadata:
   name: hive-scripts
 data:
+  copy-hadoop-config.sh: |
+    #!/bin/bash
+    set -ex
+    cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/
+    cd /hadoop-config/
+    faq '.configuration.property+=[{name: ("fs.azure.account.key." + env.AZURE_STORAGE_ACCOUNT_NAME + ".blob.core.windows.net"), value: env.AZURE_SECRET_ACCESS_KEY }]' core-site.xml > core-site.xml.temp
+    cp core-site.xml.temp core-site.xml
+
   entrypoint.sh: |
     #!/bin/bash
     set -e

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -30,6 +30,7 @@ spec:
         hive-scripts-hash: {{ include (print $.Template.BasePath "/hive/hive-scripts-configmap.yaml") . | sha256sum }}
         hive-jmx-config-hash: {{ include (print $.Template.BasePath "/hive/hive-jmx-config.yaml") . | sha256sum }}
         hive-aws-credentials-secret-hash: {{ include (print $.Template.BasePath "/hive/hive-aws-credentials-secret.yaml") . | sha256sum }}
+        hive-azure-credentials-secret-hash: {{ include (print $.Template.BasePath "/hive/hive-azure-credentials-secret.yaml") . | sha256sum }}
 {{- if .Values.hive.spec.annotations }}
 {{ toYaml .Values.hive.spec.annotations | indent 8 }}
 {{- end }}
@@ -77,15 +78,32 @@ spec:
       - name: copy-starter-hive
         image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
-        command:
-        - '/bin/bash'
-        - '-c'
-        - 'cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/'
+        command: ["/hive-scripts/copy-hadoop-config.sh"]
+{{- if or .Values.hive.spec.config.azure.secretName .Values.hive.spec.config.azure.createSecret }}
+        env:
+        - name: AZURE_STORAGE_ACCOUNT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.hive.spec.config.azure.secretName | default "hive-azure-credentials" }}"
+              key: azure-storage-account-name
+        - name: AZURE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.hive.spec.config.azure.secretName | default "hive-azure-credentials" }}"
+              key: azure-secret-access-key
+{{- end }}
         volumeMounts:
         - name: hadoop-config
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+        - name: hive-scripts
+          mountPath: /hive-scripts
+      volumes:
+      - name: hive-scripts
+        configMap:
+          name: hive-scripts
+          defaultMode: 0555
       containers:
       - name: hiveserver2
         command: ["/hive-scripts/entrypoint.sh"]

--- a/charts/openshift-metering/templates/presto/presto-azure-credentials-secret.yaml
+++ b/charts/openshift-metering/templates/presto/presto-azure-credentials-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.presto.spec.config.azure.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: presto-azure-credentials
+data:
+{{- if .Values.presto.spec.config.azure.storageAccountName }}
+  azure-storage-account-name: {{ .Values.presto.spec.config.azure.storageAccountName | b64enc | quote}}
+{{- end}}
+{{- if .Values.presto.spec.config.azure.secretAccessKey }}
+  azure-secret-access-key: {{ .Values.presto.spec.config.azure.secretAccessKey | b64enc | quote}}
+{{- end}}
+{{- end -}}

--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -23,6 +23,11 @@ data:
 
     cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/
     cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/
+    cd /hadoop-config/
+    faq '.configuration.property+=[{name: ("fs.azure.account.key." + env.AZURE_STORAGE_ACCOUNT_NAME + ".blob.core.windows.net"), value: env.AZURE_SECRET_ACCESS_KEY }]' core-site.xml > core-site.xml.temp
+    cp core-site.xml.temp core-site.xml
+
+
 
   entrypoint.sh: |
     #!/bin/bash

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -28,6 +28,7 @@ spec:
         presto-common-config-hash: {{ include (print $.Template.BasePath "/presto/presto-common-config.yaml") . | sha256sum }}
         presto-catalog-config-hash: {{ include (print $.Template.BasePath "/presto/presto-catalog-config-secret.yaml") . | sha256sum }}
         presto-jmx-config-hash: {{ include (print $.Template.BasePath "/presto/presto-jmx-config.yaml") . | sha256sum }}
+        presto-azure-credentials-secret-hash: {{ include (print $.Template.BasePath "/presto/presto-azure-credentials-secret.yaml") . | sha256sum }}
 {{- if .Values.presto.spec.config.aws.createSecret -}}
         presto-aws-credentials-hash: {{ include (print $.Template.BasePath "/presto/presto-aws-credentials-secret.yaml") . | sha256sum }}
 {{- end }}
@@ -96,6 +97,18 @@ spec:
           value: /opt/ghostunnel/tls/tls.key
         - name: GHOSTUNNEL_CLIENT_KEYSTORE
           value: /opt/ghostunnel/tls/keystore-combined.pem
+{{- end }}
+{{- if or .Values.presto.spec.config.azure.secretName .Values.presto.spec.config.azure.createSecret }}
+        - name: AZURE_STORAGE_ACCOUNT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.presto.spec.config.azure.secretName | default "presto-azure-credentials" }}"
+              key: azure-storage-account-name
+        - name: AZURE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.presto.spec.config.azure.secretName | default "presto-azure-credentials" }}"
+              key: azure-secret-access-key
 {{- end }}
 {{- include "presto-common-env" . | indent 8 }}
         volumeMounts:

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -465,6 +465,12 @@ presto:
         createSecret: false
         secretName: ""
 
+      azure:
+        storageAccountName: ""
+        secretAccessKey: ""
+        createSecret: false
+        secretName: ""
+
       tls:
         # server cert
         certificate: ""
@@ -634,6 +640,12 @@ hive:
         createSecret: false
         secretName: ""
 
+      azure:
+        storageAccountName: ""
+        secretAccessKey: ""
+        createSecret: false
+        secretName: ""
+
       sharedVolume:
         enabled: false
         mountPath: /user/hive/warehouse
@@ -789,6 +801,12 @@ hadoop:
 
       aws:
         accessKeyID: ""
+        secretAccessKey: ""
+        createSecret: false
+        secretName: ""
+
+      azure:
+        storageAccountName: ""
         secretAccessKey: ""
         createSecret: false
         secretName: ""

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -92,7 +92,6 @@ _storage_overrides:
           defaultFS: "s3a://{{ _storage_spec | json_query('hive.s3.bucket') | regex_replace('\\/?$', '/') }}"
         hdfs:
           enabled: false
-
   hdfs:
     hadoop:
       spec:
@@ -253,16 +252,19 @@ meteringconfig_enable_reporting_aws_billing: "{{ _openshift_reporting_spec.awsBi
 
 meteringconfig_enable_hdfs: "{{ _hadoop_spec.hdfs.enabled | default(true) }}"
 meteringconfig_create_hadoop_aws_credentials: "{{ _hadoop_spec.config.aws.createSecret | default(false) }}"
+meteringconfig_create_hadoop_azure_credentials: "{{ _hadoop_spec.config.azure.createSecret | default(false) }}"
 
 meteringconfig_create_hive_metastore_pvc: "{{ _hive_spec.metastore.storage.create | default(true) }}"
 meteringconfig_create_hive_shared_volume_pvc: "{{ _hive_spec.config.sharedVolume.enabled and _hive_spec.config.sharedVolume.createPVC | default(false) }}"
 meteringconfig_create_hive_aws_credentials: "{{ _hive_spec.config.aws.createSecret | default(false) }}"
+meteringconfig_create_hive_azure_credentials: "{{ _hive_spec.config.azure.createSecret | default(false) }}"
 
 meteringconfig_create_hive_metastore_tls_secrets: "{{ _hive_spec.metastore.config.tls.enabled and _hive_spec.metastore.config.tls.createSecret | default(false) }}"
 meteringconfig_create_hive_server_metastore_tls_secrets: "{{ _hive_spec.server.config.metastoreTLS.enabled and _hive_spec.server.config.metastoreTLS.createSecret | default(false) }}"
 meteringconfig_create_hive_server_tls_secrets: "{{ _hive_spec.server.config.tls.enabled and _hive_spec.server.config.tls.createSecret | default(false) }}"
 
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.aws.createSecret | default(false) }}"
+meteringconfig_create_presto_azure_credentials: "{{ _presto_spec.config.azure.createSecret | default(false) }}"
 meteringconfig_create_presto_hive_metastore_tls_secrets: "{{ _presto_spec.config.connectors.hive.tls.createSecret | default(false) }}"
 
 #

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
@@ -14,6 +14,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: hadoop-aws-credentials
         create: "{{ meteringconfig_create_hadoop_aws_credentials }}"
+      - template_file: templates/hadoop/hadoop-azure-credentials.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: hadoop-azure-credentials
+        create: "{{ meteringconfig_create_hadoop_azure_credentials }}"
       - template_file: templates/hadoop/hadoop-scripts.yaml
         apis: [ {kind: configmap} ]
         prune_label_value: hadoop-scripts

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -17,6 +17,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: hive-aws-credentials-secret
         create: "{{ meteringconfig_create_hive_aws_credentials }}"
+      - template_file: templates/hive/hive-azure-credentials-secret.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: hive-azure-credentials-secret
+        create: "{{ meteringconfig_create_hive_azure_credentials }}"
       - template_file: templates/hive/hive-metastore-tls-secrets.yaml
         apis: [ {kind: secret} ]
         prune_label_value: hive-metastore-tls-secrets

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
@@ -9,6 +9,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: presto-aws-credentials-secret
         create: "{{ meteringconfig_create_presto_aws_credentials }}"
+      - template_file: templates/presto/presto-azure-credentials-secret.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: presto-azure-credentials-secret
+        create: "{{ meteringconfig_create_presto_azure_credentials }}"
       - template_file: templates/presto/presto-tls-secrets.yaml
         apis: [ {kind: secret} ]
         prune_label_value: presto-tls-secrets


### PR DESCRIPTION
…h commands to initialize_presto.sh and creadted azure_secret_copy.sh in hadoop-scripts.yaml and hive-scripts-configmap.yaml to edit core-site.xml dynamically, adding in sensitive azure account details.