### PR TITLE
Rename the 'http' port name to 'api' in the reporting-operator service.

### DIFF
--- a/Documentation/reportqueries.md
+++ b/Documentation/reportqueries.md
@@ -144,14 +144,14 @@ This example, unlike the previous is designed to be used with Reports.
 
 You can modify the ReportQuery to display all columns or to hide or show columns as needed. The full endpoint displays all columns.
 To query report results using the reporting-operator API for full endpoint the api call is:
-`http://127.0.0.1:8001/api/v1/namespaces/metering/services/http:reporting-operator:http/proxy/api/v2/reports/metering/namespace-cpu-request/full?format=json`
+`http://127.0.0.1:8001/api/v1/namespaces/metering/services/http:reporting-operator:api/proxy/api/v2/reports/metering/namespace-cpu-request/full?format=json`
 This example is showing the `namespace-cpu-request` query in JSON format.
 
 To use the TableHidden display feature:
 - enter `TableHidden` field in query as true or false. In `node-cpu-capacity` the `labels` tableHidden value is set to `true`.
 - Next run a report.
 To query report results using the reporting-operator API for tableHidden endpoint the api call is:
-`http://127.0.0.1:8001/api/v1/namespaces/metering/services/http:reporting-operator:http/proxy/api/v2/reports/metering/namespace-cpu-request/table?format=json`
+`http://127.0.0.1:8001/api/v1/namespaces/metering/services/http:reporting-operator:api/proxy/api/v2/reports/metering/namespace-cpu-request/table?format=json`
 
 [apiTable]: api.md#v2-reports-table
 [presto-select]: https://prestodb.io/docs/current/sql/select.html

--- a/Documentation/using-metering.md
+++ b/Documentation/using-metering.md
@@ -91,16 +91,16 @@ $ kubectl proxy
 
 Using `kubectl proxy` requires that the URL be accessed through a prefix that
 points to the Kubernetes service. (See the upstream documentation on
-[manually constructing apiserver proxy URLs][accessing-services] for more details.) The following example assumes that Metering is deployed in the `metering` namespace:
+[manually constructing apiserver proxy URLs][accessing-services] for more details.) The following example assumes that the `$METERING_NAMESPACE` environment variable is properly set:
 
 ```
-http://127.0.0.1:8001/api/v1/namespaces/$METERING_NAMESPACE/services/http:reporting-operator:http/proxy/api/v1/reports/get?name=[Report Name]&namespace=$METERING_NAMESPACE&format=[Format]
+http://127.0.0.1:8001/api/v1/namespaces/$METERING_NAMESPACE/services/http:reporting-operator:api/proxy/api/v1/reports/get?name=[Report Name]&namespace=$METERING_NAMESPACE&format=[Format]
 ```
 
-If you are using Openshift, you'll need to change to the following, which uses the `openshift-metering` namespace and HTTPS by default:
+If you are using Openshift, you'll need to change to the following, which uses HTTPS by default:
 
 ```
-http://127.0.0.1:8001/api/v1/namespaces/$METERING_NAMESPACE/services/https:reporting-operator:http/proxy/api/v1/reports/get?name=[Report Name]&namespace=$METERING_NAMESPACE&format=[Format]
+http://127.0.0.1:8001/api/v1/namespaces/$METERING_NAMESPACE/services/https:reporting-operator:api/proxy/api/v1/reports/get?name=[Report Name]&namespace=$METERING_NAMESPACE&format=[Format]
 ```
 
 For example, the results of a report with the name `namespace-cpu-request` report can be fetched in

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -158,7 +158,7 @@ spec:
         env:
 {{- include "presto-common-env" . | indent 8 }}
         ports:
-        - name: http
+        - name: api
           containerPort: 8080
           protocol: TCP
         - name: metrics

--- a/charts/openshift-metering/templates/presto/presto-service.yaml
+++ b/charts/openshift-metering/templates/presto/presto-service.yaml
@@ -8,7 +8,7 @@ metadata:
     component: presto-coordinator
 spec:
   ports:
-  - name: http
+  - name: api
     port: 8080
   - name: metrics
     port: 8082
@@ -28,7 +28,7 @@ metadata:
     component: presto-coordinator
 spec:
   ports:
-  - name: http
+  - name: api
     port: 8080
   - name: metrics
     port: 8082
@@ -46,7 +46,7 @@ metadata:
     app: presto
 spec:
   ports:
-  - name: http
+  - name: api
     port: 8080
   clusterIP: None
   selector:

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -122,7 +122,7 @@ spec:
         env:
 {{- include "presto-common-env" . | indent 8 }}
         ports:
-        - name: http
+        - name: api
           containerPort: 8080
           protocol: TCP
         - name: metrics

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -313,11 +313,11 @@ spec:
         resources:
 {{ toYaml $operatorValues.spec.resources | indent 10 }}
         ports:
-        - name: "http"
+        - name: api
           containerPort: 8080
-        - name: "pprof"
+        - name: pprof
           containerPort: 6060
-        - name: "metrics"
+        - name: metrics
           containerPort: 8082
 {{/* When using auth-proxy, disable probes against the reporting-operator pod since we'll listen on localhost, and we'll configure to probe the auth proxy pod instead */}}
 {{- if not $operatorValues.spec.authProxy.enabled }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-route.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-route.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ $operatorValues.spec.route.name }}
 spec:
   port:
-    targetPort: http
+    targetPort: api
   tls:
     termination: Reencrypt
     insecureEdgeTerminationPolicy: Allow

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-service.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-service.yaml
@@ -15,16 +15,16 @@ spec:
   selector:
     app: reporting-operator
   ports:
-  - name: http
+  - name: api
     port: 8080
 {{- if $operatorValues.spec.authProxy.enabled }}
     targetPort: auth-proxy
 {{- else }}
-    targetPort: http
+    targetPort: api
 {{- end }}
 {{- if and (eq (lower $operatorValues.spec.apiService.type) "nodeport" "loadbalancer") $operatorValues.spec.apiService.nodePort }}
     nodePort: {{ $operatorValues.spec.apiService.nodePort }}
 {{- end }}
-  - port: 8082
+  - name: metrics
+    port: 8082
     targetPort: metrics
-    name: metrics


### PR DESCRIPTION
This can cause confusion when trying to access the reporting-operator API, i.e.:
```
curl "http://127.0.0.1:8001/api/v1/namespaces/$METERING_NAMESPACE/services/https:reporting-operator:http/proxy/api/v1/reports/get?name=namespace-cpu-utilization&namespace=$METERING_NAMESPACE&format=tab"
```

The `/services/https:reporting-operator:http` endpoint can be a bit misleading with the current port name being `http`, so this PR would change that endpoint to `/services/https:reporting-operator:api`.

For more information, check out: https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-services/#manually-constructing-apiserver-proxy-urls