### PR TITLE
Improve running local tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ unit-docker: metering-src-docker-build
 		$(METERING_SRC_IMAGE_REPO):$(METERING_SRC_IMAGE_TAG) \
 		make unit
 
-integration:
+integration: bin/test2json
 	hack/integration.sh
 
 integration-local: reporting-operator-local metering-ansible-operator-docker-build
@@ -136,7 +136,7 @@ integration-docker: metering-src-docker-build
 	docker cp metering-integration-docker:/out bin/integration-docker-test-output
 	docker rm metering-integration-docker
 
-e2e:
+e2e: bin/test2json
 	hack/e2e.sh
 
 e2e-local: reporting-operator-local metering-ansible-operator-docker-build

--- a/hack/e2e-test-runner.sh
+++ b/hack/e2e-test-runner.sh
@@ -188,7 +188,8 @@ function cleanup() {
     fi
 
     echo "Stopping background jobs"
-    kill $(jobs -rp)
+    local pids=$(jobs -pr)
+    [ -n "$pids" ] && kill $pids
     # Wait for any jobs
     wait 2>/dev/null
 

--- a/hack/run-reporting-operator-local.sh
+++ b/hack/run-reporting-operator-local.sh
@@ -35,7 +35,8 @@ function cleanup() {
 
     echo "Stopping background jobs"
     # kill any background jobs
-    jobs -p | xargs kill
+    local pids=$(jobs -pr)
+    [ -n "$pids" ] && kill $pids
     # Wait for any jobs
     wait 2>/dev/null
 


### PR DESCRIPTION
- Makefile: Build test2json before running integration/e2e
- hack: Only kill if there are background jobs to kill