### PR TITLE
Update the storage sub-schema validation to restrict mutually exclusive fields from being set.

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -129,24 +129,64 @@ spec:
                       type:
                         enum:
                         - hdfs
+                    allOf:
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - s3
                     properties:
                       type:
                         enum:
                         - s3
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - azure
                     properties:
                       type:
                         enum:
                         - azure
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - sharedPVC
                     properties:
                       type:
                         enum:
                         - sharedPVC
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
 
             tls:
               type: object

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -129,24 +129,64 @@ spec:
                       type:
                         enum:
                         - hdfs
+                    allOf:
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - s3
                     properties:
                       type:
                         enum:
                         - s3
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - azure
                     properties:
                       type:
                         enum:
                         - azure
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - sharedPVC
                     properties:
                       type:
                         enum:
                         - sharedPVC
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
 
             tls:
               type: object

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
@@ -129,24 +129,64 @@ spec:
                       type:
                         enum:
                         - hdfs
+                    allOf:
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - s3
                     properties:
                       type:
                         enum:
                         - s3
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - azure
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - azure
                     properties:
                       type:
                         enum:
                         - azure
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - sharedPVC
                   - required:
                     - sharedPVC
                     properties:
                       type:
                         enum:
                         - sharedPVC
+                    allOf:
+                    - not:
+                        required:
+                        - hdfs
+                    - not:
+                        required:
+                        - s3
+                    - not:
+                        required:
+                        - azure
 
             tls:
               type: object


### PR DESCRIPTION
This allows us to control what fields are set, and error when a user provides multiple `spec.storage.hive` items, i.e.:
```
apiVersion: metering.openshift.io/v1
kind: MeteringConfig
metadata:
  name: "operator-metering"
spec:
  unsupportedFeatures:
    enableHDFS: true

  storage:
    type: "hive"
    hive:
      type: "azure"
      hdfs:
        namenode: "hdfs-namenode-0.hdfs-namenode:9820"
      s3:
        bucket: stub
        region: stubstub
        secretName: stubstubstub
```
Before this change, this configuration would pass validation, but now this would produce the error message:
```
"spec.storage.hive" must validate one and only one schema (oneOf). Found none valid
"spec.storage.hive" must not validate the schema (not)
"spec.storage.hive" must validate all the schemas (allOf)
```