### PR TITLE
Add properties and update validation to spec.hive.storage in the MeteringConfig CRD.

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -94,23 +94,40 @@ spec:
                       - container
                       - secretName
                       properties:
+                        createSecret:
+                          type: boolean
                         container:
                           type: string
+                          minLength: 1
                         secretName:
                           type: string
+                          minLength: 1
+                        storageAccountName:
+                          type: string
+                          minLength: 1
+                        secretAccessKey:
+                          type: string
+                          minLength: 1
                         rootDirectory:
                           type: string
+                          minLength: 1
                     sharedPVC:
                       type: object
                       properties:
-                        claimName:
-                          type: string
-                        storageClass:
-                          type: string
-                        size:
-                          type: string
                         createPVC:
                           type: boolean
+                        claimName:
+                          type: string
+                          minLength: 1
+                        storageClass:
+                          type: string
+                          minLength: 1
+                        size:
+                          type: string
+                          minLength: 1
+                        mountPath:
+                          type: string
+                          minLength: 1
                       oneOf:
                       - required:
                         - claimName

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -94,23 +94,40 @@ spec:
                       - container
                       - secretName
                       properties:
+                        createSecret:
+                          type: boolean
                         container:
                           type: string
+                          minLength: 1
                         secretName:
                           type: string
+                          minLength: 1
+                        storageAccountName:
+                          type: string
+                          minLength: 1
+                        secretAccessKey:
+                          type: string
+                          minLength: 1
                         rootDirectory:
                           type: string
+                          minLength: 1
                     sharedPVC:
                       type: object
                       properties:
-                        claimName:
-                          type: string
-                        storageClass:
-                          type: string
-                        size:
-                          type: string
                         createPVC:
                           type: boolean
+                        claimName:
+                          type: string
+                          minLength: 1
+                        storageClass:
+                          type: string
+                          minLength: 1
+                        size:
+                          type: string
+                          minLength: 1
+                        mountPath:
+                          type: string
+                          minLength: 1
                       oneOf:
                       - required:
                         - claimName

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
@@ -94,23 +94,40 @@ spec:
                       - container
                       - secretName
                       properties:
+                        createSecret:
+                          type: boolean
                         container:
                           type: string
+                          minLength: 1
                         secretName:
                           type: string
+                          minLength: 1
+                        storageAccountName:
+                          type: string
+                          minLength: 1
+                        secretAccessKey:
+                          type: string
+                          minLength: 1
                         rootDirectory:
                           type: string
+                          minLength: 1
                     sharedPVC:
                       type: object
                       properties:
-                        claimName:
-                          type: string
-                        storageClass:
-                          type: string
-                        size:
-                          type: string
                         createPVC:
                           type: boolean
+                        claimName:
+                          type: string
+                          minLength: 1
+                        storageClass:
+                          type: string
+                          minLength: 1
+                        size:
+                          type: string
+                          minLength: 1
+                        mountPath:
+                          type: string
+                          minLength: 1
                       oneOf:
                       - required:
                         - claimName


### PR DESCRIPTION
This PR adds the `spec.storage.hive.sharedPVC.mountpath` property, which was undefined previously. 

I also needed to update the `spec.storage.hive.azure` properties to include variables used in the ansible-operator (for developmental purpose), which weren't specified in the documentation.