### PR TITLE
Add support for Google Cloud Storage with Json keyfile as auth

### DIFF
--- a/Documentation/configuring-storage.md
+++ b/Documentation/configuring-storage.md
@@ -50,6 +50,26 @@ data:
 ```
 The `spec.storage.hive.azure.container` should be the container you wish to store metering data at, and the optional `spec.storage.hive.azure.rootDirectory` should be the folder you want your data in, inside the container.
 
+## Storing data in Google Cloud Storage
+
+You can also store your data in Google Cloud Storage, and to do so, you must use an existing bucket.
+Edit the `spec.storage` section in the example [gcs-storage.yaml][gcs-config] configuration.
+Set the `spec.storage.hive.gcs.bucket` and `spec.storage.hive.gcs.secretName` with the secret following this format:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: your-gcs-secret
+data:
+  gcs-service-account.json: "c2VjcmV0Cg=="
+```
+You can easily create the secret by calling:
+```
+kubectl -n $METERING_NAMESPACE create secret generic your-gcs-secret --from-file gcs-service-account.json=/path/to/your/service-account-key.json
+```
+Where $METERING_NAMESPACE is your namespace.
+The spec.storage.hive.gcs.bucket field should be the name of the bucket you wish to hold your metering data. You can also specify a sub-directory within this bucket by appending the name of the directory after the bucket name. For example: bucket: metering-gcs/test, where the bucket's name is metering-gcs and test is the name of the sub-directory.
+
 ## Using shared volumes for storage
 
 Metering has no storage by default, but can use any ReadWriteMany PersistentVolume or [StorageClass][storage-classes] that provisions a ReadWriteMany PersistentVolume.
@@ -76,6 +96,7 @@ For more details read [configuring HDFS][configuring-hdfs].
 [storage-classes]: https://kubernetes.io/docs/concepts/storage/storage-classes/
 [s3-storage-config]: ../manifests/metering-config/s3-storage.yaml
 [azure-blob-storage-config]: ../manifests/metering-config/azure-blob-storage.yaml
+[gcs-config]: ../manifests/metering-config/gcs-storage.yaml
 [shared-storage-config]: ../manifests/metering-config/shared-storage.yaml
 [hdfs-storage-config]: ../manifests/metering-config/hdfs-storage.yaml
 [configuring-hive-metastore]: configuring-hive-metastore.md

--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -61,6 +61,7 @@ spec:
                       - sharedPVC
                       - s3
                       - azure
+                      - gcs
                     hdfs:
                       type: object
                       required:
@@ -110,6 +111,35 @@ spec:
                         rootDirectory:
                           type: string
                           minLength: 1
+                    gcs:
+                      type: object
+                      required:
+                        - bucket
+                      oneOf:
+                      - required:
+                        - serviceAccountKeyJSON
+                        allOf:
+                        - not:
+                            required:
+                            - secretName
+                      - required:
+                        - secretName
+                        allOf:
+                        - not:
+                            required:
+                            - serviceAccountKeyJSON
+                      properties:
+                        bucket:
+                          type: string
+                          minLength: 1
+                        secretName:
+                          type: string
+                          minLength: 1
+                        createSecret:
+                          type: boolean
+                        serviceAccountKeyJSON:
+                          type: string
+                          minLength: 1
                     sharedPVC:
                       type: object
                       properties:
@@ -154,6 +184,9 @@ spec:
                         - azure
                     - not:
                         required:
+                        - gcs
+                    - not:
+                        required:
                         - sharedPVC
                   - required:
                     - s3
@@ -168,6 +201,9 @@ spec:
                     - not:
                         required:
                         - azure
+                    - not:
+                        required:
+                        - gcs
                     - not:
                         required:
                         - sharedPVC
@@ -186,6 +222,28 @@ spec:
                         - s3
                     - not:
                         required:
+                        - gcs
+                    - not:
+                        required:
+                        - sharedPVC
+                  - required:
+                    - gcs
+                    properties:
+                      type:
+                        enum:
+                        - gcs
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
                         - sharedPVC
                   - required:
                     - sharedPVC
@@ -200,6 +258,9 @@ spec:
                     - not:
                         required:
                         - s3
+                    - not:
+                        required:
+                        - gcs
                     - not:
                         required:
                         - azure
@@ -1042,6 +1103,15 @@ spec:
                               type: string
                             storageAccountName:
                               type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
+                              type: string
                         connectors:
                           type: object
                           properties:
@@ -1521,6 +1591,15 @@ spec:
                             secretName:
                               type: string
                             storageAccountName:
+                              type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
                               type: string
                         db:
                           type: object
@@ -2031,6 +2110,15 @@ spec:
                             secretName:
                               type: string
                             storageAccountName:
+                              type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
                               type: string
                         defaultFS:
                           type: string

--- a/charts/openshift-metering/templates/hadoop/_hadoop_config_helpers.tpl
+++ b/charts/openshift-metering/templates/hadoop/_hadoop_config_helpers.tpl
@@ -61,8 +61,24 @@
       <value>{{ .Values.hadoop.spec.config.defaultFS }}</value>
   </property>
   <property>
+      <name>fs.gs.impl</name>
+      <value>com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem</value>
+  </property>
+  <property>
       <name>fs.AbstractFileSystem.wasb.Impl</name>
       <value>org.apache.hadoop.fs.azure.Wasb</value>
+  </property>
+  <property>
+      <name>fs.AbstractFileSystem.gs.impl</name>
+      <value>com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS</value>
+  </property>
+  <property>
+      <name>fs.gs.auth.service.account.enable</name>
+      <value>true</value>
+  </property>
+  <property>
+      <name>fs.gs.reported.permissions</name>
+      <value>733</value>
   </property>
 </configuration>
 {{- end }}

--- a/charts/openshift-metering/templates/hadoop/hadoop-config.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-config.yaml
@@ -4,6 +4,6 @@ metadata:
   name: "{{ .Values.hadoop.spec.configSecretName }}"
 data:
 {{- if .Values.hadoop.spec.hdfs.enabled }}
-  hdfs-site.xml : {{ include "hdfs-site-xml" . | b64enc }}
+  hdfs-site.xml: {{ include "hdfs-site-xml" . | b64enc }}
 {{- end}}
   core-site.xml: {{ include "core-site-xml" . | b64enc }}

--- a/charts/openshift-metering/templates/hadoop/hadoop-gcs-credentials.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-gcs-credentials.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.hadoop.spec.config.gcs.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hadoop-gcs-credentials
+data:
+{{- if .Values.hadoop.spec.config.gcs.serviceAccountKeyJSON }}
+  gcs-service-account.json: {{ .Values.hadoop.spec.config.gcs.serviceAccountKeyJSON | toJson | b64enc | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -10,6 +10,10 @@ data:
     cd /hadoop-config/
     faq '.configuration.property+=[{name: ("fs.azure.account.key." + env.AZURE_STORAGE_ACCOUNT_NAME + ".blob.core.windows.net"), value: env.AZURE_SECRET_ACCESS_KEY }]' core-site.xml > core-site.xml.temp
     cp core-site.xml.temp core-site.xml
+    if [ -a /gcs-json/gcs-service-account.json ]; then
+      faq '.configuration.property+=[{name: "fs.gs.auth.service.account.json.keyfile" , value: "/gcs-json/gcs-service-account.json" }]' core-site.xml > core-site.xml.temp.temp
+      cp core-site.xml.temp.temp core-site.xml
+    fi
 
   entrypoint.sh: |
     #!/bin/bash

--- a/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
@@ -134,8 +134,8 @@ spec:
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/copy-hadoop-config.sh"]
-{{- if or .Values.hadoop.spec.config.azure.secretName .Values.hadoop.spec.config.azure.createSecret }}
         env:
+{{- if or .Values.hadoop.spec.config.azure.secretName .Values.hadoop.spec.config.azure.createSecret }}
         - name: AZURE_STORAGE_ACCOUNT_NAME
           valueFrom:
             secretKeyRef:
@@ -154,6 +154,10 @@ spec:
           mountPath: /hadoop-starting-config
         - name: hadoop-scripts
           mountPath: /hadoop-scripts
+{{- if or .Values.hadoop.spec.config.gcs.secretName .Values.hadoop.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
+{{- end }}
       volumes:
       - name: hadoop-scripts
         configMap:
@@ -274,6 +278,11 @@ spec:
         emptyDir: {}
       - name: hadoop-logs
         emptyDir: {}
+{{- if or .Values.hadoop.spec.config.gcs.secretName .Values.hadoop.spec.config.gcs.createSecret }}
+      - name: gcs-json
+        secret:
+          secretName: "{{ .Values.hadoop.spec.config.gcs.secretName | default "hadoop-gcs-credentials" }}"
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: "hdfs-datanode-data"

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -101,8 +101,8 @@ spec:
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/copy-hadoop-config.sh"]
-{{- if or .Values.hadoop.spec.config.azure.secretName .Values.hadoop.spec.config.azure.createSecret }}
         env:
+{{- if or .Values.hadoop.spec.config.azure.secretName .Values.hadoop.spec.config.azure.createSecret }}
         - name: AZURE_STORAGE_ACCOUNT_NAME
           valueFrom:
             secretKeyRef:
@@ -121,6 +121,10 @@ spec:
           mountPath: /hadoop-starting-config
         - name: hadoop-scripts
           mountPath: /hadoop-scripts
+{{- if or .Values.hadoop.spec.config.gcs.secretName .Values.hadoop.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
+{{- end }}
       containers:
       - name: hdfs-namenode
         image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
@@ -229,6 +233,11 @@ spec:
         emptyDir: {}
       - name: hadoop-logs
         emptyDir: {}
+{{- if or .Values.hadoop.spec.config.gcs.secretName .Values.hadoop.spec.config.gcs.createSecret }}
+      - name: gcs-json
+        secret:
+          secretName: "{{ .Values.hadoop.spec.config.gcs.secretName | default "hadoop-gcs-credentials" }}"
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: "hdfs-namenode-data"

--- a/charts/openshift-metering/templates/hive/hive-azure-credentials-secret.yaml
+++ b/charts/openshift-metering/templates/hive/hive-azure-credentials-secret.yaml
@@ -6,8 +6,8 @@ metadata:
 data:
 {{- if .Values.hive.spec.config.azure.storageAccountName }}
   azure-storage-account-name: {{ .Values.hive.spec.config.azure.storageAccountName | b64enc | quote}}
-{{- end}}
+{{- end }}
 {{- if .Values.hive.spec.config.azure.secretAccessKey }}
   azure-secret-access-key: {{ .Values.hive.spec.config.azure.secretAccessKey | b64enc | quote}}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/openshift-metering/templates/hive/hive-gcs-credentials-secret.yaml
+++ b/charts/openshift-metering/templates/hive/hive-gcs-credentials-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.hive.spec.config.gcs.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hive-gcs-credentials
+data:
+{{- if .Values.hive.spec.config.gcs.serviceAccountKeyJSON }}
+  gcs-service-account.json: {{ .Values.hive.spec.config.gcs.serviceAccountKeyJSON | toJson | b64enc | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -79,6 +79,10 @@ spec:
           mountPath: /hadoop-starting-config
         - name: hive-scripts
           mountPath: /hive-scripts
+{{- if or .Values.hive.spec.config.gcs.secretName .Values.hive.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
+{{- end }}
       volumes:
       - name: hive-scripts
         configMap:
@@ -143,6 +147,10 @@ spec:
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+{{- end }}
+{{- if or .Values.hive.spec.config.gcs.secretName .Values.hive.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
 {{- end }}
         - name: hive-jmx-config
           mountPath: /opt/jmx_exporter/config
@@ -231,6 +239,11 @@ spec:
       - name: hadoop-starting-config
         secret:
           secretName: {{ .Values.hive.spec.config.hadoopConfigSecretName  }}
+{{- end }}
+{{- if or .Values.hive.spec.config.gcs.secretName .Values.hive.spec.config.gcs.createSecret }}
+      - name: gcs-json
+        secret:
+          secretName: {{ .Values.hive.spec.config.gcs.secretName | default "hive-gcs-credentials" }}
 {{- end }}
       - name: hive-jmx-config
         configMap:

--- a/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
@@ -10,6 +10,10 @@ data:
     cd /hadoop-config/
     faq '.configuration.property+=[{name: ("fs.azure.account.key." + env.AZURE_STORAGE_ACCOUNT_NAME + ".blob.core.windows.net"), value: env.AZURE_SECRET_ACCESS_KEY }]' core-site.xml > core-site.xml.temp
     cp core-site.xml.temp core-site.xml
+    if [ -a /gcs-json/gcs-service-account.json ]; then
+      faq '.configuration.property+=[{name: "fs.gs.auth.service.account.json.keyfile" , value: "/gcs-json/gcs-service-account.json" }]' core-site.xml > core-site.xml.temp.temp
+      cp core-site.xml.temp.temp core-site.xml
+    fi
 
   entrypoint.sh: |
     #!/bin/bash

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -104,6 +104,10 @@ spec:
           mountPath: /hadoop-starting-config
         - name: hive-scripts
           mountPath: /hive-scripts
+{{- if or .Values.hive.spec.config.gcs.secretName .Values.hive.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
+{{- end }}
       volumes:
       - name: hive-scripts
         configMap:
@@ -172,6 +176,10 @@ spec:
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
 {{- end}}
+{{- if or .Values.hive.spec.config.gcs.secretName .Values.hive.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
+{{- end }}
         - name: hive-jmx-config
           mountPath: /opt/jmx_exporter/config
         # openshift requires volumeMounts for VOLUMEs in a Dockerfile
@@ -281,6 +289,11 @@ spec:
       - name: hadoop-starting-config
         secret:
           secretName: {{ .Values.hive.spec.config.hadoopConfigSecretName }}
+{{- end }}
+{{- if or .Values.hive.spec.config.gcs.secretName .Values.hive.spec.config.gcs.createSecret }}
+      - name: gcs-json
+        secret:
+          secretName: {{ .Values.hive.spec.config.gcs.secretName | default "hive-gcs-credentials" }}
 {{- end }}
       - name: hive-jmx-config
         configMap:

--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -26,8 +26,10 @@ data:
     cd /hadoop-config/
     faq '.configuration.property+=[{name: ("fs.azure.account.key." + env.AZURE_STORAGE_ACCOUNT_NAME + ".blob.core.windows.net"), value: env.AZURE_SECRET_ACCESS_KEY }]' core-site.xml > core-site.xml.temp
     cp core-site.xml.temp core-site.xml
-
-
+    if [ -a /gcs-json/gcs-service-account.json ]; then
+      faq '.configuration.property+=[{name: "fs.gs.auth.service.account.json.keyfile" , value: "/gcs-json/gcs-service-account.json" }]' core-site.xml > core-site.xml.temp.temp
+      cp core-site.xml.temp.temp core-site.xml
+    fi
 
   entrypoint.sh: |
     #!/bin/bash

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -126,6 +126,10 @@ spec:
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+{{- if or .Values.presto.spec.config.gcs.secretName .Values.presto.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
+{{- end }}
 {{- if .Values.presto.spec.config.tls.enabled }}
         - name: presto-tls
           mountPath: /opt/presto/tls
@@ -180,6 +184,10 @@ spec:
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+{{- end }}
+{{- if or .Values.presto.spec.config.gcs.secretName .Values.presto.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
 {{- end }}
 {{- if .Values.presto.spec.config.tls.enabled }}
         - name: presto-tls
@@ -241,6 +249,11 @@ spec:
       - name: hadoop-starting-config
         secret:
           secretName: {{ .Values.presto.spec.config.connectors.hive.hadoopConfigSecretName }}
+{{- end }}
+{{- if or .Values.presto.spec.config.gcs.secretName .Values.presto.spec.config.gcs.createSecret }}
+      - name: gcs-json
+        secret:
+          secretName: {{ .Values.presto.spec.config.gcs.secretName | default "presto-gcs-credentials" }}
 {{- end }}
 {{- if .Values.presto.spec.config.tls.enabled }}
       - name: presto-tls

--- a/charts/openshift-metering/templates/presto/presto-gcs-credentials-secret.yaml
+++ b/charts/openshift-metering/templates/presto/presto-gcs-credentials-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.presto.spec.config.gcs.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: presto-gcs-credentials
+data:
+{{- if .Values.presto.spec.config.gcs.serviceAccountKeyJSON }}
+  gcs-service-account.json: {{ .Values.presto.spec.config.gcs.serviceAccountKeyJSON | toJson | b64enc | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -125,6 +125,10 @@ spec:
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+{{- if or .Values.presto.spec.config.gcs.secretName .Values.presto.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
+{{- end }}
 {{- if .Values.presto.spec.config.tls.enabled }}
         - name: presto-tls
           mountPath: /opt/presto/tls
@@ -179,6 +183,10 @@ spec:
           mountPath: /hadoop-config
         - name: hadoop-starting-config
           mountPath: /hadoop-starting-config
+{{- end }}
+{{- if or .Values.presto.spec.config.gcs.secretName .Values.presto.spec.config.gcs.createSecret }}
+        - name: gcs-json
+          mountPath: /gcs-json
 {{- end }}
 {{- if .Values.presto.spec.config.tls.enabled }}
         - name: presto-tls
@@ -240,6 +248,11 @@ spec:
       - name: hadoop-starting-config
         secret:
           secretName: {{ .Values.presto.spec.config.connectors.hive.hadoopConfigSecretName }}
+{{- end }}
+{{- if or .Values.presto.spec.config.gcs.secretName .Values.presto.spec.config.gcs.createSecret }}
+      - name: gcs-json
+        secret:
+          secretName: {{ .Values.presto.spec.config.gcs.secretName | default "presto-gcs-credentials" }}
 {{- end }}
 {{- if .Values.presto.spec.config.tls.enabled }}
       - name: presto-tls

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -467,6 +467,11 @@ presto:
         createSecret: false
         secretName: ""
 
+      gcs:
+        createSecret: false
+        secretName: ""
+        serviceAccountKeyJSON: ""
+
       tls:
         # server cert
         certificate: ""
@@ -642,6 +647,11 @@ hive:
         createSecret: false
         secretName: ""
 
+      gcs:
+        createSecret: false
+        secretName: ""
+        serviceAccountKeyJSON: ""
+
       sharedVolume:
         enabled: false
         mountPath: /user/hive/warehouse
@@ -808,6 +818,11 @@ hadoop:
         secretAccessKey: ""
         createSecret: false
         secretName: ""
+
+      gcs:
+        createSecret: false
+        secretName: ""
+        serviceAccountKeyJSON: ""
 
     image:
       pullPolicy: Always

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -133,6 +133,42 @@ _base_storage_overrides:
         hdfs:
           enabled: false
 
+  gcs:
+    storage:
+      hive:
+        # gcs storage defaults
+        gcs:
+          # Intentionally an invalid default name to ensure that this is overridden, and obvious when it's not.
+          bucket: "-unconfigured-metering-bucket-name-"
+          secretName: ""
+          createSecret: false
+          serviceAccountKeyJSON: ""
+    presto:
+      spec:
+        config:
+          gcs:
+            secretName: "{{ _storage_spec | json_query('hive.gcs.secretName') }}"
+            createSecret: "{{ _storage_spec | json_query('hive.gcs.createSecret') }}"
+            serviceAccountKeyJSON: "{{ _storage_spec | json_query('hive.gcs.serviceAccountKeyJSON') }}"
+    hive:
+      spec:
+        config:
+          metastoreWarehouseDir: "gs://{{ _storage_spec | json_query('hive.gcs.bucket') }}"
+          gcs:
+            secretName: "{{ _storage_spec | json_query('hive.gcs.secretName') }}"
+            createSecret: "{{ _storage_spec | json_query('hive.gcs.createSecret') }}"
+            serviceAccountKeyJSON: "{{ _storage_spec | json_query('hive.gcs.serviceAccountKeyJSON') }}"
+    hadoop:
+      spec:
+        config:
+          defaultFS: "gs://{{ _storage_spec | json_query('hive.gcs.bucket') }}"
+          gcs:
+            secretName: "{{ _storage_spec | json_query('hive.gcs.secretName') }}"
+            createSecret: "{{ _storage_spec | json_query('hive.gcs.createSecret') }}"
+            serviceAccountKeyJSON: "{{ _storage_spec | json_query('hive.gcs.serviceAccountKeyJSON') }}"
+        hdfs:
+          enabled: false
+
   hdfs:
     hadoop:
       spec:
@@ -187,6 +223,10 @@ meteringconfig_storage_azure_credentials_secret_name: "{{ _storage_spec | json_q
 meteringconfig_storage_hive_storage_type: "{{ _storage_spec | json_query('hive.type') }}"
 meteringconfig_storage_overrides: "{{ _storage_overrides[meteringconfig_storage_hive_storage_type] | default({}, true) }}"
 
+# variables for validating GCS
+meteringconfig_storage_gcs_bucket_name: "{{ _storage_spec | json_query('hive.gcs.bucket') }}"
+meteringconfig_storage_gcs_create_secret: "{{ _storage_spec | json_query('hive.gcs.createSecret') | default(false, true) }}"
+meteringconfig_storage_gcs_credentials_secret_name: "{{ _storage_spec | json_query('hive.gcs.secretName') }}"
 #
 # Override the default values with _tls_overrides when spec.tls.enabled is set to true, else use values.yaml and meteringconfig_spec_overrides
 #
@@ -411,11 +451,13 @@ meteringconfig_enable_reporting_aws_billing: "{{ _openshift_reporting_spec.awsBi
 meteringconfig_enable_hdfs: "{{ _hadoop_spec.hdfs.enabled | default(true) }}"
 meteringconfig_create_hadoop_aws_credentials: "{{ _hadoop_spec.config.aws.createSecret | default(false) }}"
 meteringconfig_create_hadoop_azure_credentials: "{{ _hadoop_spec.config.azure.createSecret | default(false) }}"
+meteringconfig_create_hadoop_gcs_credentials: "{{ _hadoop_spec.config.gcs.createSecret | default(false) }}"
 
 meteringconfig_create_hive_metastore_pvc: "{{ _hive_spec.metastore.storage.create | default(true) }}"
 meteringconfig_create_hive_shared_volume_pvc: "{{ _hive_spec.config.sharedVolume.enabled and _hive_spec.config.sharedVolume.createPVC | default(false) }}"
 meteringconfig_create_hive_aws_credentials: "{{ _hive_spec.config.aws.createSecret | default(false) }}"
 meteringconfig_create_hive_azure_credentials: "{{ _hive_spec.config.azure.createSecret | default(false) }}"
+meteringconfig_create_hive_gcs_credentials: "{{ _hive_spec.config.gcs.createSecret | default(false) }}"
 
 meteringconfig_create_hive_metastore_tls_secrets: "{{ _hive_spec.metastore.config.tls.enabled and _hive_spec.metastore.config.tls.createSecret | default(false) }}"
 meteringconfig_create_hive_server_metastore_tls_secrets: "{{ _hive_spec.server.config.metastoreTLS.enabled and _hive_spec.server.config.metastoreTLS.createSecret | default(false) }}"
@@ -424,6 +466,7 @@ meteringconfig_create_hive_server_tls_secrets: "{{ _hive_spec.server.config.tls.
 meteringconfig_create_presto_aws_credentials: "{{ _presto_spec.config.aws.createSecret | default(false) }}"
 meteringconfig_create_presto_azure_credentials: "{{ _presto_spec.config.azure.createSecret | default(false) }}"
 meteringconfig_create_presto_hive_metastore_tls_secrets: "{{ _presto_spec.config.connectors.hive.tls.enabled and _presto_spec.config.connectors.hive.tls.createSecret | default(false) }}"
+meteringconfig_create_presto_gcs_credentials: "{{ _presto_spec.config.gcs.createSecret | default(false) }}"
 
 meteringconfig_template_hive_metastore_tls_secret: "{{ _hive_spec.metastore.config.tls.enabled and _hive_spec.metastore.config.tls.createSecret and _hive_spec.metastore.config.tls.secretName != 'hive-metastore-server-tls'}}"
 meteringconfig_template_hive_server_tls_secret: "{{ _hive_spec.server.config.tls.enabled and _hive_spec.server.config.tls.createSecret and _hive_spec.server.config.tls.secretName != 'hive-server-tls'}}"
@@ -456,4 +499,3 @@ meteringconfig_create_reporting_operator_hive_auth_secrets: "{{ _reporting_op_sp
 meteringconfig_create_reporting_operator_tls_secrets: "{{ _reporting_op_spec.config.tls.api.createSecret | default(false) }}"
 meteringconfig_create_reporting_operator_route: "{{ _reporting_op_spec.route.enabled | default(false) }}"
 meteringconfig_create_reporting_operator_cluster_monitoring_view_rbac: "{{ _reporting_op_spec.rbac.createClusterMonitoringViewRBAC | default(true) }}"
-

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -58,7 +58,7 @@
 
 - name: Configure Azure Storage
   block:
-    - name: Validate Metering Azure bucket name
+    - name: Validate Metering Azure container name
       assert:
         that:
           - meteringconfig_storage_azure_container_name != ""
@@ -73,3 +73,26 @@
 
   when: meteringconfig_storage_hive_storage_type == 'azure' and meteringconfig_storage_azure_create_secret
 
+- name: Configure GCS Storage
+  block:
+    - name: Validate Metering gcs bucket name
+      assert:
+        that:
+          - meteringconfig_storage_gcs_bucket_name != ""
+        msg: "storage.hive.gcs.bucket cannot be empty"
+
+    - name: Validate Metering gcs credentials
+      assert:
+        that:
+          - meteringconfig_storage_gcs_credentials_secret_name == ""
+        msg: "storage.hive.gcs.secretName is only used to reference existing secrets, must be empty if creating new secrets"
+      when: meteringconfig_storage_gcs_create_secret
+
+    - name: Validate Metering gcs credentials
+      assert:
+        that:
+          - meteringconfig_storage_gcs_credentials_secret_name != ""
+        msg: "storage.hive.gcs.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
+      when: not meteringconfig_storage_gcs_create_secret
+
+  when: meteringconfig_storage_hive_storage_type == 'gcs'

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -9,8 +9,8 @@
 - name: Validate Hive storage configuration
   assert:
     that:
-      - hiveStorageType is not undefined and hiveStorageType in ['s3', 'sharedPVC', 'hdfs', 'azure']
-    msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of 's3', 'azure', or 'sharedPVC'"
+      - hiveStorageType is not undefined and hiveStorageType in ['s3', 'sharedPVC', 'hdfs', 'azure', 'gcs']
+    msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of 's3', 'azure', 'gcs', or 'sharedPVC'"
   vars:
     hiveStorageType: "{{ meteringconfig_spec_overrides | json_query('storage.hive.type') }}"
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
@@ -18,6 +18,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: hadoop-azure-credentials
         create: "{{ meteringconfig_create_hadoop_azure_credentials }}"
+      - template_file: templates/hadoop/hadoop-gcs-credentials.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: hadoop-gcs-credentials
+        create: "{{ meteringconfig_create_hadoop_gcs_credentials }}"
       - template_file: templates/hadoop/hadoop-scripts.yaml
         apis: [ {kind: configmap} ]
         prune_label_value: hadoop-scripts

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -17,6 +17,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: hive-aws-credentials-secret
         create: "{{ meteringconfig_create_hive_aws_credentials }}"
+      - template_file: templates/hive/hive-gcs-credentials-secret.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: hive-gcs-credentials-secret
+        create: "{{ meteringconfig_create_hive_gcs_credentials }}"
       - template_file: templates/hive/hive-azure-credentials-secret.yaml
         apis: [ {kind: secret} ]
         prune_label_value: hive-azure-credentials-secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
@@ -13,6 +13,10 @@
         apis: [ {kind: secret} ]
         prune_label_value: presto-azure-credentials-secret
         create: "{{ meteringconfig_create_presto_azure_credentials }}"
+      - template_file: templates/presto/presto-gcs-credentials-secret.yaml
+        apis: [ {kind: secret} ]
+        prune_label_value: presto-gcs-credentials-secret
+        create: "{{ meteringconfig_create_presto_gcs_credentials }}"
       - template_file: templates/presto/presto-tls-secrets.yaml
         apis: [ {kind: secret} ]
         prune_label_value: presto-tls-secrets

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -61,6 +61,7 @@ spec:
                       - sharedPVC
                       - s3
                       - azure
+                      - gcs
                     hdfs:
                       type: object
                       required:
@@ -110,6 +111,35 @@ spec:
                         rootDirectory:
                           type: string
                           minLength: 1
+                    gcs:
+                      type: object
+                      required:
+                        - bucket
+                      oneOf:
+                      - required:
+                        - serviceAccountKeyJSON
+                        allOf:
+                        - not:
+                            required:
+                            - secretName
+                      - required:
+                        - secretName
+                        allOf:
+                        - not:
+                            required:
+                            - serviceAccountKeyJSON
+                      properties:
+                        bucket:
+                          type: string
+                          minLength: 1
+                        secretName:
+                          type: string
+                          minLength: 1
+                        createSecret:
+                          type: boolean
+                        serviceAccountKeyJSON:
+                          type: string
+                          minLength: 1
                     sharedPVC:
                       type: object
                       properties:
@@ -154,6 +184,9 @@ spec:
                         - azure
                     - not:
                         required:
+                        - gcs
+                    - not:
+                        required:
                         - sharedPVC
                   - required:
                     - s3
@@ -168,6 +201,9 @@ spec:
                     - not:
                         required:
                         - azure
+                    - not:
+                        required:
+                        - gcs
                     - not:
                         required:
                         - sharedPVC
@@ -186,6 +222,28 @@ spec:
                         - s3
                     - not:
                         required:
+                        - gcs
+                    - not:
+                        required:
+                        - sharedPVC
+                  - required:
+                    - gcs
+                    properties:
+                      type:
+                        enum:
+                        - gcs
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
                         - sharedPVC
                   - required:
                     - sharedPVC
@@ -200,6 +258,9 @@ spec:
                     - not:
                         required:
                         - s3
+                    - not:
+                        required:
+                        - gcs
                     - not:
                         required:
                         - azure
@@ -1042,6 +1103,15 @@ spec:
                               type: string
                             storageAccountName:
                               type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
+                              type: string
                         connectors:
                           type: object
                           properties:
@@ -1521,6 +1591,15 @@ spec:
                             secretName:
                               type: string
                             storageAccountName:
+                              type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
                               type: string
                         db:
                           type: object
@@ -2031,6 +2110,15 @@ spec:
                             secretName:
                               type: string
                             storageAccountName:
+                              type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
                               type: string
                         defaultFS:
                           type: string

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
@@ -61,6 +61,7 @@ spec:
                       - sharedPVC
                       - s3
                       - azure
+                      - gcs
                     hdfs:
                       type: object
                       required:
@@ -110,6 +111,35 @@ spec:
                         rootDirectory:
                           type: string
                           minLength: 1
+                    gcs:
+                      type: object
+                      required:
+                        - bucket
+                      oneOf:
+                      - required:
+                        - serviceAccountKeyJSON
+                        allOf:
+                        - not:
+                            required:
+                            - secretName
+                      - required:
+                        - secretName
+                        allOf:
+                        - not:
+                            required:
+                            - serviceAccountKeyJSON
+                      properties:
+                        bucket:
+                          type: string
+                          minLength: 1
+                        secretName:
+                          type: string
+                          minLength: 1
+                        createSecret:
+                          type: boolean
+                        serviceAccountKeyJSON:
+                          type: string
+                          minLength: 1
                     sharedPVC:
                       type: object
                       properties:
@@ -154,6 +184,9 @@ spec:
                         - azure
                     - not:
                         required:
+                        - gcs
+                    - not:
+                        required:
                         - sharedPVC
                   - required:
                     - s3
@@ -168,6 +201,9 @@ spec:
                     - not:
                         required:
                         - azure
+                    - not:
+                        required:
+                        - gcs
                     - not:
                         required:
                         - sharedPVC
@@ -186,6 +222,28 @@ spec:
                         - s3
                     - not:
                         required:
+                        - gcs
+                    - not:
+                        required:
+                        - sharedPVC
+                  - required:
+                    - gcs
+                    properties:
+                      type:
+                        enum:
+                        - gcs
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
                         - sharedPVC
                   - required:
                     - sharedPVC
@@ -200,6 +258,9 @@ spec:
                     - not:
                         required:
                         - s3
+                    - not:
+                        required:
+                        - gcs
                     - not:
                         required:
                         - azure
@@ -1042,6 +1103,15 @@ spec:
                               type: string
                             storageAccountName:
                               type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
+                              type: string
                         connectors:
                           type: object
                           properties:
@@ -1521,6 +1591,15 @@ spec:
                             secretName:
                               type: string
                             storageAccountName:
+                              type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
                               type: string
                         db:
                           type: object
@@ -2031,6 +2110,15 @@ spec:
                             secretName:
                               type: string
                             storageAccountName:
+                              type: string
+                        gcs:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            createSecret:
+                              type: boolean
+                            serviceAccountKeyJSON:
                               type: string
                         defaultFS:
                           type: string

--- a/manifests/metering-config/gcs-storage.yaml
+++ b/manifests/metering-config/gcs-storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: "operator-metering"
+spec:
+  storage:
+    type: "hive"
+    hive:
+      type: "gcs"
+      gcs:
+        bucket: "metering-gcs/test1"
+        secretName: "my-gcs-secret"


### PR DESCRIPTION
Edited helm and ansible to support GCS settings
Added doccumentation for GCS
Added mounts for new Json file as Secrets
Edited hadoop-scripts.yaml, hive-scripts-configmap.yaml, and presto-common-config.yaml to copy the Json keyfile if it is mounted