### PR TITLE
images/metering-ansible-operator: Update conditional to check if the 'resources' field is defined in the registered variable.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -44,8 +44,8 @@
     no_log: true
     when: presto_auth_secret_exists
   vars:
-    presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources and presto_secret_tls_buf.resources | length > 0 }}"
-    presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources and presto_secret_auth_buf.resources | length > 0 }}"
+    presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources is defined and presto_secret_tls_buf.resources | length > 0 }}"
+    presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources is defined and presto_secret_auth_buf.resources | length > 0 }}"
   when: meteringconfig_tls_enabled
 
 #
@@ -72,6 +72,6 @@
     no_log: true
     when: not presto_auth_secret_exists
   vars:
-    presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources and presto_secret_tls_buf.resources | length > 0 }}"
-    presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources and presto_secret_auth_buf.resources | length > 0 }}"
+    presto_tls_secret_exists: "{{ presto_secret_tls_buf.resources is defined and presto_secret_tls_buf.resources | length > 0 }}"
+    presto_auth_secret_exists: "{{ presto_secret_auth_buf.resources is defined and presto_secret_auth_buf.resources | length > 0 }}"
   when: meteringconfig_tls_enabled and (not presto_tls_secret_exists or not presto_auth_secret_exists)


### PR DESCRIPTION
This lead to errors in the case where the secret didn't exist (therefore the 'resources' field would be undefined).