### PR TITLE
images/metering-ansible-operator: Move all reporting-operator TLS-related tasks to its own task file and clean-up TLS-related tasks.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_openssl.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_openssl.yml
@@ -35,6 +35,7 @@
       ownca_path: "{{ certificates_dir.path }}/ca.crt"
       ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
       selfsigned_digest: sha256
+  when: not presto_tls_secret_exists
 
 #
 # Generate the Client cert/key to enable client-side authentication
@@ -70,3 +71,4 @@
       ownca_path: "{{ certificates_dir.path }}/ca.crt"
       ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
       selfsigned_digest: sha256
+  when: not presto_auth_secret_exists

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -1,73 +1,77 @@
 ---
 
-- name: Validate user's Presto TLS configuration
+- name: Validate the user-provided Presto TLS configuration
   include_tasks: validate_presto_tls.yml
   when: not meteringconfig_tls_enabled
 
 #
 # Check for Presto TLS and auth secret existence (to avoid re-generating/overwriting the secret data if that secret name already exists)
 #
-- name: Check for the existence of the Presto TLS secret
-  k8s_facts:
-    api_version: v1
-    kind: Secret
-    name: "{{ meteringconfig_spec.presto.spec.config.tls.secretName }}"
-    namespace: "{{ meta.namespace }}"
-  no_log: true
-  register: presto_secret_tls_buf
-  when: meteringconfig_tls_enabled
-
-- name: Check for the existence of the Presto Auth secret
-  k8s_facts:
-    api_version: v1
-    kind: Secret
-    name: "{{ meteringconfig_spec.presto.spec.config.auth.secretName }}"
-    namespace: "{{ meta.namespace }}"
-  no_log: true
-  register: presto_secret_auth_buf
-  when: meteringconfig_tls_enabled
-
-#
-# Generate server and client certificates using the Ansible OpenSSL modules when top-level spec.tls.enabled is set to true
-#
-- name: Configure TLS and client-side authentication for Presto and reporting-operator
+- name: Check for the existence of Presto TLS-related secrets
   block:
-  - name: Generate presto server and client TLS certificates and keys
+  - name: Check for the existence of the Presto TLS secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec.presto.spec.config.tls.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: presto_secret_tls_buf
+    when: meteringconfig_tls_enabled
+
+  - name: Check for the existence of the Presto Auth secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec.presto.spec.config.auth.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: presto_secret_auth_buf
+
+  - name: Configure Presto to use existing server TLS secret data
+    set_fact:
+      _meteringconfig_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_presto_server_certificate: "{{ presto_secret_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_presto_server_key: "{{ presto_secret_tls_buf.resources[0].data['tls.key'] | b64decode }}"
+    no_log: true
+    when: presto_tls_secret_exists
+
+  - name: Configure Presto to use existing client TLS secret data
+    set_fact:
+      _meteringconfig_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_presto_client_certificate: "{{ presto_secret_auth_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_presto_client_key: "{{ presto_secret_auth_buf.resources[0].data['tls.key'] | b64decode }}"
+    no_log: true
+    when: presto_auth_secret_exists
+  vars:
+    presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources and presto_secret_tls_buf.resources | length > 0 }}"
+    presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources and presto_secret_auth_buf.resources | length > 0 }}"
+  when: meteringconfig_tls_enabled
+
+#
+# Generate server and client certificates for Presto (as needed) using the Ansible OpenSSL modules when top-level spec.tls.enabled is set to true
+#
+- name: Configure TLS and client-side authentication for Presto
+  block:
+  - name: Generate Presto server and client TLS certificates and keys
     include_tasks: configure_presto_openssl.yml
 
-  - name: Configure Presto to use generated TLS files
+  - name: Configure Presto to use generated server certificate and key
     set_fact:
-      _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-
       _meteringconfig_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
       _meteringconfig_presto_server_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_server.crt') + '\n' }}"
       _meteringconfig_presto_server_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_server.key') + '\n' }}"
+    no_log: true
+    when: not presto_tls_secret_exists
 
-      _meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-      _meteringconfig_reporting_operator_client_cert: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.crt') + '\n' }}"
-      _meteringconfig_reporting_operator_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.key') + '\n' }}"
-
+  - name: Configure Presto to use the generated client certificate and key
+    set_fact:
       _meteringconfig_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
       _meteringconfig_presto_client_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.crt') + '\n' }}"
       _meteringconfig_presto_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/presto_client.key') + '\n' }}"
     no_log: true
-  when: meteringconfig_tls_enabled and (presto_secret_tls_buf.resources | length == 0 or presto_secret_auth_buf.resources | length == 0)
-
-#
-# Update the MeteringConfig values to use the pre-existing Presto TLS/auth secret data (when the secret already exists)
-#
-- name: Configure Presto to use existing server TLS secret data
-  set_fact:
-    _meteringconfig_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-    _meteringconfig_presto_server_certificate: "{{ presto_secret_tls_buf.resources[0].data['tls.crt'] | b64decode }}"
-    _meteringconfig_presto_server_key: "{{ presto_secret_tls_buf.resources[0].data['tls.key'] | b64decode }}"
-  no_log: true
-  when: meteringconfig_tls_enabled and presto_secret_tls_buf.resources | length > 0
-
-- name: Configure Presto to use existing client TLS secret data
-  set_fact:
-    _meteringconfig_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-    _meteringconfig_presto_client_certificate: "{{ presto_secret_auth_buf.resources[0].data['tls.crt'] | b64decode }}"
-    _meteringconfig_presto_client_key: "{{ presto_secret_auth_buf.resources[0].data['tls.key'] | b64decode }}"
-  no_log: true
-  when: meteringconfig_tls_enabled and presto_secret_auth_buf.resources | length > 0
+    when: not presto_auth_secret_exists
+  vars:
+    presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources and presto_secret_tls_buf.resources | length > 0 }}"
+    presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources and presto_secret_auth_buf.resources | length > 0 }}"
+  when: meteringconfig_tls_enabled and (not presto_tls_secret_exists or not presto_auth_secret_exists)

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_openssl.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_openssl.yml
@@ -1,0 +1,37 @@
+---
+
+#
+# Generate the reporting-operator client cert/key
+# The reporting-operator talks to Presto and Hive Server
+#
+- name: Setup the client certificate/key
+  block:
+  - name: Generate an RSA private key for the reporting-operator client
+    openssl_privatekey:
+      size: 2048
+      type: RSA
+      path: "{{ certificates_dir.path }}/reporting_operator_client.key"
+
+  - name: Generate the reporting-operator client CSR
+    openssl_csr:
+      path: "{{ certificates_dir.path }}/reporting_operator_client.csr"
+      privatekey_path: "{{ certificates_dir.path }}/reporting_operator_client.key"
+      common_name: "reporting-operator"
+      basicConstraints:
+      - 'CA:FALSE'
+      basicConstraints_critical: false
+      key_usage:
+      - digitalSignature
+      - keyEncipherment
+      extended_key_usage:
+      - clientAuth
+
+  - name: Generate the reporting-operator client certificate
+    openssl_certificate:
+      path: "{{ certificates_dir.path }}/reporting_operator_client.crt"
+      privatekey_path: "{{ certificates_dir.path }}/reporting_operator_client.key"
+      csr_path: "{{ certificates_dir.path }}/reporting_operator_client.csr"
+      provider: ownca
+      ownca_path: "{{ certificates_dir.path }}/ca.crt"
+      ownca_privatekey_path: "{{ certificates_dir.path }}/ca.key"
+      selfsigned_digest: sha256

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -1,65 +1,82 @@
 ---
 
 #
-# Presto and reporting-operator TLS
+# Reporting Operator Presto TLS/auth
 #
-- name: Check for the existence of the reporting-operator presto server TLS secret
-  k8s_facts:
-    api_version: v1
-    kind: Secret
-    name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.tls.secretName }}"
-    namespace: "{{ meta.namespace }}"
-  no_log: true
-  register: reporting_operator_tls_secret_buf
-  when: meteringconfig_tls_enabled
+- name: Check for the existence of the reporting-operator Presto TLS-related secrets
+  block:
+  - name: Check for the existence of the reporting-operator Presto server TLS secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.tls.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: reporting_operator_tls_secret_buf
 
-- name: Check for the existence of the reporting-operator presto client auth TLS secret
-  k8s_facts:
-    api_version: v1
-    kind: Secret
-    name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.auth.secretName }}"
-    namespace: "{{ meta.namespace }}"
-  no_log: true
-  register: reporting_operator_auth_secret_buf
-  when: meteringconfig_tls_enabled
+  - name: Check for the existence of the reporting-operator Presto client auth TLS secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.auth.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: reporting_operator_auth_secret_buf
 
-- name: Configure reporting-operator to use existing presto server TLS secret data
-  set_fact:
-    _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-  no_log: true
+  - name: Configure the reporting operator Presto TLS to use existing Root CA data
+    set_fact:
+      _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+    when: not reporting_operator_tls_secret_exists
+
+  - name: Configure TLS and authentication in the reporting-operator to Presto
+    block:
+    - name: Generate reporting-operator client certs as needed
+      include_tasks: configure_reporting_operator_openssl.yml
+
+    - name: Configure reporting-operator to use generated client TLS data
+      set_fact:
+        _meteringconfig_reporting_operator_presto_client_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+        _meteringconfig_reporting_operator_client_cert: "{{ lookup('file', '{{ certificates_dir.path }}/reporting_operator_client.crt') + '\n' }}"
+        _meteringconfig_reporting_operator_client_key: "{{ lookup('file', '{{ certificates_dir.path }}/reporting_operator_client.key') + '\n' }}"
+    when: not reporting_operator_auth_secret_exists
+
+  - name: Configure the reporting-operator to use existing presto server TLS secret data
+    set_fact:
+      _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+    no_log: true
+    when: reporting_operator_tls_secret_exists
+
+  - name: Configure the reporting-operator to use existing presto client TLS secret data
+    set_fact:
+      _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
+      _meteringconfig_reporting_operator_client_cert: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
+      _meteringconfig_reporting_operator_client_key: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
+    no_log: true
+    when: reporting_operator_auth_secret_exists
   vars:
     reporting_operator_tls_secret_exists: "{{ reporting_operator_tls_secret_buf.resources is defined and reporting_operator_tls_secret_buf.resources | length > 0 }}"
-  when: meteringconfig_tls_enabled and reporting_operator_tls_secret_exists
-
-- name: Configure reporting-operator to use existing presto client TLS secret data
-  set_fact:
-    _meteringconfig_reporting_operator_presto_server_ca_certificate: "{{ _meteringconfig_tls_root_ca_certificate }}"
-    _meteringconfig_reporting_operator_client_cert: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.crt'] | b64decode }}"
-    _meteringconfig_reporting_operator_client_key: "{{ reporting_operator_auth_secret_buf.resources[0].data['tls.key'] | b64decode }}"
-  no_log: true
-  vars:
     reporting_operator_auth_secret_exists: "{{ reporting_operator_auth_secret_buf.resources is defined and reporting_operator_auth_secret_buf.resources | length > 0 }}"
-  when: meteringconfig_tls_enabled and reporting_operator_auth_secret_exists
+  when: meteringconfig_tls_enabled
 
 #
 # Reporting Operator Auth-Proxy
 #
-- name: Validate user's authProxy configuration
+- name: Validate the user-provided authProxy configuration
   include_tasks: validate_reporting_operator_tls.yml
   when: not meteringconfig_tls_enabled
 
-- name: Check for the existence of the reporting-operator authProxy cookie seed secret
-  k8s_facts:
-    api_version: v1
-    kind: Secret
-    name: "{{ meteringconfig_spec['reporting-operator'].spec.authProxy.cookie.secretName }}"
-    namespace: "{{ meta.namespace }}"
-  no_log: true
-  register: reporting_operator_auth_proxy_cookie_secret_buf
-  when: meteringconfig_tls_enabled
-
-- name: Generate authProxy secret data
+- name: Check for the existence of reporting-operator authProxy-related secret data
   block:
+  - name: Check for the existence of the reporting-operator authProxy cookie seed secret
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec['reporting-operator'].spec.authProxy.cookie.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: reporting_operator_auth_proxy_cookie_secret_buf
+    when: meteringconfig_tls_enabled
+
   - name: Generate a 32-character random string
     command: openssl rand -base64 32
     register: cookie_seed_random_string

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
@@ -1,13 +1,34 @@
 ---
 
-- name: Check if Root CA secret already exists
-  k8s_facts:
-    api_version: v1
-    kind: Secret
-    name: "{{ meteringconfig_spec.tls.secretName }}"
-    namespace: "{{ meta.namespace }}"
-  no_log: true
-  register: root_ca_secret_buf
+- name: Check for the existence of the Metering Root CA secret
+  block:
+  - name: Check if Root CA secret already exists
+    k8s_facts:
+      api_version: v1
+      kind: Secret
+      name: "{{ meteringconfig_spec.tls.secretName }}"
+      namespace: "{{ meta.namespace }}"
+    no_log: true
+    register: root_ca_secret_buf
+
+  - name: Use pre-existing CA secret cert/key when secret already exists
+    block:
+    - set_fact:
+        _meteringconfig_tls_root_ca_certificate: "{{ root_ca_secret_buf.resources[0].data['ca.crt'] | b64decode }}"
+        _meteringconfig_tls_root_ca_key: "{{ root_ca_secret_buf.resources[0].data['ca.key'] | b64decode }}"
+
+    - name: Add root CA certificate to certificates directory
+      copy:
+        content: "{{ _meteringconfig_tls_root_ca_certificate }}"
+        dest: "{{ certificates_dir.path }}/ca.crt"
+
+    - name: Add root CA private key to certificates directory
+      copy:
+        content: "{{ _meteringconfig_tls_root_ca_key }}"
+        dest: "{{ certificates_dir.path }}/ca.key"
+    when: root_ca_secret_exists
+  vars:
+    root_ca_secret_exists: "{{ root_ca_secret_buf.resources is defined and root_ca_secret_buf.resources | length > 0 }}"
   when: meteringconfig_tls_enabled
 
 #
@@ -38,33 +59,10 @@
       provider: selfsigned
       selfsigned_digest: sha256
 
-  - name: Use generate cert/key when secret doesn't already exist
+  - name: Use the generated root certificate authority cert/key values
     set_fact:
       _meteringconfig_tls_root_ca_certificate: "{{ lookup('file', '{{ certificates_dir.path }}/ca.crt') + '\n' }}"
       _meteringconfig_tls_root_ca_key: "{{ lookup('file', '{{ certificates_dir.path }}/ca.key') + '\n' }}"
-
   vars:
     root_ca_secret_exists: "{{ root_ca_secret_buf.resources is defined and root_ca_secret_buf.resources | length > 0 }}"
   when: meteringconfig_tls_enabled and not root_ca_secret_exists
-
-- name: Use pre-existing CA secret cert/key when secret already exists
-  block:
-  - set_fact:
-      _meteringconfig_tls_root_ca_certificate: "{{ root_ca_secret_buf.resources[0].data['ca.crt'] | b64decode }}"
-      _meteringconfig_tls_root_ca_key: "{{ root_ca_secret_buf.resources[0].data['ca.key'] | b64decode }}"
-
-  - name: Add root CA certificate to certificates directory
-    copy:
-      content: "{{ _meteringconfig_tls_root_ca_certificate }}"
-      dest: "{{ certificates_dir.path }}/ca.crt"
-    when: meteringconfig_tls_enabled
-
-  - name: Add root CA private key to certificates directory
-    copy:
-      content: "{{ _meteringconfig_tls_root_ca_key }}"
-      dest: "{{ certificates_dir.path }}/ca.key"
-    when: meteringconfig_tls_enabled
-
-  vars:
-    root_ca_secret_exists: "{{ root_ca_secret_buf.resources is defined and root_ca_secret_buf.resources | length > 0 }}"
-  when: meteringconfig_tls_enabled and root_ca_secret_exists

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
@@ -6,40 +6,47 @@
 - name: Validate that the user-provided Presto server TLS fields are not empty
   block:
   - name: Validate that the user provided a non-empty TLS certificate value
-    fail:
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.tls.certificate == ""
       msg: "presto.spec.config.tls.certificate cannot be empty if createSecret: true and secretName != ''"
-    when: meteringconfig_spec.presto.spec.config.tls.certificate == ""
 
   - name: Validate that the user provided a non-empty TLS CA certificate value
-    fail:
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.tls.caCertificate == ""
       msg: "presto.spec.config.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
-    when: meteringconfig_spec.presto.spec.config.tls.caCertificate == ""
 
   - name: Validate that the user provided a non-empty TLS key value
-    fail:
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.tls.key == ""
       msg: "presto.spec.config.tls.key cannot be empty if createSecret: true and secretName != ''"
-    when: meteringconfig_spec.presto.spec.config.tls.key == ""
   when: meteringconfig_template_presto_tls_secret
 
 - name: Validate that the user-provided Presto client Auth fields are not empty
   block:
   - name: Validate that the user provided a non-empty auth certificate value
-    fail:
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.auth.certificate == ""
       msg: "presto.spec.config.auth.certificate cannot be empty if createSecret: true and secretName != ''"
-    when: meteringconfig_spec.presto.spec.config.auth.certificate == ""
 
   - name: Validate that the user provided a non-empty auth CA certificate value
-    fail:
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.auth.caCertificate == ""
       msg: "presto.spec.config.auth.caCertificate cannot be empty if createSecret: true and secretName != ''"
-    when: meteringconfig_spec.presto.spec.config.auth.caCertificate == ""
 
   - name: Validate that the user provided a non-empty auth key value
-    fail:
+    assert:
+      that:
+        - meteringconfig_spec.presto.spec.config.auth.key == ""
       msg: "presto.spec.config.auth.key cannot be empty if createSecret: true and secretName != ''"
-    when: meteringconfig_spec.presto.spec.config.auth.key == ""
 
   - name: Validate that TLS is enabled when auth is enabled
-    fail:
+    assert:
+      that:
+        - not meteringconfig_spec.presto.spec.config.tls.enabled and meteringconfig_spec.presto.spec.config.auth.enabled
       msg: "Invalid configuration passed: you cannot enable auth but disable TLS."
-    when: not meteringconfig_spec.presto.spec.config.tls.enabled and meteringconfig_spec.presto.spec.config.auth.enabled
   when: meteringconfig_template_presto_auth_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
@@ -23,4 +23,3 @@
         - meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.data != ""
       msg: "spec.reporting-operator.spec.authProxy.authenticatedEmails: secretName and/or data key(s) cannot be empty when enabled and createSecret is set to true"
     when: meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.enabled and meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.createSecret
-  when: not meteringconfig_tls_enabled


### PR DESCRIPTION
This would add another file `configure_reporting_operator_openssl.yml`, which is used to automatically generate client cert/key for the reporting-operator to use when communicating with Presto and Hive Server.

Also, in this PR, there was some inconsistency on how related tasks were handled between the reporting-operator, Presto, and Root CA. I'd rather make these changes in a PR separate from #825 .