### PR TITLE
charts/openshift-metering: Set bind host for hive server and metastore to 127.0.0.1 with TLS/auth enabled

### DIFF
--- a/charts/openshift-metering/templates/hive/hive-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-configmap.yaml
@@ -30,6 +30,22 @@ data:
         <value>JMX</value>
       </property>
       <property>
+        <name>hive.server2.thrift.bind.host</name>
+{{- if .Values.hive.spec.server.config.tls.enabled }}
+        <value>127.0.0.1</value>
+{{- else }}
+        <value>0.0.0.0</value>
+{{- end }}
+      </property>
+      <property>
+        <name>hive.metastore.thrift.bind.host</name>
+{{- if .Values.hive.spec.metastore.config.tls.enabled }}
+        <value>127.0.0.1</value>
+{{- else }}
+        <value>0.0.0.0</value>
+{{- end }}
+      </property>
+      <property>
         <name>hive.metastore.uris</name>
 {{- if .Values.hive.spec.metastore.config.tls.enabled }}
         <value>thrift://localhost:9083</value>

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -1,3 +1,8 @@
+{{/* When using TLS set probes to use the ghostunnel server port */}}
+{{- if .Values.hive.spec.metastore.config.tls.enabled -}}
+{{- $_ := set .Values.hive.spec.metastore.readinessProbe.tcpSocket "port" 9084 -}}
+{{- $_ := set .Values.hive.spec.metastore.livenessProbe.tcpSocket "port" 9084 -}}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -92,6 +97,7 @@ spec:
 {{- end }}
         - containerPort: 8082
           name: metrics
+{{- if not .Values.hive.spec.metastore.config.tls.enabled }}
 {{- if .Values.hive.spec.metastore.readinessProbe }}
         readinessProbe:
 {{ toYaml .Values.hive.spec.metastore.readinessProbe | indent 10 }}
@@ -99,6 +105,7 @@ spec:
 {{- if .Values.hive.spec.metastore.livenessProbe }}
         livenessProbe:
 {{ toYaml .Values.hive.spec.metastore.livenessProbe | indent 10 }}
+{{- end }}
 {{- end }}
         env:
         - name: HIVE_LOGLEVEL
@@ -192,6 +199,15 @@ spec:
         volumeMounts:
         - name: hive-metastore-tls-secret
           mountPath: /opt/hive/tls
+{{- if .Values.hive.spec.metastore.readinessProbe }}
+        readinessProbe:
+{{ toYaml .Values.hive.spec.metastore.readinessProbe | indent 10 }}
+{{- end }}
+{{- if .Values.hive.spec.metastore.livenessProbe }}
+        livenessProbe:
+{{ toYaml .Values.hive.spec.metastore.livenessProbe | indent 10 }}
+{{- end }}
+
 {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -1,3 +1,8 @@
+{{/* When using TLS set probes to use the ghostunnel server port */}}
+{{- if .Values.hive.spec.server.config.tls.enabled -}}
+{{- $_ := set .Values.hive.spec.server.readinessProbe.tcpSocket "port" 10001 -}}
+{{- $_ := set .Values.hive.spec.server.livenessProbe.tcpSocket "port" 10001 -}}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -119,6 +124,7 @@ spec:
 {{- end }}
         - containerPort: 8082
           name: metrics
+{{- if not .Values.hive.spec.server.config.tls.enabled }}
 {{- if .Values.hive.spec.server.readinessProbe }}
         readinessProbe:
 {{ toYaml .Values.hive.spec.server.readinessProbe | indent 10 }}
@@ -126,6 +132,7 @@ spec:
 {{- if .Values.hive.spec.server.livenessProbe }}
         livenessProbe:
 {{ toYaml .Values.hive.spec.server.livenessProbe | indent 10 }}
+{{- end }}
 {{- end }}
         terminationMessagePath: /dev/termination-log
         env:
@@ -242,6 +249,15 @@ spec:
         volumeMounts:
         - name: hive-server-tls-secret
           mountPath: /opt/hive/server-tls
+{{- if .Values.hive.spec.server.readinessProbe }}
+        readinessProbe:
+{{ toYaml .Values.hive.spec.server.readinessProbe | indent 10 }}
+{{- end }}
+{{- if .Values.hive.spec.server.livenessProbe }}
+        livenessProbe:
+{{ toYaml .Values.hive.spec.server.livenessProbe | indent 10 }}
+{{- end }}
+
 {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -701,20 +701,21 @@ hive:
         size: 5Gi
 
       livenessProbe:
+        tcpSocket:
+          port: 9083
         failureThreshold: 3
         initialDelaySeconds: 90
         periodSeconds: 30
         successThreshold: 1
+        timeoutSeconds: 15
+
+      readinessProbe:
         tcpSocket:
           port: 9083
-        timeoutSeconds: 15
-      readinessProbe:
         failureThreshold: 3
         initialDelaySeconds: 60
         periodSeconds: 20
         successThreshold: 1
-        tcpSocket:
-          port: 9083
         timeoutSeconds: 15
 
     server:
@@ -766,20 +767,21 @@ hive:
           memory: 500Mi
 
       livenessProbe:
+        tcpSocket:
+          port: 10000
         failureThreshold: 3
         initialDelaySeconds: 300
         periodSeconds: 30
         successThreshold: 1
+        timeoutSeconds: 15
+
+      readinessProbe:
         tcpSocket:
           port: 10000
-        timeoutSeconds: 15
-      readinessProbe:
         failureThreshold: 3
         initialDelaySeconds: 60
         periodSeconds: 20
         successThreshold: 1
-        tcpSocket:
-          port: 10000
         timeoutSeconds: 15
 
     securityContext:


### PR DESCRIPTION
Ensures that the pod is unaccessible on it's unauthenticated ports and
all communication must be done through ghostunnel which requires TLS and
auth.