### PR TITLE
Update ReportDataSource CRD to comply with k8s structural standards.

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/reportdatasource.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/reportdatasource.crd.yaml
@@ -133,16 +133,12 @@ spec:
                     name:
                       type: string
                       minLength: 1
-          anyOf:
-          - type: object
-            required:
+          oneOf:
+          - required:
             - prometheusMetricsImporter
-          - type: object
-            required:
+          - required:
             - reportQueryView
-          - type: object
-            required:
+          - required:
             - awsBilling
-          - type: object
-            required:
+          - required:
             - prestoTable

--- a/manifests/deploy/openshift/metering-ansible-operator/reportdatasource.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/reportdatasource.crd.yaml
@@ -133,17 +133,13 @@ spec:
                     name:
                       type: string
                       minLength: 1
-          anyOf:
-          - type: object
-            required:
+          oneOf:
+          - required:
             - prometheusMetricsImporter
-          - type: object
-            required:
+          - required:
             - reportQueryView
-          - type: object
-            required:
+          - required:
             - awsBilling
-          - type: object
-            required:
+          - required:
             - prestoTable
 

--- a/manifests/deploy/openshift/olm/bundle/4.2/reportdatasource.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/reportdatasource.crd.yaml
@@ -133,17 +133,13 @@ spec:
                     name:
                       type: string
                       minLength: 1
-          anyOf:
-          - type: object
-            required:
+          oneOf:
+          - required:
             - prometheusMetricsImporter
-          - type: object
-            required:
+          - required:
             - reportQueryView
-          - type: object
-            required:
+          - required:
             - awsBilling
-          - type: object
-            required:
+          - required:
             - prestoTable
 


### PR DESCRIPTION
See [extending CRDs with structural validation](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema) for more information on some of the limitations of openAPI V3 features.

More specifically, this violates rule no.3 described in the link above.