### PR TITLE
Fix issues with database/table cleanup

### DIFF
--- a/pkg/hive/query.go
+++ b/pkg/hive/query.go
@@ -118,7 +118,7 @@ func generateDropDatabaseSQL(dbName string, ignoreNotExists, cascade bool) strin
 		`DROP DATABASE
 %s
 %s
-%s`, dbName, ifExists, cascadeStr)
+%s`, ifExists, dbName, cascadeStr)
 }
 
 // generateColumnListSQL returns a Hive CREATE column string from a slice of

--- a/pkg/operator/hivetables.go
+++ b/pkg/operator/hivetables.go
@@ -404,6 +404,9 @@ func (op *Reporting) waitForHiveTable(namespace, name string, pollInterval, time
 func (op *Reporting) dropHiveTable(hiveTable *metering.HiveTable) error {
 	tableName := hiveTable.Status.TableName
 	databaseName := hiveTable.Status.DatabaseName
+	if tableName == "" {
+		return nil
+	}
 	logger := op.logger.WithFields(log.Fields{"hiveTable": hiveTable.Name, "namespace": hiveTable.Namespace, "tableName": tableName})
 	logger.Infof("dropping hive table %s", tableName)
 	err := op.hiveTableManager.DropTable(databaseName, tableName, true)

--- a/pkg/operator/prestotables.go
+++ b/pkg/operator/prestotables.go
@@ -250,6 +250,9 @@ func prestoTableNeedsFinalizer(prestoTable *metering.PrestoTable) bool {
 
 func (op *Reporting) dropPrestoTable(prestoTable *metering.PrestoTable) error {
 	if !prestoTable.Spec.Unmanaged {
+		if prestoTable.Status.TableName == "" {
+			return nil
+		}
 		if prestoTable.Status.View {
 			return op.prestoTableManager.DropView(prestoTable.Status.Catalog, prestoTable.Status.Schema, prestoTable.Status.TableName, true)
 		} else {

--- a/pkg/operator/storagelocations.go
+++ b/pkg/operator/storagelocations.go
@@ -165,7 +165,7 @@ func storageLocationNeedsFinalizer(storageLocation *metering.StorageLocation) bo
 
 func (op *Reporting) deleteStorage(storageLocation *metering.StorageLocation) error {
 	if storageLocation.Spec.Hive != nil {
-		if !storageLocation.Spec.Hive.UnmanagedDatabase {
+		if !storageLocation.Spec.Hive.UnmanagedDatabase && storageLocation.Status.Hive.DatabaseName != "" {
 			return op.hiveDatabaseManager.DropDatabase(storageLocation.Status.Hive.DatabaseName, true, false)
 		}
 	}


### PR DESCRIPTION
First commit fixes a panic dropping a database early during startup when finalizers are enabled.
Other commits ensure we remove finalizers when handling deletions, even if EnableFinalizers is false.
This is important in case the EnableFinalizers config changes from true to false, and when resources may have their finalizers set already.
Also fixes invalid SQL for dropping Hive databases.