### PR TITLE
validate fsGroup as integer

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -1348,7 +1348,7 @@ spec:
                       type: object
                       properties:
                         fsGroup:
-                          type: string
+                          type: integer
                         runAsGroup:
                           type: integer
                           format: int64
@@ -1741,7 +1741,7 @@ spec:
                       type: object
                       properties:
                         fsGroup:
-                          type: string
+                          type: integer
                         runAsGroup:
                           type: integer
                           format: int64
@@ -2234,7 +2234,7 @@ spec:
                           type: object
                           properties:
                             fsGroup:
-                              type: string
+                              type: integer
                             runAsGroup:
                               type: integer
                               format: int64

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -1348,7 +1348,7 @@ spec:
                       type: object
                       properties:
                         fsGroup:
-                          type: string
+                          type: integer
                         runAsGroup:
                           type: integer
                           format: int64
@@ -1741,7 +1741,7 @@ spec:
                       type: object
                       properties:
                         fsGroup:
-                          type: string
+                          type: integer
                         runAsGroup:
                           type: integer
                           format: int64
@@ -2234,7 +2234,7 @@ spec:
                           type: object
                           properties:
                             fsGroup:
-                              type: string
+                              type: integer
                             runAsGroup:
                               type: integer
                               format: int64

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
@@ -1348,7 +1348,7 @@ spec:
                       type: object
                       properties:
                         fsGroup:
-                          type: string
+                          type: integer
                         runAsGroup:
                           type: integer
                           format: int64
@@ -1741,7 +1741,7 @@ spec:
                       type: object
                       properties:
                         fsGroup:
-                          type: string
+                          type: integer
                         runAsGroup:
                           type: integer
                           format: int64
@@ -2234,7 +2234,7 @@ spec:
                           type: object
                           properties:
                             fsGroup:
-                              type: string
+                              type: integer
                             runAsGroup:
                               type: integer
                               format: int64


### PR DESCRIPTION
With the new validation schema, fsGroup in metering-custom.yaml cannot be an integer (the schema requires a string) nor a string (fails while parsing \ufffd as an integer, if I remember correctly), nor a map (like the k8s docs suggest).

After reading the sources, I am still not sure how it's supposed to work, or if this is due to a bug or work in progress. But reverting the schema to integer fixes the issue for me.