### PR TITLE
Azure settings overide

### DIFF
--- a/Documentation/configuring-storage.md
+++ b/Documentation/configuring-storage.md
@@ -34,6 +34,22 @@ If you left `spec.storage.hive.s3.createBucket` set to true, or unset, then you 
 Please note that this must be done before installation.
 Changing these settings after installation will result in broken and unexpected behavior.
 
+## Storing data in Azure
+
+You can also store your data in Azure blob storage, and to do so, you must use an existing container.
+Edit the `spec.storage` section in the example [azure-blob-storage.yaml][azure-blob-storage-config]] configuration.
+Set the `spec.storage.hive.azure.container` and `spec.storage.hive.azure.secretName` with the secret following this format:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: your-azure-secret
+data:
+  azure-storage-account-name: "dGVzdAo="
+  azure-secret-access-key: "c2VjcmV0Cg=="
+```
+The `spec.storage.hive.azure.container` should be the container you wish to store metering data at, and the optional `spec.storage.hive.azure.rootDirectory` should be the folder you want your data in, inside the container.
+
 ## Using shared volumes for storage
 
 Metering has no storage by default, but can use any ReadWriteMany PersistentVolume or [StorageClass][storage-classes] that provisions a ReadWriteMany PersistentVolume.
@@ -59,6 +75,7 @@ For more details read [configuring HDFS][configuring-hdfs].
 
 [storage-classes]: https://kubernetes.io/docs/concepts/storage/storage-classes/
 [s3-storage-config]: ../manifests/metering-config/s3-storage.yaml
+[azure-blob-storage-config]: ../manifests/metering-config/azure-blob-storage.yaml
 [shared-storage-config]: ../manifests/metering-config/shared-storage.yaml
 [hdfs-storage-config]: ../manifests/metering-config/hdfs-storage.yaml
 [configuring-hive-metastore]: configuring-hive-metastore.md

--- a/charts/openshift-metering/templates/hadoop/hadoop-azure-credentials.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-azure-credentials.yaml
@@ -6,8 +6,8 @@ metadata:
 data:
 {{- if .Values.hadoop.spec.config.azure.storageAccountName }}
   azure-storage-account-name: {{ .Values.hadoop.spec.config.azure.storageAccountName | b64enc | quote}}
-{{- end}}
+{{- end }}
 {{- if .Values.hadoop.spec.config.azure.secretAccessKey }}
   azure-secret-access-key: {{ .Values.hadoop.spec.config.azure.secretAccessKey | b64enc | quote}}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -121,11 +121,6 @@ spec:
           mountPath: /hadoop-starting-config
         - name: hadoop-scripts
           mountPath: /hadoop-scripts
-      volumes:
-      - name: hadoop-scripts
-        configMap:
-          name: hadoop-scripts
-          defaultMode: 0775
       containers:
       - name: hdfs-namenode
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
       - name: hive-scripts
         configMap:
           name: hive-scripts
-          defaultMode: 0555
+          defaultMode: 0775
       containers:
       - name: metastore
         command: ["/hive-scripts/entrypoint.sh"]
@@ -208,7 +208,7 @@ spec:
       - name: hive-scripts
         configMap:
           name: hive-scripts
-          defaultMode: 0555
+          defaultMode: 0775
 {{- if .Values.hive.spec.config.useHadoopConfig }}
       - name: hadoop-config
         emptyDir: {}

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -103,7 +103,7 @@ spec:
       - name: hive-scripts
         configMap:
           name: hive-scripts
-          defaultMode: 0555
+          defaultMode: 0775
       containers:
       - name: hiveserver2
         command: ["/hive-scripts/entrypoint.sh"]
@@ -258,7 +258,7 @@ spec:
       - name: hive-scripts
         configMap:
           name: hive-scripts
-          defaultMode: 0555
+          defaultMode: 0775
 {{- if .Values.hive.spec.config.useHadoopConfig }}
       - name: hadoop-config
         emptyDir: {}

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -3,7 +3,6 @@
 meteringconfig_chart_path: "{{ lookup('env','HELM_CHART_PATH') }}"
 meteringconfig_prune_label_key: 'metering.openshift.io/prune'
 meteringconfig_prune_namespace_label_key: 'metering.openshift.io/ns-prune'
-
 meteringconfig_default_values_file: "{{ meteringconfig_chart_path + '/values.yaml' }}"
 meteringconfig_default_values: "{{ lookup('file', meteringconfig_default_values_file) | from_yaml }}"
 
@@ -53,7 +52,7 @@ meteringconfig_default_image_overrides:
         repository: "{{ lookup('env','METERING_HADOOP_IMAGE').split(':')[0] | default(meteringconfig_hadoop_default_image_repo, true) }}"
         tag: "{{ lookup('env','METERING_HADOOP_IMAGE').split(':')[1] | default(meteringconfig_hadoop_default_image_tag, true) }}"
 
-_storage_overrides:
+_base_storage_overrides:
   s3:
     storage:
       hive:
@@ -92,6 +91,48 @@ _storage_overrides:
           defaultFS: "s3a://{{ _storage_spec | json_query('hive.s3.bucket') | regex_replace('\\/?$', '/') }}"
         hdfs:
           enabled: false
+
+  azure:
+    storage:
+      hive:
+        # azure storage defaults
+        azure:
+          # Intentionally an invalid default name to ensure that this is overridden, and obvious when it's not.
+          container: "-unconfigured-metering-container-name-"
+          secretName: ""
+          storageAccountName: ""
+          secretAccessKey: ""
+          createSecret: false
+          rootDirectory: ""
+    presto:
+      spec:
+        config:
+          azure:
+            secretName: "{{ _storage_spec | json_query('hive.azure.secretName') }}"
+            createSecret: "{{ _storage_spec | json_query('hive.azure.createSecret') }}"
+            storageAccountName: "{{ _storage_spec | json_query('hive.azure.storageAccountName') }}"
+            secretAccessKey: "{{ _storage_spec | json_query('hive.azure.secretAccessKey') }}"
+    hive:
+      spec:
+        config:
+          metastoreWarehouseDir: "wasbs://{{ _storage_spec | json_query('hive.azure.container') }}@{{ _storage_spec | json_query('hive.azure.storageAccountName') }}.blob.core.windows.net{{ _storage_spec | json_query('hive.azure.rootDirectory') | default('/', True) | regex_replace('^\\/?', '/') }}"
+          azure:
+            secretName: "{{ _storage_spec | json_query('hive.azure.secretName') }}"
+            createSecret: "{{ _storage_spec | json_query('hive.azure.createSecret') }}"
+            storageAccountName: "{{ _storage_spec | json_query('hive.azure.storageAccountName') }}"
+            secretAccessKey: "{{ _storage_spec | json_query('hive.azure.secretAccessKey') }}"
+    hadoop:
+      spec:
+        config:
+          defaultFS: "wasbs://{{ _storage_spec | json_query('hive.azure.container') }}@{{ _storage_spec | json_query('hive.azure.storageAccountName') }}.blob.core.windows.net{{ _storage_spec | json_query('hive.azure.rootDirectory') | default('/', True) | regex_replace('^\\/?', '/') }}"
+          azure:
+            secretName: "{{ _storage_spec | json_query('hive.azure.secretName') }}"
+            createSecret: "{{ _storage_spec | json_query('hive.azure.createSecret') }}"
+            storageAccountName: "{{ _storage_spec | json_query('hive.azure.storageAccountName') }}"
+            secretAccessKey: "{{ _storage_spec | json_query('hive.azure.secretAccessKey') }}"
+        hdfs:
+          enabled: false
+
   hdfs:
     hadoop:
       spec:
@@ -120,6 +161,29 @@ _storage_overrides:
         hdfs:
           enabled: false
 
+# overides the accountname(potentially empty) from a designated secret and generate the storage URL
+meteringconfig_storage_azure_create_secret: "{{ _storage_spec | json_query('hive.azure.createSecret') | default(false, true) }}"
+
+_azure_secret_account_name: ""
+#
+# Use _azure_account_overides when meteringconfig_storage_azure_create_secret is false to correctly set the defaultFS and metastoreWarehouseDir with the storage account name from the user's secret.
+#
+_azure_account_overides:
+  azure:
+    hadoop:
+      spec:
+        config:
+          defaultFS: "wasbs://{{ _storage_spec | json_query('hive.azure.container') }}@{{ _azure_secret_account_name  }}.blob.core.windows.net{{ _storage_spec | json_query('hive.azure.rootDirectory')| default('/', True) | regex_replace('^\\/?', '/') }}"
+    hive:
+      spec:
+        config:
+          metastoreWarehouseDir: "wasbs://{{ _storage_spec | json_query('hive.azure.container') }}@{{ _azure_secret_account_name }}.blob.core.windows.net{{ _storage_spec | json_query('hive.azure.rootDirectory')| default('/', True) | regex_replace('^\\/?', '/') }}"
+
+_meteringconfig_azure_overrides: "{{ meteringconfig_storage_azure_create_secret | ternary({} , _azure_account_overides ) | default({}, true) }}"
+_storage_overrides: "{{ _base_storage_overrides | combine(_meteringconfig_azure_overrides, recursive = True) }}"
+meteringconfig_storage_azure_container_name: "{{ _storage_spec | json_query('hive.azure.container') }}"
+meteringconfig_storage_azure_storage_account_name: "{{ _storage_spec | json_query('hive.azure.storageAccountName') }}"
+meteringconfig_storage_azure_credentials_secret_name: "{{ _storage_spec | json_query('hive.azure.secretName') }}"
 meteringconfig_storage_hive_storage_type: "{{ _storage_spec | json_query('hive.type') }}"
 meteringconfig_storage_overrides: "{{ _storage_overrides[meteringconfig_storage_hive_storage_type] | default({}, true) }}"
 
@@ -392,3 +456,4 @@ meteringconfig_create_reporting_operator_hive_auth_secrets: "{{ _reporting_op_sp
 meteringconfig_create_reporting_operator_tls_secrets: "{{ _reporting_op_spec.config.tls.api.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_route: "{{ _reporting_op_spec.route.enabled | default(false) }}"
 meteringconfig_create_reporting_operator_cluster_monitoring_view_rbac: "{{ _reporting_op_spec.rbac.createClusterMonitoringViewRBAC | default(true) }}"
+

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_openssl.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_openssl.yml
@@ -1,5 +1,4 @@
 ---
-
 #
 # Generate the Presto Server cert/key
 #

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -1,3 +1,4 @@
+
 ---
 
 - name: Configure S3 Storage
@@ -34,3 +35,36 @@
       when: operator_s3_credentials_secret.resources | length > 0
 
   when: meteringconfig_storage_hive_storage_type == 's3' and meteringconfig_storage_s3_create_bucket
+
+- name: Get azure storage account name
+  block:
+    - name: Get Azure storage credentials secret
+      k8s_facts:
+        api_version: v1
+        kind: Secret
+        name: "{{ meteringconfig_spec.storage.hive.azure.secretName }}"
+        namespace: "{{ meta.namespace }}"
+      register: azure_secret_buf
+
+    - name: Extract Azure storage account name
+      set_fact:
+        _azure_secret_account_name: "{{ azure_secret_buf.resources[0].data['azure-storage-account-name'] | b64decode | default(omit)  }}"
+  when: meteringconfig_storage_hive_storage_type == 'azure' and not meteringconfig_storage_azure_create_secret
+
+- name: Configure Azure Storage
+  block:
+    - name: Validate Metering Azure bucket name
+      assert:
+        that:
+          - meteringconfig_storage_azure_container_name != ""
+          - meteringconfig_storage_azure_storage_account_name != ""
+        msg: "storage.hive.azure.container and storage.hive.azure.storageAccountName cannot be empty"
+
+    - name: Validate Metering Azure credentials
+      assert:
+        that:
+          - meteringconfig_storage_azure_credentials_secret_name == ""
+        msg: "storage.hive.azure.secretName is only used to reference existing secrets, must be empty if creating new secrets"
+
+  when: meteringconfig_storage_hive_storage_type == 'azure' and meteringconfig_storage_azure_create_secret
+

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -7,10 +7,10 @@
 
 - name: Validate Hive storage configuration
   fail:
-    msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of 's3', or 'sharedPVC'"
+    msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of 's3', 'azure', or 'sharedPVC'"
   vars:
     hiveStorageType: "{{ meteringconfig_spec_overrides | json_query('storage.hive.type') }}"
-  when: hiveStorageType is undefined or hiveStorageType not in ['s3', 'sharedPVC', 'hdfs']
+  when: hiveStorageType is undefined or hiveStorageType not in ['s3', 'sharedPVC', 'hdfs', 'azure']
 
 - name: Configure TLS
   include_tasks: configure_tls.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -57,4 +57,3 @@
       - template_file: templates/hive/hive-server-statefulset.yaml
         apis: [ {kind: statefulset, api_version: 'apps/v1'} ]
         prune_label_value: hive-server-statefulset
-

--- a/manifests/metering-config/azure-blob-storage.yaml
+++ b/manifests/metering-config/azure-blob-storage.yaml
@@ -1,0 +1,13 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: "operator-metering"
+spec:
+  storage:
+    type: "hive"
+    hive:
+      type: "azure"
+      azure:
+        container: "bucket1"
+        secretName: "my-azure-secret"
+        rootDirectory: "/testDir"


### PR DESCRIPTION

added settings to Ansible, allowing setting the azure credentials in one place to apply to all the different nodes.

