### PR TITLE
Dockerfile.metering-ansible-operator*: Install openssl

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -3,10 +3,10 @@ FROM quay.io/openshift/origin-metering-helm:latest as helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli:latest as cli
 # real base
-FROM quay.io/operator-framework/ansible-operator:v0.6.0
+FROM quay.io/openshift/origin-ansible-operator:latest
 
 USER root
-RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools" \
+RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools openssl" \
     && yum -y install epel-release \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -6,7 +6,7 @@ FROM openshift/ose-cli:latest as cli
 FROM openshift/ose-ansible-operator:latest
 
 USER root
-RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-boto3" \
+RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-boto3 openssl" \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \


### PR DESCRIPTION
The upstream ansible base is now based on UBI so we need to install
openssl since it's no longer pre-installed in our base image.