### PR TITLE
hack: Delete PVCs during uninstall

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -17,7 +17,7 @@ source "${ROOT_DIR}/hack/lib/util.sh"
 : "${CREATE_NAMESPACE:=true}"
 : "${SKIP_DELETE_CRDS:=true}"
 : "${SKIP_METERING_OPERATOR_DEPLOYMENT:=false}"
-: "${DELETE_PVCS:=false}"
+: "${DELETE_PVCS:=true}"
 
 : "${DEPLOY_PLATFORM:=openshift}"
 METERING_NAMESPACE=$(sanetize_namespace "${METERING_NAMESPACE:-metering}")

--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -48,5 +48,5 @@ fi
 
 if [ "$DELETE_PVCS" == "true" ]; then
     echo "Deleting PVCs"
-    kube-remove-non-file pvc -l "app in (hive-metastore, hdfs-namenode, hdfs-datanode)"
+    kube-remove-non-file pvc -l "app in (hive, hdfs)"
 fi


### PR DESCRIPTION
metering-ansible-operator deletes the hive-metastore PVC using an
ownerRef when the MeteringConfig is deleted, so we should also delete
the hdfs PVC.