### PR TITLE
Enable TLS in the reporting-operator, Presto, and Hive by default.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -130,8 +130,15 @@ _meteringconfig_reporting_operator_presto_server_ca_certificate: ""
 _meteringconfig_reporting_operator_presto_server_secret_name: "reporting-operator-presto-server-tls"
 
 _meteringconfig_reporting_operator_presto_client_secret_name: "reporting-operator-presto-client-tls"
-_meteringconfig_reporting_operator_client_cert: ""
-_meteringconfig_reporting_operator_client_key: ""
+_meteringconfig_reporting_operator_presto_client_cert: ""
+_meteringconfig_reporting_operator_presto_client_key: ""
+
+_meteringconfig_reporting_operator_hive_client_secret_name: "reporting-operator-hive-client-tls"
+_meteringconfig_reporting_operator_hive_client_certificate: ""
+_meteringconfig_reporting_operator_hive_client_key: ""
+
+_meteringconfig_reporting_operator_hive_server_ca_certificate: ""
+_meteringconfig_reporting_operator_hive_server_secret_name: "reporting-operator-hive-server-tls"
 
 _meteringconfig_reporting_operator_auth_proxy_cookie_seed: ""
 
@@ -144,6 +151,26 @@ _meteringconfig_presto_client_secret_name: "presto-client-tls"
 _meteringconfig_presto_client_ca_certificate: ""
 _meteringconfig_presto_client_certificate: ""
 _meteringconfig_presto_client_key: ""
+
+_meteringconfig_presto_hive_client_secret_name: "presto-hive-metastore-client-tls"
+_meteringconfig_presto_hive_client_ca_certificate: ""
+_meteringconfig_presto_hive_client_certificate: ""
+_meteringconfig_presto_hive_client_key: ""
+
+_meteringconfig_hive_metastore_server_secret_name: "hive-metastore-server-tls"
+_meteringconfig_hive_metastore_server_certificate: ""
+_meteringconfig_hive_metastore_server_key: ""
+_meteringconfig_hive_metastore_server_ca_certificate: ""
+
+_meteringconfig_hive_server_secret_name: "hive-server-tls"
+_meteringconfig_hive_server_certificate: ""
+_meteringconfig_hive_server_key: ""
+_meteringconfig_hive_server_ca_certificate: ""
+
+_meteringconfig_hive_server_client_secret_name: "hive-server-auth-tls"
+_meteringconfig_hive_server_client_certificate: ""
+_meteringconfig_hive_server_client_key: ""
+_meteringconfig_hive_server_client_ca_certificate: ""
 
 _meteringconfig_tls_root_ca_certificate: ""
 _meteringconfig_tls_root_ca_key: ""
@@ -166,12 +193,28 @@ _tls_overrides:
             secretName: "{{ _meteringconfig_reporting_operator_presto_server_secret_name }}"
 
           auth:
-            certificate: "{{ _meteringconfig_reporting_operator_client_cert }}"
-            key: "{{ _meteringconfig_reporting_operator_client_key }}"
+            certificate: "{{ _meteringconfig_reporting_operator_presto_client_cert }}"
+            key: "{{ _meteringconfig_reporting_operator_presto_client_key }}"
 
             enabled: true
             createSecret: true
             secretName: "{{ _meteringconfig_reporting_operator_presto_client_secret_name }}"
+
+        hive:
+          tls:
+            caCertificate: "{{ _meteringconfig_reporting_operator_hive_server_ca_certificate }}"
+
+            enabled: true
+            createSecret: true
+            secretName: "{{ _meteringconfig_reporting_operator_hive_server_secret_name }}"
+
+          auth:
+            certificate: "{{ _meteringconfig_reporting_operator_hive_client_certificate }}"
+            key: "{{ _meteringconfig_reporting_operator_hive_client_key }}"
+
+            enabled: true
+            createSecret: true
+            secretName: "{{ _meteringconfig_reporting_operator_hive_client_secret_name }}"
 
       authProxy:
         enabled: true
@@ -204,6 +247,57 @@ _tls_overrides:
           enabled: true
           createSecret: true
           secretName: "{{ _meteringconfig_presto_client_secret_name }}"
+
+        connectors:
+          hive:
+            tls:
+              certificate: "{{  _meteringconfig_presto_hive_client_certificate }}"
+              key: "{{ _meteringconfig_presto_hive_client_key }}"
+              caCertificate: "{{ _meteringconfig_presto_hive_client_ca_certificate }}"
+
+              enabled: true
+              createSecret: true
+              secretName: "{{ _meteringconfig_presto_hive_client_secret_name }}"
+
+  hive:
+    spec:
+      metastore:
+        config:
+          tls:
+            certificate: "{{ _meteringconfig_hive_metastore_server_certificate }}"
+            key: "{{ _meteringconfig_hive_metastore_server_key }}"
+            caCertificate: "{{ _meteringconfig_hive_metastore_server_ca_certificate }}"
+
+            enabled: true
+            createSecret: true
+            secretName: "{{ _meteringconfig_hive_metastore_server_secret_name }}"
+
+          auth:
+            enabled: true
+
+      server:
+        config:
+          tls:
+            certificate: "{{ _meteringconfig_hive_server_certificate }}"
+            key: "{{ _meteringconfig_hive_server_key }}"
+            caCertificate: "{{ _meteringconfig_hive_server_ca_certificate }}"
+
+            enabled: true
+            createSecret: true
+            secretName: "{{ _meteringconfig_hive_server_secret_name }}"
+
+          auth:
+            enabled: true
+
+          metastoreTLS:
+            certificate: "{{ _meteringconfig_hive_server_client_certificate }}"
+            key: "{{ _meteringconfig_hive_server_client_key }}"
+            caCertificate: "{{ _meteringconfig_hive_server_client_ca_certificate }}"
+
+            enabled: true
+            createSecret: true
+            secretName: "{{ _meteringconfig_hive_server_client_secret_name }}"
+
 
 # check if the user's spec contains the top-level tls.enabled field. if true, use the value stored in that field, else default to the value stored in values.yaml
 meteringconfig_tls_enabled: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides, recursive=True) | json_query('tls.enabled') }}"
@@ -265,13 +359,19 @@ meteringconfig_create_hive_server_tls_secrets: "{{ _hive_spec.server.config.tls.
 
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.aws.createSecret | default(false) }}"
 meteringconfig_create_presto_azure_credentials: "{{ _presto_spec.config.azure.createSecret | default(false) }}"
-meteringconfig_create_presto_hive_metastore_tls_secrets: "{{ _presto_spec.config.connectors.hive.tls.createSecret | default(false) }}"
+meteringconfig_create_presto_hive_metastore_tls_secrets: "{{ _presto_spec.config.connectors.hive.tls.enabled and _presto_spec.config.connectors.hive.tls.createSecret | default(false) }}"
+
+meteringconfig_template_hive_metastore_tls_secret: "{{ _hive_spec.metastore.config.tls.enabled and _hive_spec.metastore.config.tls.createSecret and _hive_spec.metastore.config.tls.secretName != 'hive-metastore-server-tls'}}"
+meteringconfig_template_hive_server_tls_secret: "{{ _hive_spec.server.config.tls.enabled and _hive_spec.server.config.tls.createSecret and _hive_spec.server.config.tls.secretName != 'hive-server-tls'}}"
+meteringconfig_template_hive_server_auth_secret: "{{ _hive_spec.server.config.metastoreTLS.enabled and _hive_spec.server.config.metastoreTLS.createSecret and _hive_spec.server.config.metastoreTLS.secretName != 'hive-server-auth-tls' }}"
+meteringconfig_template_hive_secrets: "{{ meteringconfig_template_hive_metastore_tls_secret or meteringconfig_template_hive_server_tls_secret or meteringconfig_template_hive_server_auth_secret }}"
 
 #
 # Enabling Presto TLS/Auth by Default
 #
 meteringconfig_template_presto_tls_secret: "{{ _presto_spec.config.tls.enabled and _presto_spec.config.tls.createSecret and _presto_spec.config.tls.secretName != 'presto-server-tls' }}"
 meteringconfig_template_presto_auth_secret: "{{ _presto_spec.config.auth.enabled and _presto_spec.config.auth.createSecret and _presto_spec.config.auth.secretName != 'presto-client-tls' }}"
+meteringconfig_template_presto_hive_tls_secret: "{{ _presto_spec.config.connectors.hive.tls.enabled and _presto_spec.config.connectors.hive.tls.createSecret and _presto_spec.config.connectors.hive.tls.secretName != 'presto-hive-metastore-client-tls' }}"
 meteringconfig_create_presto_tls_secrets: "{{ _presto_spec.config.tls.enabled and _presto_spec.config.tls.createSecret | default(false) }}"
 meteringconfig_create_presto_auth_secrets: "{{ _presto_spec.config.auth.enabled and _presto_spec.config.auth.createSecret | default(false) }}"
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_openssl.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_openssl.yml
@@ -1,0 +1,111 @@
+---
+
+#
+# Generate a Hive Metastore Server cert/key
+#
+- name: Setup the Hive Metastore server certificate/key
+  block:
+  - name: Generate an RSA private key for Hive Metastore server
+    openssl_privatekey:
+      size: 2048
+      type: RSA
+      path: "{{ certificates_dir.path }}/hive_metastore_server.key"
+
+  - name: Generate the Hive Metastore server CSR
+    openssl_csr:
+      path: "{{ certificates_dir.path }}/hive_metastore_server.csr"
+      privatekey_path: "{{ certificates_dir.path }}/hive_metastore_server.key"
+      common_name: "hive-metastore"
+      subject_alt_name: "DNS:localhost,DNS:hive-metastore,DNS:hive-metastore.{{ meta.namespace }}.svc.cluster.local"
+      basicConstraints:
+      - 'CA:FALSE'
+      basicConstraints_critical: false
+      key_usage:
+      - digitalSignature
+      - keyEncipherment
+      extended_key_usage:
+      - serverAuth
+
+  - name: Generate the Hive Metastore server certificate
+    openssl_certificate:
+      path: "{{ certificates_dir.path }}/hive_metastore_server.crt"
+      privatekey_path: "{{ certificates_dir.path }}/hive_metastore_server.key"
+      csr_path: "{{ certificates_dir.path }}/hive_metastore_server.csr"
+      provider: ownca
+      ownca_path: "{{ certificates_dir.path }}/ca.crt"
+      ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
+      selfsigned_digest: sha256
+  when: not hive_metastore_tls_secret_exists
+
+#
+# Generate the Hive Server, Server cert/key
+#
+- name: Setup the Hive Server server certificate/key
+  block:
+  - name: Generate an RSA private key for Hive Server server
+    openssl_privatekey:
+      size: 2048
+      type: RSA
+      path: "{{ certificates_dir.path }}/hive_server.key"
+
+  - name: Generate the Hive Server server CSR
+    openssl_csr:
+      path: "{{ certificates_dir.path }}/hive_server.csr"
+      privatekey_path: "{{ certificates_dir.path }}/hive_server.key"
+      common_name: "hive-server"
+      subject_alt_name: "DNS:localhost,DNS:hive-server,DNS:hive-server.{{ meta.namespace }}.svc.cluster.local"
+      basicConstraints:
+      - 'CA:FALSE'
+      basicConstraints_critical: false
+      key_usage:
+      - digitalSignature
+      - keyEncipherment
+      extended_key_usage:
+      - serverAuth
+
+  - name: Generate the Hive Server server certificate
+    openssl_certificate:
+      path: "{{ certificates_dir.path }}/hive_server.crt"
+      privatekey_path: "{{ certificates_dir.path }}/hive_server.key"
+      csr_path: "{{ certificates_dir.path }}/hive_server.csr"
+      provider: ownca
+      ownca_path: "{{ certificates_dir.path }}/ca.crt"
+      ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
+      selfsigned_digest: sha256
+  when: not hive_server_tls_secret_exists
+
+#
+# Generate the Hive Server Client TLS cert/key to enable authentication
+#
+- name: Setup the Hive Server client certificate/key
+  block:
+  - name: Generate an RSA private key for the Hive Server client
+    openssl_privatekey:
+      size: 2048
+      type: RSA
+      path: "{{ certificates_dir.path }}/hive_server_client.key"
+
+  - name: Generate the Hive Server client CSR
+    openssl_csr:
+      path: "{{ certificates_dir.path }}/hive_server_client.csr"
+      privatekey_path: "{{ certificates_dir.path }}/hive_server_client.key"
+      common_name: "hive-server"
+      basicConstraints:
+      - 'CA:FALSE'
+      basicConstraints_critical: false
+      key_usage:
+      - digitalSignature
+      - keyEncipherment
+      extended_key_usage:
+      - clientAuth
+
+  - name: Generate the Hive Server client certificate
+    openssl_certificate:
+      path: "{{ certificates_dir.path }}/hive_server_client.crt"
+      privatekey_path: "{{ certificates_dir.path }}/hive_server_client.key"
+      csr_path: "{{ certificates_dir.path }}/hive_server_client.csr"
+      provider: ownca
+      ownca_path: "{{ certificates_dir.path }}/ca.crt"
+      ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
+      selfsigned_digest: sha256
+  when: not hive_server_client_tls_secret_exists

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
@@ -1,0 +1,108 @@
+---
+#
+# Validate user-provided Hive TLS configuration when top-level spec.tls.enabled is set to false
+#
+- name: Validate the user-provided Hive TLS configuration
+  include_tasks: validate_hive_tls.yml
+  when: not meteringconfig_tls_enabled
+
+#
+# Check for Hive TLS and auth secret existence (to avoid re-generating/overwriting the secret data if that secret name already exists)
+#
+- name: Check for the existence of Hive TLS-related secrets
+  block:
+  - name: Check for the existence of the Hive Metastore TLS secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec.hive.spec.metastore.config.tls.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: hive_metastore_tls_buf
+
+  - name: Check for the existence of the Hive Server Metastore TLS secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec.hive.spec.server.config.metastoreTLS.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: hive_server_client_tls_buf
+
+  - name: Check for the existence of the Hive Server TLS secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec.hive.spec.server.config.tls.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: hive_server_tls_buf
+
+  - name: Configure Hive Metastore to use existing server TLS secret data
+    set_fact:
+      _meteringconfig_hive_metastore_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_hive_metastore_server_certificate: "{{ hive_metastore_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_hive_metastore_server_key: "{{ hive_metastore_tls_buf.resources[0].data['tls.key'] | b64decode }}"
+    no_log: true
+    when: hive_metastore_tls_secret_exists
+
+  - name: Configure Hive Server to use existing server TLS secret data
+    set_fact:
+      _meteringconfig_hive_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_hive_server_certificate: "{{ hive_server_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_hive_server_key: "{{ hive_server_tls_buf.resources[0].data['tls.key'] | b64decode }}"
+    no_log: true
+    when: hive_server_tls_secret_exists
+
+  - name: Configure Hive Server to use existing client TLS secret data
+    set_fact:
+      _meteringconfig_hive_server_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_hive_server_client_certificate: "{{ hive_server_client_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_hive_server_client_key: "{{ hive_server_client_tls_buf.resources[0].data['tls.key'] | b64decode }}"
+    no_log: true
+    when: hive_server_client_tls_secret_exists
+  vars:
+    hive_metastore_tls_secret_exists: "{{ hive_metastore_tls_buf.resources is defined and hive_metastore_tls_buf.resources | length > 0 }}"
+    hive_server_tls_secret_exists: "{{ hive_server_tls_buf.resources is defined and hive_server_tls_buf.resources | length > 0 }}"
+    hive_server_client_tls_secret_exists: "{{ hive_server_client_tls_buf.resources is defined and hive_server_client_tls_buf.resources | length > 0 }}"
+  when: meteringconfig_tls_enabled
+
+#
+# Generate server and client certificates using the Ansible OpenSSL modules when top-level spec.tls.enabled is set to true
+#
+- name: Configure TLS and authentication for Hive
+  block:
+  - name: Generate certificates and keys for Hive
+    include_tasks: configure_hive_openssl.yml
+
+  - name: Configure Hive to use the generated TLS files
+    set_fact:
+      # hive.spec.metastore.config.tls
+      _meteringconfig_hive_metastore_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_hive_metastore_server_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/hive_metastore_server.crt') + '\n' }}"
+      _meteringconfig_hive_metastore_server_key: "{{ lookup('file', '{{ certificates_dir.path }}/hive_metastore_server.key') + '\n' }}"
+    no_log: true
+    when: not hive_metastore_tls_secret_exists
+
+  - name: Configure Hive Server to use the generated server cert/key data
+    set_fact:
+      # hive.spec.server.config.tls
+      _meteringconfig_hive_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_hive_server_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/hive_server.crt') + '\n' }}"
+      _meteringconfig_hive_server_key: "{{ lookup('file', '{{ certificates_dir.path }}/hive_server.key') + '\n' }}"
+    no_log: true
+    when: not hive_server_tls_secret_exists
+
+  - name: Configure Hive Server to use the generated client cert/key data
+    set_fact:
+      # hive.spec.server.config.metastoreTLS
+      _meteringconfig_hive_server_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_hive_server_client_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/hive_server_client.crt') + '\n' }}"
+      _meteringconfig_hive_server_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/hive_server_client.key') + '\n' }}"
+    no_log: true
+    when: not hive_server_client_tls_secret_exists
+  vars:
+    hive_metastore_tls_secret_exists: "{{ hive_metastore_tls_buf.resources is defined and hive_metastore_tls_buf.resources | length > 0 }}"
+    hive_server_tls_secret_exists: "{{ hive_server_tls_buf.resources is defined and hive_server_tls_buf.resources | length > 0 }}"
+    hive_server_client_tls_secret_exists: "{{ hive_server_client_tls_buf.resources is defined and hive_server_client_tls_buf.resources | length > 0 }}"
+  when: meteringconfig_tls_enabled and (not hive_metastore_tls_secret_exists or not hive_server_tls_secret_exists or not hive_server_client_tls_secret_exists)

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_openssl.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_openssl.yml
@@ -1,7 +1,7 @@
 ---
 
 #
-# Generate a Server cert/key
+# Generate the Presto Server cert/key
 #
 - name: Setup the server certificate/key
   block:
@@ -38,7 +38,7 @@
   when: not presto_tls_secret_exists
 
 #
-# Generate the Client cert/key to enable client-side authentication
+# Generate the Presto Client cert/key to enable client-side authentication
 #
 - name: Setup the client certificate/key
   block:
@@ -71,4 +71,4 @@
       ownca_path: "{{ certificates_dir.path }}/ca.crt"
       ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
       selfsigned_digest: sha256
-  when: not presto_auth_secret_exists
+  when: not presto_auth_secret_exists or not presto_hive_tls_secret_exists

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -1,5 +1,7 @@
 ---
-
+#
+# Validate user-provided Presto TLS configuration when top-level spec.tls.enabled is set to false
+#
 - name: Validate the user-provided Presto TLS configuration
   include_tasks: validate_presto_tls.yml
   when: not meteringconfig_tls_enabled
@@ -17,7 +19,6 @@
       namespace: "{{ meta.namespace }}"
     no_log: true
     register: presto_secret_tls_buf
-    when: meteringconfig_tls_enabled
 
   - name: Check for the existence of the Presto Auth secret
     k8s_facts:
@@ -28,7 +29,16 @@
     no_log: true
     register: presto_secret_auth_buf
 
-  - name: Configure Presto to use existing server TLS secret data
+  - name: Check for the existence of the Presto-Hive client TLS secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec.presto.spec.config.connectors.hive.tls.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: presto_hive_secret_tls_buf
+
+  - name: Configure Presto to use the existing server TLS secret data
     set_fact:
       _meteringconfig_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
       _meteringconfig_presto_server_certificate: "{{ presto_secret_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
@@ -36,28 +46,38 @@
     no_log: true
     when: presto_tls_secret_exists
 
-  - name: Configure Presto to use existing client TLS secret data
+  - name: Configure Presto to use the existing client TLS secret data
     set_fact:
       _meteringconfig_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
       _meteringconfig_presto_client_certificate: "{{ presto_secret_auth_buf.resources[0].data['tls.crt'] | b64decode }}"
       _meteringconfig_presto_client_key: "{{ presto_secret_auth_buf.resources[0].data['tls.key'] | b64decode }}"
     no_log: true
     when: presto_auth_secret_exists
+
+  - name: Configure Presto/Hive to use the existing Presto client TLS secret data
+    set_fact:
+      _meteringconfig_presto_hive_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_presto_hive_client_certificate: "{{ presto_hive_secret_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_presto_hive_client_key: "{{ presto_hive_secret_tls_buf.resources[0].data['tls.key'] | b64decode }}"
+    no_log: true
+    when: presto_hive_tls_secret_exists
   vars:
-    presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources is defined and presto_secret_tls_buf.resources | length > 0 }}"
-    presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources is defined and presto_secret_auth_buf.resources | length > 0 }}"
+    presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources and presto_secret_tls_buf.resources | length > 0 }}"
+    presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources and presto_secret_auth_buf.resources | length > 0 }}"
+    presto_hive_tls_secret_exists: "{{ presto_hive_secret_tls_buf.resources is defined and presto_hive_secret_tls_buf.resources | length > 0 }}"
   when: meteringconfig_tls_enabled
 
 #
 # Generate server and client certificates for Presto (as needed) using the Ansible OpenSSL modules when top-level spec.tls.enabled is set to true
 #
-- name: Configure TLS and client-side authentication for Presto
+- name: Configure TLS and client-side authentication for Presto and Presto connectors
   block:
   - name: Generate Presto server and client TLS certificates and keys
     include_tasks: configure_presto_openssl.yml
 
   - name: Configure Presto to use generated server certificate and key
     set_fact:
+      # presto.spec.config.tls
       _meteringconfig_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
       _meteringconfig_presto_server_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_server.crt') + '\n' }}"
       _meteringconfig_presto_server_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_server.key') + '\n' }}"
@@ -66,12 +86,23 @@
 
   - name: Configure Presto to use the generated client certificate and key
     set_fact:
+      # presto.spec.config.auth
       _meteringconfig_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
       _meteringconfig_presto_client_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.crt') + '\n' }}"
       _meteringconfig_presto_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.key') + '\n' }}"
     no_log: true
     when: not presto_auth_secret_exists
+
+  - name: Configure Presto/Hive to use the generated Presto client certificate and key
+    set_fact:
+      # presto.spec.connectors.hive.tls
+      _meteringconfig_presto_hive_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_presto_hive_client_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.crt') + '\n' }}"
+      _meteringconfig_presto_hive_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.key') + '\n' }}"
+    no_log: true
+    when: not presto_hive_tls_secret_exists
   vars:
     presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources is defined and presto_secret_tls_buf.resources | length > 0 }}"
     presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources is defined and presto_secret_auth_buf.resources | length > 0 }}"
-  when: meteringconfig_tls_enabled and (not presto_tls_secret_exists or not presto_auth_secret_exists)
+    presto_hive_tls_secret_exists: "{{ presto_hive_secret_tls_buf.resources is defined and presto_hive_secret_tls_buf.resources | length > 0 }}"
+  when: meteringconfig_tls_enabled and (not presto_tls_secret_exists or not presto_auth_secret_exists or not presto_hive_tls_secret_exists)

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -5,16 +5,7 @@
 #
 - name: Check for the existence of the reporting-operator Presto TLS-related secrets
   block:
-  - name: Check for the existence of the reporting-operator Presto server TLS secret
-    k8s_facts:
-      api_version: v1
-      kind: Secret
-      name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.tls.secretName }}"
-      namespace: "{{ meta.namespace }}"
-    no_log: true
-    register: reporting_operator_tls_secret_buf
-
-  - name: Check for the existence of the reporting-operator Presto client auth TLS secret
+  - name: Check for the existence of the reporting-operator Presto client auth secret
     k8s_facts:
       api_version: v1
       kind: Secret
@@ -23,43 +14,76 @@
     no_log: true
     register: reporting_operator_auth_secret_buf
 
-  - name: Configure the reporting operator Presto TLS to use existing Root CA data
-    set_fact:
-      _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-    when: not reporting_operator_tls_secret_exists
-
-  - name: Configure TLS and authentication in the reporting-operator to Presto
-    block:
-    - name: Generate reporting-operator client certs as needed
-      include_tasks: configure_reporting_operator_openssl.yml
-
-    - name: Configure reporting-operator to use generated client TLS data
-      set_fact:
-        _meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-        _meteringconfig_reporting_operator_client_cert: "{{ lookup('file', '{{ certificates_dir.path }}/reporting_operator_client.crt') + '\n' }}"
-        _meteringconfig_reporting_operator_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/reporting_operator_client.key') + '\n' }}"
-    when: not reporting_operator_auth_secret_exists
-
   - name: Configure the reporting-operator to use existing presto server TLS secret data
     set_fact:
       _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
     no_log: true
-    when: reporting_operator_tls_secret_exists
 
   - name: Configure the reporting-operator to use existing presto client TLS secret data
     set_fact:
-      _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-      _meteringconfig_reporting_operator_client_cert: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
-      _meteringconfig_reporting_operator_client_key: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
+      _meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_reporting_operator_presto_client_cert: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_reporting_operator_presto_client_key: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
     no_log: true
     when: reporting_operator_auth_secret_exists
   vars:
-    reporting_operator_tls_secret_exists: "{{ reporting_operator_tls_secret_buf.resources is defined and reporting_operator_tls_secret_buf.resources | length > 0 }}"
+    reporting_operator_auth_secret_exists: "{{ reporting_operator_auth_secret_buf.resources is defined and reporting_operator_auth_secret_buf.resources | length > 0 }}"
+  when: meteringconfig_tls_enabled
+
+- name: Configure TLS and authentication in the reporting-operator to Presto
+  block:
+  - name: Generate the reporting-operator client certs as needed
+    include_tasks: configure_reporting_operator_openssl.yml
+
+  - name: Configure the reporting-operator to use it's client own cert/key when communicating with Presto
+    set_fact:
+      _meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_reporting_operator_presto_client_cert: "{{ lookup('file', '{{ certificates_dir.path }}/reporting_operator_client.crt') + '\n' }}"
+      _meteringconfig_reporting_operator_presto_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/reporting_operator_client.key') + '\n' }}"
+    no_log: true
+    when: not reporting_operator_auth_secret_exists
+  vars:
     reporting_operator_auth_secret_exists: "{{ reporting_operator_auth_secret_buf.resources is defined and reporting_operator_auth_secret_buf.resources | length > 0 }}"
   when: meteringconfig_tls_enabled
 
 #
-# Reporting Operator Auth-Proxy
+# Reporting Operator Hive TLS/auth
+#
+- name: Check for the existence of reporting-operator Hive TLS-related secrets
+  block:
+  - name: Check for the existence of the reporting-operator Hive client auth secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec['reporting-operator'].spec.config.hive.auth.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: reporting_operator_hive_auth_secret_buf
+
+  - name: Configure the reporting-operator to use the Metering Root CA for Hive Server CA
+    set_fact:
+      _meteringconfig_reporting_operator_hive_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+    no_log: true
+
+  - name: Configure the reporting-operator to use it's client own cert/key when communicating with Hive
+    set_fact:
+      _meteringconfig_reporting_operator_hive_client_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/reporting_operator_client.crt') + '\n' }}"
+      _meteringconfig_reporting_operator_hive_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/reporting_operator_client.key') + '\n' }}"
+    no_log: true
+    when: not reporting_operator_hive_auth_secret_exists
+
+  - name: Configure the reporting-operator to use the existing client cert/key
+    set_fact:
+      _meteringconfig_reporting_operator_hive_client_certificate: "{{ reporting_operator_hive_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_reporting_operator_hive_client_key: "{{ reporting_operator_hive_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
+    no_log: true
+    when: reporting_operator_hive_auth_secret_exists
+  vars:
+    reporting_operator_hive_auth_secret_exists: "{{ reporting_operator_hive_auth_secret_buf.resources is defined and reporting_operator_hive_auth_secret_buf.resources | length > 0 }}"
+  when: meteringconfig_tls_enabled
+
+#
+# Reporting Operator Openshift Auth-Proxy
 #
 - name: Validate the user-provided authProxy configuration
   include_tasks: validate_reporting_operator_tls.yml
@@ -77,19 +101,23 @@
     register: reporting_operator_auth_proxy_cookie_secret_buf
     when: meteringconfig_tls_enabled
 
-  - name: Generate a 32-character random string
-    command: openssl rand -base64 32
-    register: cookie_seed_random_string
-    when: not reporting_operator_auth_proxy_cookie_secret_exists
+  - name: Generate cookie seed and configuring authProxy to use that generated seed value
+    block:
+    - name: Generate a 32-character random string
+      command: openssl rand -base64 32
+      register: cookie_seed_random_string
+      when: not reporting_operator_auth_proxy_cookie_secret_exists
 
-  - name: Configure authProxy cookie seed secret
-    set_fact:
-      _meteringconfig_reporting_operator_auth_proxy_cookie_seed: "{{ cookie_seed_random_string.stdout }}"
+    - name: Configure authProxy cookie seed secret
+      set_fact:
+        _meteringconfig_reporting_operator_auth_proxy_cookie_seed: "{{ cookie_seed_random_string.stdout }}"
+      no_log: true
     when: not reporting_operator_auth_proxy_cookie_secret_exists
 
   - name: Configure authProxy cookie seed secret to use pre-existing secret data
     set_fact:
       _meteringconfig_reporting_operator_auth_proxy_cookie_seed: "{{ reporting_operator_auth_proxy_cookie_secret_buf.resources[0].data['cookie-secret-seed'] | b64decode }}"
+    no_log: true
     when: reporting_operator_auth_proxy_cookie_secret_exists
   vars:
     reporting_operator_auth_proxy_cookie_secret_exists: "{{ reporting_operator_auth_proxy_cookie_secret_buf.resources is defined and reporting_operator_auth_proxy_cookie_secret_buf.resources | length > 0 }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
@@ -1,5 +1,8 @@
 ---
-
+#
+# Check if the metering root CA secret already exists and instead needs to be copied into a temp directory
+# This temp directory would contain all the necessary TLS data (shared with Presto, Hive, reporting-operator)
+#
 - name: Check for the existence of the Metering Root CA secret
   block:
   - name: Check if Root CA secret already exists
@@ -11,11 +14,13 @@
     no_log: true
     register: root_ca_secret_buf
 
+  # note: other resources (presto, hive, reporting-operator) depend on these variables
   - name: Use pre-existing CA secret cert/key when secret already exists
     block:
     - set_fact:
         _meteringconfig_tls_root_ca_certificate: "{{ root_ca_secret_buf.resources[0].data['ca.crt'] | b64decode }}"
         _meteringconfig_tls_root_ca_key: "{{ root_ca_secret_buf.resources[0].data['ca.key'] | b64decode }}"
+      no_log: true
 
     - name: Add root CA certificate to certificates directory
       copy:
@@ -32,7 +37,7 @@
   when: meteringconfig_tls_enabled
 
 #
-# Generate a Root Certificate Authority
+# Generate the metering root certificate authority
 #
 - name: Setup the root certificate authority
   block:
@@ -63,6 +68,7 @@
     set_fact:
       _meteringconfig_tls_root_ca_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/ca.crt') + '\n' }}"
       _meteringconfig_tls_root_ca_key: "{{ lookup('file', '{{ certificates_dir.path }}/ca.key') + '\n' }}"
+    no_log: true
   vars:
     root_ca_secret_exists: "{{ root_ca_secret_buf.resources is defined and root_ca_secret_buf.resources | length > 0 }}"
   when: meteringconfig_tls_enabled and not root_ca_secret_exists

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
@@ -8,11 +8,14 @@
       state: directory
     register: certificates_dir
 
-  - name: Generate root certificate authority
+  - name: Generate the metering root certificate authority
     include_tasks: configure_root_ca.yml
 
   - name: Configure TLS and client-side authentication in Presto
     include_tasks: configure_presto_tls.yml
+
+  - name: Configure TLS and authentication in Hive
+    include_tasks: configure_hive_tls.yml
 
   - name: Configure TLS and authentication in the reporting-operator
     include_tasks: configure_reporting_operator_tls.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_tls.yml
@@ -1,0 +1,80 @@
+---
+
+#
+# Validate the user-provided cert/key/caCert fields are non-empty when top-level spec.tls.enabled is false
+# Note: there are three TLS sections we need to verify: hive.spec.metastore.tls, hive.spec.server.tls, hive.spec.server.metastoreTLS
+#
+- name: Validate that the user-provided Hive Metastore TLS fields are not empty
+  block:
+  - name: Validate that the user provided a non-empty Hive Metastore TLS certificate value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.metastore.config.tls.certificate == ""
+      msg: "hive.spec.metastore.config.tls.certificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty Hive Metastore TLS CA certificate value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.metastore.config.tls.caCertificate == ""
+      msg: "hive.spec.metastore.config.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty Hive Metastore TLS key value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.metastore.config.tls.key == ""
+      msg: "hive.spec.metastore.config.tls.key cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that TLS is enabled when auth is enabled
+    assert:
+      that:
+        - not meteringconfig_spec.hive.spec.metastore.config.tls.enabled and meteringconfig_spec.hive.spec.metastore.config.auth.enabled
+      msg: "Invalid configuration for hive.spec.metastore.config.tls: you cannot enable auth but disable TLS."
+  when: meteringconfig_template_hive_metastore_tls_secret
+
+- name: Validate user-provided Hive Server TLS fields are non-empty
+  block:
+  - name: Validate that the user provided a non-empty Hive Server TLS certificate value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.server.config.tls.certificate == ""
+      msg: "hive.spec.server.config.tls.certificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty Hive Server TLS CA certificate value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.server.config.tls.caCertificate == ""
+      msg: "hive.spec.server.config.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty Hive Server TLS key value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.server.config.tls.key == ""
+      msg: "hive.spec.server.config.tls.key cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that TLS is enabled when auth is enabled
+    assert:
+      that:
+        - not meteringconfig_spec.hive.spec.server.config.tls.enabled and meteringconfig_spec.hive.spec.server.config.auth.enabled
+      msg: "Invalid configuration for hive.spec.server.config.tls: you cannot enable auth but disable TLS."
+  when: meteringconfig_template_hive_server_tls_secret
+
+- name: Validate user-provided Hive Server Auth (metastoreTLS) fields are non-empty
+  block:
+  - name: Validate that the user provided a non-empty Hive Server client TLS certificate value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.server.config.metastoreTLS.certificate == ""
+      msg: "hive.spec.server.config.metastoreTLS.certificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty Hive Server client TLS CA certificate value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.server.config.metastoreTLS.caCertificate == ""
+      msg: "hive.spec.server.config.metastoreTLS.caCertificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty Hive Server client TLS key value
+    assert:
+      that:
+        - meteringconfig_spec.hive.spec.server.config.metastoreTLS.key == ""
+      msg: "hive.spec.server.config.metastoreTLS.key cannot be empty if createSecret: true and secretName != ''"
+  when: meteringconfig_template_hive_server_auth_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
@@ -48,5 +48,26 @@
     assert:
       that:
         - not meteringconfig_spec.presto.spec.config.tls.enabled and meteringconfig_spec.presto.spec.config.auth.enabled
-      msg: "Invalid configuration passed: you cannot enable auth but disable TLS."
+      msg: "Invalid configuration: you cannot enable auth but disable TLS."
   when: meteringconfig_template_presto_auth_secret
+
+- name: Validate that the user provided Presto/Hive client TLS fields are not empty
+  block:
+  - name: Validate that the user provided a non-empty Hive client TLS certificate value
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.connectors.hive.tls.certificate != ""
+      msg: "spec.presto.spec.config.connectors.hive.tls.certificate cannot be empty when createSecret is set to true"
+
+  - name: Validate that the user provided a non-empty Hive client TLS key value
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.connectors.hive.tls.key != ""
+      msg: "spec.presto.spec.config.connectors.hive.tls.key cannot be empty when createSecret is set to true"
+
+  - name: Validate that the user provided a non-empty Hive client TLS CA certificate value
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.connectors.hive.tls.caCertificate != ""
+      msg: "spec.presto.spec.config.connectors.hive.tls.caCertificate cannot be empty when createSecret is set to true"
+  when: meteringconfig_template_presto_hive_tls_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
@@ -1,5 +1,68 @@
 #
-# Validate that the user configured authProxy fields correctly
+# Validate that the user-provided reporting-operator Presto fields were properly configured
+#
+- name: Validate that the user-provided Presto server TLS fields are not empty
+  block:
+  - name: Validate that the user provided a non-empty TLS CA certificate value
+    assert:
+      that:
+        - meteringconfig_spec['reporting-operator'].spec.config.presto.tls.caCertificate != ""
+      msg: "reporting-operator.spec.config.presto.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
+  when: meteringconfig_template_presto_tls_secret
+
+- name: Validate that the user-provided Presto client Auth fields are not empty
+  block:
+  - name: Validate that the user provided a non-empty auth certificate value
+    assert:
+      that:
+        - meteringconfig_spec['reporting-operator'].spec.config.presto.auth.certificate != ""
+      msg: "reporting-operator.spec.config.presto.auth.certificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty auth key value
+    assert:
+      that:
+        - meteringconfig_spec['reporting-operator'].spec.config.presto.auth.key != ""
+      msg: "reporting-operator.spec.config.presto.auth.key cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that TLS is enabled when auth is enabled
+    assert:
+      that:
+        - not meteringconfig_spec['reporting-operator'].spec.config.presto.tls.enabled and meteringconfig_spec['reporting-operator'].spec.config.presto.auth.enabled
+      msg: "Invalid configuration: you cannot enable auth but disable TLS."
+  when: meteringconfig_template_presto_auth_secret
+
+#
+# Validate that the user-provided reporting-operator Hive fields were properly configured
+#
+- name: Validate that the user-provided Hive TLS/auth fields are not empty
+  block:
+  - name: Validate that the user provided a non-empty Hive TLS CA certificate value
+    assert:
+      that:
+        - meteringconfig_spec['reporting-operator'].spec.config.hive.tls.caCertificate != ""
+      msg: "reporting-operator.spec.config.presto.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty Hive auth certificate value
+    assert:
+      that:
+        - meteringconfig_spec['reporting-operator'].spec.config.hive.auth.certificate != ""
+      msg: "reporting-operator.spec.config.hive.auth.certificate cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that the user provided a non-empty Hive auth key value
+    assert:
+      that:
+        - meteringconfig_spec['reporting-operator'].spec.config.hive.auth.key != ""
+      msg: "reporting-operator.spec.config.hive.auth.key cannot be empty if createSecret: true and secretName != ''"
+
+  - name: Validate that TLS is enabled when auth is enabled
+    assert:
+      that:
+        - not meteringconfig_spec['reporting-operator'].spec.config.hive.tls.enabled and meteringconfig_spec['reporting-operator'].spec.config.hive.auth.enabled
+      msg: "Invalid configuration: you cannot enable auth but disable TLS."
+  when: meteringconfig_template_hive_secrets
+
+#
+# Validate that the user-provided authProxy fields were properly configured
 #
 - name: Validate the user-provided authProxy fields are not empty
   block:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -417,11 +417,13 @@ func (op *Reporting) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("error loading Hive CA File: %s", err)
 		}
+
 		rootCertPool := x509.NewCertPool()
 		rootCertPool.AppendCertsFromPEM(rootCert)
 
 		hiveTLSConfig := &tls.Config{
-			RootCAs: rootCertPool,
+			RootCAs:            rootCertPool,
+			InsecureSkipVerify: op.cfg.HiveTLSInsecureSkipVerify,
 		}
 
 		if op.cfg.HiveUseClientCertAuth {


### PR DESCRIPTION
Currently, there's pre-existing support to enable TLS/auth in Hive (which communicates with reporting-operator, Presto) by manually setting the necessary fields. This PR would enable TLS in Hive by default, which is conditioned on the top-level `spec.tls.enabled: true` field in the `MeteringConfig` CR.

We add all the necessary default variables (we need to update the reporting-operator Hive, hive, and Presto connectors sections to do this.) These new default variables act as overrides to the default values and use Ansible's "lazy evaluation" to avoid the usage of the `combine` filter.

When a user specifies `spec.tls.enabled: false` and manually configures TLS/auth for Hive, we do some basic validation: check if any necessary fields are non-empty, ensure TLS is not disabled when auth is enabled, etc. If those basic validation checks pass, then we use existing secret templates to create the TLS-related secrets containing the cert/key values they specified for the user.