### PR TITLE
Dockerfile.metering-ansible-operator*: Fix entrypoint

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -37,7 +37,7 @@ COPY charts/openshift-metering ${HELM_CHART_PATH}
 
 COPY manifests/deploy/openshift/olm/bundle /manifests
 
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ansible-operator", "run", "ansible", "--watches-file=/opt/ansible/watches.yaml"]
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -31,7 +31,7 @@ COPY charts/openshift-metering ${HELM_CHART_PATH}
 
 COPY manifests/deploy/openshift/olm/bundle /manifests
 
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ansible-operator", "run", "ansible", "--watches-file=/opt/ansible/watches.yaml"]
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \


### PR DESCRIPTION
Entrypoint in the base image is no longer a script, so update to calling
tini directly against the ansible-operator binary.