### PR TITLE
manifests/metering-config: Remove the 'class: null' key from MeteringConfig examples.

### DIFF
--- a/manifests/metering-config/hdfs-storage.yaml
+++ b/manifests/metering-config/hdfs-storage.yaml
@@ -36,7 +36,6 @@ spec:
             # If you have a storageClass which provides SSDs, uncomment and
             # specify it here:
             # class: "fast-ssd"
-            class: null
             # The default size of 5Gi is fairly small. With 1000 namespaces and
             # at least 5 pods per namespace you could expect a few hundred Mb of
             # storage per week.
@@ -67,7 +66,6 @@ spec:
             # If you have a storageClass which provides SSDs, uncomment and
             # specify it here:
             # class: "fast-ssd"
-            class: null
             # Namenodes mostly need larger disks because they consume more
             # inodes, and the amount of storage needed grows over time as more
             # blocks are created on HDFS datanodes.

--- a/manifests/metering-config/metastore-storage.yaml
+++ b/manifests/metering-config/metastore-storage.yaml
@@ -9,6 +9,5 @@ spec:
         storage:
           # Default is null, which means using the default storage class if it exists.
           # If you wish to use a different storage class, specify it here
-          class: null
           # class: "fast-ssd"
           size: "5Gi"

--- a/manifests/metering-config/recommended-resource-limits.yaml
+++ b/manifests/metering-config/recommended-resource-limits.yaml
@@ -84,7 +84,6 @@ spec:
           # If you have a storageClass which provides SSDs, uncomment and
           # specify it here:
           # class: "fast-ssd"
-          class: null
           # Generally the default metastore size of 5Gi is sufficient, but
           # with a large amount of ReportDataSources, you may wish to
           # increase it.


### PR DESCRIPTION
Currently, this would be invalid if we define the type of the `class` key to be of type string (as string != null).