### PR TITLE
Add 'logHelmTemplate' to MeteringConfig values.

### DIFF
--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -4,6 +4,8 @@ global:
 unsupportedFeatures:
   enableHDFS: false
 
+logHelmTemplate: true
+
 storage:
   type: "hive"
   hive: {}


### PR DESCRIPTION
I was getting the error:
```
ValidationError(MeteringConfig.spec): unknown field "logHelmTemplate" in io.openshift.metering.v1.MeteringConfig.spec
```
and noticed that there was no `spec.logHelmTemplate` in the `charts/openshift-metering/values.yaml`.