### PR TITLE
Documentation: Clarify that Metering only supports Amazon s3 in relevant sections.

### DIFF
--- a/Documentation/configuring-storage.md
+++ b/Documentation/configuring-storage.md
@@ -5,18 +5,18 @@ The primary storage requirement is to persist data collected by the reporting-op
 
 Additionally, Hive metastore requires storage for it's database containing metadata about database tables managed by Presto or Hive. By default, this information is stored in an embedded database called Derby, which keeps it's data on disk in a PersistentVolume, but metastore can also be configured to use an existing Mysql or Postgresql database, instead of Derby. Read the [configuring the Hive metastore documentation][configuring-hive-metastore] for more details.
 
-## Storing data in S3
+## Storing data in Amazon S3
+**Note**: Metering only supports Amazon S3, and not any S3 compatible API at this time.
 
-By default, metering has no stored configured but can be configured to store data in S3.
-
-To use S3 for storage, edit the `spec.storage` section in the example [s3-storage.yaml][s3-storage-config] configuration.
+To use Amazon S3 for storage, edit the `spec.storage` section in the example [s3-storage.yaml][s3-storage-config] configuration.
 Set the `spec.storage.hive.s3.bucket`, `spec.storage.hive.s3.region` and `spec.storage.hive.s3.secretName` values.
-The `bucket` should be the name and optionally the path within the bucket you wish to store metering data at, and the `region` should be the region to create your bucket in.
-If you wish to provide an existing bucket, or do not want to provide IAM credentials that have CreateBucket permissions, set `spec.storage.hive.s3.createBucket` to `false` and provide the name of a pre-existing bucket for `spec.storage.hive.s3.bucket`.
-The `secretName` should be the name of a secret in the metering namespace containing AWS credentials in the `data.aws-access-key-id` and `data.aws-secret-access-key` fields.
+
+The `bucket` and `region` fields should be the name, and optionally the path within the bucket you wish to store Metering data at, and the region in which you wish to create your bucket in, respectively.
+
+If you want to provide an existing S3 bucket, or do not want to provide IAM credentials that have CreateBucket permissions, set `spec.storage.hive.s3.createBucket` to `false` and provide the name of a pre-existing bucket for `spec.storage.hive.s3.bucket`.
+The `secretName` should be the name of a secret in the Metering namespace containing the AWS credentials in the `data.aws-access-key-id` and `data.aws-secret-access-key` fields.
 
 For example:
-
 ```
 apiVersion: v1
 kind: Secret
@@ -27,8 +27,8 @@ data:
   aws-secret-access-key: "c2VjcmV0Cg=="
 ```
 
-To store data in S3, the `aws-access-key-id` and `aws-secret-access-key` credentials must have read and write access to the bucket.
-For an example of an IAM policy granting the required permissions see the [aws/read-write.json](aws/read-write.json) file.
+To store data in Amazon S3, the `aws-access-key-id` and `aws-secret-access-key` credentials must have read and write access to the bucket.
+For an example of an IAM policy granting the required permissions, see the [aws/read-write.json](aws/read-write.json) file.
 If you left `spec.storage.hive.s3.createBucket` set to true, or unset, then you should use [aws/read-write-create.json](aws/read-write-create.json) which contains permissions for creating and deleting buckets.
 
 Please note that this must be done before installation.

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -13,7 +13,7 @@
     - [exposing the reporting API](configuring-reporting-operator.md#exposing-the-reporting-api)
     - [configuring Authentication on Openshift](configuring-reporting-operator.md#openshift-authentication)
   - [configuring storage](configuring-storage.md)
-    - [storing data in s3](configuring-storage.md#storing-data-in-s3)
+    - [storing data in Amazon S3](configuring-storage.md#storing-data-in-s3)
     - [storing data in a ReadWriteMany PVC](configuring-storage.md#using-shared-volumes-for-storage)
   - [configuring the Hive metastore](configuring-hive-metastore.md)
   - [configuring aws billing correlation for cost correlation](configuring-aws-billing.md)

--- a/Documentation/metering-config.md
+++ b/Documentation/metering-config.md
@@ -15,7 +15,7 @@ For details on different types of configuration read the relevant document:
   - [exposing the reporting API](configuring-reporting-operator.md#exposing-the-reporting-api)
   - [configuring Authentication on Openshift](configuring-reporting-operator.md#openshift-authentication)
 - [configuring storage](configuring-storage.md)
-  - [storing data in s3](configuring-storage.md#storing-data-in-s3)
+  - [storing data in Amazon S3](configuring-storage.md#storing-data-in-s3)
 - [configuring the Hive metastore](configuring-hive-metastore.md)
 - [configuring aws billing correlation for cost correlation](configuring-aws-billing.md)
 


### PR DESCRIPTION
Previously, there was some confusion as to whether Metering is able to support any s3 alternative.