### PR TITLE
manifests/metering-config: Add 'spec.storage.type' field to shared-storage.yaml.

### DIFF
--- a/manifests/metering-config/shared-storage.yaml
+++ b/manifests/metering-config/shared-storage.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "operator-metering"
 spec:
   storage:
+    type: "hive"
     hive:
       type: "sharedPVC"
       sharedPVC:


### PR DESCRIPTION
This field is a required `spec.storage` property, and is also present in the `s3-storage.yaml`, `hdfs-storage.yaml`, `azure-blob-storage.yaml` manifest files.