### PR TITLE
Standardize CPU_Core_Seconds

### DIFF
--- a/Documentation/rollup-reports.md
+++ b/Documentation/rollup-reports.md
@@ -47,7 +47,7 @@ spec:
     unit: kubernetes_namespace
   - name: pod_usage_cpu_core_seconds
     type: double
-    unit: core_seconds
+    unit: cpu_core_seconds
   inputs:
   - name: ReportingStart
     type: time

--- a/charts/openshift-metering/templates/openshift-reporting/report-queries/pod-cpu.yaml
+++ b/charts/openshift-metering/templates/openshift-reporting/report-queries/pod-cpu.yaml
@@ -220,7 +220,7 @@ spec:
     unit: kubernetes_namespace
   - name: pod_request_cpu_core_seconds
     type: double
-    unit: core_seconds
+    unit: cpu_core_seconds
   inputs:
   - name: ReportingStart
     type: time
@@ -272,7 +272,7 @@ spec:
     unit: kubernetes_namespace
   - name: pod_usage_cpu_core_seconds
     type: double
-    unit: core_seconds
+    unit: cpu_core_seconds
   inputs:
   - name: ReportingStart
     type: time
@@ -324,10 +324,10 @@ spec:
     unit: kubernetes_namespace
   - name: pod_usage_cpu_core_seconds
     type: double
-    unit: core_seconds
+    unit: cpu_core_seconds
   - name: pod_request_cpu_core_seconds
     type: double
-    unit: core_seconds
+    unit: cpu_core_seconds
   - name: pod_cpu_usage_percent
     type: double
   - name: pod_cpu_request_percent


### PR DESCRIPTION
When going thru report queries I noted most of the time we use `CPU_Core_Seconds` as the unit but there were 1-3 units involving cpu measures that were at `core_seconds` so switching to standardize. 