### PR TITLE
metering-ansible-operator: Move tini into $PATH and update entrypoint

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -20,6 +20,8 @@ RUN chmod +x /tini
 COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=cli /usr/bin/oc /usr/bin/oc
 RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
+# put tini into our path
+RUN ln -f -s /tini /usr/bin/tini
 
 RUN pip install --no-cache-dir --upgrade openshift
 RUN pip install boto3

--- a/images/metering-ansible-operator/scripts/entrypoint.sh
+++ b/images/metering-ansible-operator/scripts/entrypoint.sh
@@ -17,4 +17,5 @@ if ! whoami &> /dev/null; then
     fi
 fi
 
-exec /tini -- /usr/local/bin/ansible-operator run ansible --watches-file=/opt/ansible/watches.yaml "$@"
+# we expect tini to be in the $PATH
+exec tini -- /usr/local/bin/ansible-operator run ansible --watches-file=/opt/ansible/watches.yaml "$@"


### PR DESCRIPTION
Use `tini` from path instead of `/tini` because the OCP image installs
tini from a package and it ends up in /usr/bin/tini.