### PR TITLE
charts/openshift-metering: use correct variable for checking if Hadoop config is available to presto

### DIFF
--- a/charts/openshift-metering/templates/presto/_presto_helpers.tpl
+++ b/charts/openshift-metering/templates/presto/_presto_helpers.tpl
@@ -6,6 +6,7 @@ hive.storage-format={{ .Values.hive.spec.config.defaultFileFormat | upper }}
 hive.compression-codec=SNAPPY
 hive.hdfs.authentication.type=NONE
 hive.metastore.authentication.type=NONE
+hive.collect-column-statistics-on-write=true
 
 {{- if .Values.presto.spec.config.connectors.hive.metastoreURI }}
 hive.metastore.uri={{ .Values.presto.spec.config.connectors.hive.metastoreURI }}
@@ -17,9 +18,8 @@ hive.metastore.uri=thrift://hive-metastore:9083
 {{- if .Values.presto.spec.config.connectors.hive.metastoreTimeout }}
 hive.metastore-timeout={{ .Values.presto.spec.config.connectors.hive.metastoreTimeout }}
 {{- end }}
-{{- if .Values.presto.spec.config.useHadoopConfig}}
+{{- if .Values.presto.spec.config.connectors.hive.useHadoopConfig}}
 hive.config.resources=/hadoop-config/core-site.xml
-hive.collect-column-statistics-on-write=true
 {{- end }}
 
 {{ end }}


### PR DESCRIPTION
Fixes azure which requires the hadoop core-site.xml to work properly.

Also moves hive.collect-column-statistics-on-write=true out of the
condition, as it shouldn't have been in the condition when
hive.config.resources was added.