### PR TITLE
Add OpenAPI V3 schema validation to the PrestoTable CRD.

### DIFF
--- a/Documentation/prestotables.md
+++ b/Documentation/prestotables.md
@@ -2,25 +2,27 @@
 
 A `PrestoTable` is a custom resource that represents a database table accessible from within Presto.
 
-When created, a PrestoTable resource causes the reporting-operator to create a table within Presto according to the configuration provided or can expose an existing table that already exists to the reporting-operator.
+When a `PrestoTable` resource is created, the reporting-operator creates a table within Presto according to the configuration provided, or can expose an existing table that already exists to the reporting-operator.
 
 Please read the [Presto concepts][presto-concepts] documentation to gain an understanding of any Presto specific terminology used below.
 
 ## Fields
-
-- `unmanaged`: If true this indicates the PrestoTable resource is referencing an existing table, and should not attempt to create or manage the table within Presto.
-- `catalog`: The catalog within Presto the table to be created in, or the catalog the table should exist within if unmanaged. In many cases, this will be `hive`.
-- `schema`: The schema within the Presto catalog for the table to created in, or the schema the table should exist in if unmanaged. If the catalog is `hive` then there will always be at least the `default` schema.
-- `tableName`: The name of the table to create in Presto, or the name of an existing table if unmanaged.
-- `columns`: A list of columns that match the schema of the of the PrestoTable.
-- `properties`: Optional: A map containing string keys and values, where each key value pair is a table property for configuring the table. The available properties depends on the `catalog` used, see the Presto documentation for information on available properties.
-- `comment`: Optional: If specified, sets a comment on the table. Comments are just arbitrary strings that have no meaning to Presto, but can be used to store arbitrary information about a table.
-- `view`: Optional: If true, then `query` must also be set. When `view` is true it causes reporting-operator to create a view within Presto using `query` as the SELECT statement for creating the view. `columns` must still be set in order for other Resources to determine the correct schema for the table, despite the schema being determined from the query used.
-- `createTableAs`: Optional: If true, then `query` must also be set. When `createTableAs` is true it causes reporting-operator to create a table within Presto using `query` as the SELECT statement for creating the table, using the schema of the query and the results as the content of the table. `columns` must still be set in order for other Resources to determine the correct schema for the table, despite the schema being determined from the query used.
-- `query`: Optional: If non-empty, you must set `view` or `createTableAs` to true. Must be a SELECT query to be used for creating the table or view.
+For more information on the specific fields listed below, follow the respective links to the Presto concepts documentation.
+##### Required Fields:
+- `unmanaged`: Indicates whether a PrestoTable resource is referencing an existing table, and if set to true, the reporting-operator should not attempt to create or manage the table within Presto.
+- `catalog`: The [catalog](https://prestosql.io/docs/current/overview/concepts.html#catalog) the Presto table is created within, or the catalog the table should exist within if unmanaged. In many cases, this will be `hive`.
+- `schema`: The [schema](https://prestosql.io/docs/current/overview/concepts.html#schema) within the Presto catalog for the table to created in, or the schema the table should exist in if unmanaged. If the catalog is `hive` then there will always be at least the `default` schema.
+- `tableName`: The desired name of the [table](https://prestosql.io/docs/current/overview/concepts.html#table) to be created in Presto, or the name of an existing table if unmanaged.
+- `columns`: A list of columns that match the schema of the PrestoTable. For each list item, you must specify a `name` field, which is the name of an individual column for the Presto table, and a `type` field, which corresponds to a valid [Presto type.](https://prestosql.io/docs/current/language/types.html)
+##### Optional Fields:
+- `query`: The SELECT [query](https://prestosql.io/docs/current/overview/concepts.html#query) used for creating the table or view. If `query` is non-empty, you must set either `view` or `createTableAs` to true. Continue onto the next section for [examples](#example-prestotables) that use the `query` field.
+- `view`: Controls whether the reporting-operator needs to create a view within Presto. If true, the reporting-operator uses the `query` field as the SELECT statement used to create the table, using both the schemas of the query and results for the content of the table.
+- `createTableAs`: Controls whether the reporting-operator needs to create a table within Presto using the `query` fields as the SELECT statement for creating the table.
+- `properties`: A map containing string keys and values, where each key-value pair is a table property for configuring the table. See the [Presto connector documentation](https://prestosql.io/docs/current/connector.html) to find the available properties for a specific connector's catalog.
+- `comment`: Sets a comment on the Presto table. Comments are just arbitrary strings that have no meaning to Presto, but can be used to store arbitrary information about a table.
 
 ## Example PrestoTables
-
+##### Creating a table in Presto using a `SELECT` query:
 ```
 apiVersion: metering.openshift.io/v1
 kind: PrestoTable
@@ -42,6 +44,41 @@ spec:
     SELECT * FROM (
       VALUES (10.00, 50.00, 'USD')
     ) AS t (cost_per_gigabyte_hour, cost_per_cpu_hour, currency)
+```
+
+##### Creating a view in Presto:
+```
+apiVersion: metering.openshift.io/v1
+kind: PrestoTable
+metadata:
+  name: example_cluster_cpu_capacity_view
+spec:
+  catalog: hive
+  schema: metering
+  tableName: "example_cluster_cpu_capacity_view"
+  columns:
+  - name: timestamp
+    type: timestamp
+  - name: dt
+    type: varchar
+  - name: cpu_cores
+    type: double
+  - name: cpu_core_seconds
+    type: double
+  - name: node_count
+    type: double
+  comment: '""'
+  unmanaged: false
+  view: true
+  query: |
+    SELECT
+      "timestamp",
+      dt,
+      sum(node_capacity_cpu_cores) as cpu_cores,
+      sum(node_capacity_cpu_core_seconds) as cpu_core_seconds,
+      count(*) AS node_count
+    FROM hive.metering.example_node_cpu_capacity_view
+    GROUP BY "timestamp", dt
 ```
 
 [presto-concepts]: https://prestosql.io/docs/current/overview/concepts.html

--- a/charts/metering-ansible-operator/templates/crds/prestotable.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/prestotable.crd.yaml
@@ -21,3 +21,145 @@ spec:
   - name: Table Name
     type: string
     JSONPath: .status.tableName
+  validation:
+    openAPIV3Schema:
+      description: |
+        PrestoTable is a custom resource that represents a database table accessible from within Presto.
+        When a PrestoTable resource is created, the reporting-operator creates a table within Presto according
+        to the configuration provided, or exposes an existing table.
+        More info: https://prestosql.io/docs/current/index.html
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: |
+            PrestoTableSpec is the desired specification of a PrestoTable custom resource.
+            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Optional fields: query, view, createTableAs, properties, and comment.
+            More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
+          required:
+          - unmanaged
+          - catalog
+          - schema
+          - tableName
+          - columns
+          properties:
+            unmanaged:
+              type: boolean
+              description: |
+                Unmanaged indicates whether a PrestoTable resource is referencing an existing table,
+                and if set to true, the operator should not attempt to create or manage that table within Presto.
+            catalog:
+              type: string
+              description: |
+                Catalog specifies which catalog the Presto table is to be created within.
+                In many cases, the catalog will be set to "hive".
+                More info: https://prestosql.io/docs/current/overview/concepts.html#catalog
+              minLength: 1
+            schema:
+              type: string
+              description: |
+                The schema within the Presto catalog for the table to created in,
+                or the schema the table should exist in if unmanaged.
+                If the catalog is `hive` then there will always be at least the `default` schema.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#schema
+              minLength: 1
+            tableName:
+              type: string
+              description: |
+                TableName is the desired name of the table to be created in Presto,
+                or in the case where "unmanaged" is set to false, the name of an existing table within Presto.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#table
+              minLength: 1
+            columns:
+              type: array
+              description: |
+                A list of columns that match the schema of the PrestoTable.
+                For each list item, you must specify a `name` field, which is the name of an individual column for the Presto table,
+                and a `type` field, which corresponds to a valid type in Presto.
+                More info: https://prestosql.io/docs/current/language/types.html
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    minLength: 1
+                  type:
+                    type: string
+                    minLength: 1
+            properties:
+              type: array
+              description: |
+                Properties is a map containing string key and value pairs. Each key-value pair is a table property for
+                configuring the table. The available properties depend on the "catalog" being used.
+                Note: this is an optional field.
+            comment:
+              type: string
+              description: |
+                Sets a comment on the Presto table. Comments are just arbitrary strings that have no meaning to Presto,
+                but can be used to store arbitrary information about a table.
+                Note: this is an optional field.
+              minLength: 1
+            view:
+              type: boolean
+              description: |
+                View controls whether the reporting-operator needs to create a view within Presto.
+                If true, the reporting-operator uses the "query" field as the SELECT statement for creating the view.
+                Note: this is an optional field.
+            createTableAs:
+              type: boolean
+              description: |
+                CreateTableAs controls whether the reporting-operator needs to create a table within Presto.
+                If true, the reporting-operator uses the "query" field as the SELECT statemtnt for creating the table.
+                Note: this is an optional field.
+            query:
+              type: string
+              description: |
+                Query is a string containing a SQL SELECT query used for creating a table or view.
+                Note: this is an optional field.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#query
+              minLength: 1
+          oneOf:
+          - required:
+            - createTableAs
+            - query
+            properties:
+              createTableAs:
+                enum:
+                - true
+              unmanaged:
+                enum:
+                - false
+            allOf:
+            - not:
+                required:
+                - view
+          - required:
+            - view
+            - query
+            properties:
+              view:
+                enum:
+                - true
+              unmanaged:
+                enum:
+                - false
+            allOf:
+            - not:
+                required:
+                - createTableAs
+          - properties:
+              unmanaged:
+                enum:
+                - true
+            allOf:
+            - not:
+                required:
+                - view
+            - not:
+                required:
+                - createTableAs

--- a/manifests/deploy/openshift/metering-ansible-operator/prestotable.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/prestotable.crd.yaml
@@ -21,4 +21,146 @@ spec:
   - name: Table Name
     type: string
     JSONPath: .status.tableName
+  validation:
+    openAPIV3Schema:
+      description: |
+        PrestoTable is a custom resource that represents a database table accessible from within Presto.
+        When a PrestoTable resource is created, the reporting-operator creates a table within Presto according
+        to the configuration provided, or exposes an existing table.
+        More info: https://prestosql.io/docs/current/index.html
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: |
+            PrestoTableSpec is the desired specification of a PrestoTable custom resource.
+            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Optional fields: query, view, createTableAs, properties, and comment.
+            More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
+          required:
+          - unmanaged
+          - catalog
+          - schema
+          - tableName
+          - columns
+          properties:
+            unmanaged:
+              type: boolean
+              description: |
+                Unmanaged indicates whether a PrestoTable resource is referencing an existing table,
+                and if set to true, the operator should not attempt to create or manage that table within Presto.
+            catalog:
+              type: string
+              description: |
+                Catalog specifies which catalog the Presto table is to be created within.
+                In many cases, the catalog will be set to "hive".
+                More info: https://prestosql.io/docs/current/overview/concepts.html#catalog
+              minLength: 1
+            schema:
+              type: string
+              description: |
+                The schema within the Presto catalog for the table to created in,
+                or the schema the table should exist in if unmanaged.
+                If the catalog is `hive` then there will always be at least the `default` schema.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#schema
+              minLength: 1
+            tableName:
+              type: string
+              description: |
+                TableName is the desired name of the table to be created in Presto,
+                or in the case where "unmanaged" is set to false, the name of an existing table within Presto.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#table
+              minLength: 1
+            columns:
+              type: array
+              description: |
+                A list of columns that match the schema of the PrestoTable.
+                For each list item, you must specify a `name` field, which is the name of an individual column for the Presto table,
+                and a `type` field, which corresponds to a valid type in Presto.
+                More info: https://prestosql.io/docs/current/language/types.html
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    minLength: 1
+                  type:
+                    type: string
+                    minLength: 1
+            properties:
+              type: array
+              description: |
+                Properties is a map containing string key and value pairs. Each key-value pair is a table property for
+                configuring the table. The available properties depend on the "catalog" being used.
+                Note: this is an optional field.
+            comment:
+              type: string
+              description: |
+                Sets a comment on the Presto table. Comments are just arbitrary strings that have no meaning to Presto,
+                but can be used to store arbitrary information about a table.
+                Note: this is an optional field.
+              minLength: 1
+            view:
+              type: boolean
+              description: |
+                View controls whether the reporting-operator needs to create a view within Presto.
+                If true, the reporting-operator uses the "query" field as the SELECT statement for creating the view.
+                Note: this is an optional field.
+            createTableAs:
+              type: boolean
+              description: |
+                CreateTableAs controls whether the reporting-operator needs to create a table within Presto.
+                If true, the reporting-operator uses the "query" field as the SELECT statemtnt for creating the table.
+                Note: this is an optional field.
+            query:
+              type: string
+              description: |
+                Query is a string containing a SQL SELECT query used for creating a table or view.
+                Note: this is an optional field.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#query
+              minLength: 1
+          oneOf:
+          - required:
+            - createTableAs
+            - query
+            properties:
+              createTableAs:
+                enum:
+                - true
+              unmanaged:
+                enum:
+                - false
+            allOf:
+            - not:
+                required:
+                - view
+          - required:
+            - view
+            - query
+            properties:
+              view:
+                enum:
+                - true
+              unmanaged:
+                enum:
+                - false
+            allOf:
+            - not:
+                required:
+                - createTableAs
+          - properties:
+              unmanaged:
+                enum:
+                - true
+            allOf:
+            - not:
+                required:
+                - view
+            - not:
+                required:
+                - createTableAs
 

--- a/manifests/deploy/openshift/olm/bundle/4.2/prestotable.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/prestotable.crd.yaml
@@ -21,4 +21,146 @@ spec:
   - name: Table Name
     type: string
     JSONPath: .status.tableName
+  validation:
+    openAPIV3Schema:
+      description: |
+        PrestoTable is a custom resource that represents a database table accessible from within Presto.
+        When a PrestoTable resource is created, the reporting-operator creates a table within Presto according
+        to the configuration provided, or exposes an existing table.
+        More info: https://prestosql.io/docs/current/index.html
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: |
+            PrestoTableSpec is the desired specification of a PrestoTable custom resource.
+            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Optional fields: query, view, createTableAs, properties, and comment.
+            More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
+          required:
+          - unmanaged
+          - catalog
+          - schema
+          - tableName
+          - columns
+          properties:
+            unmanaged:
+              type: boolean
+              description: |
+                Unmanaged indicates whether a PrestoTable resource is referencing an existing table,
+                and if set to true, the operator should not attempt to create or manage that table within Presto.
+            catalog:
+              type: string
+              description: |
+                Catalog specifies which catalog the Presto table is to be created within.
+                In many cases, the catalog will be set to "hive".
+                More info: https://prestosql.io/docs/current/overview/concepts.html#catalog
+              minLength: 1
+            schema:
+              type: string
+              description: |
+                The schema within the Presto catalog for the table to created in,
+                or the schema the table should exist in if unmanaged.
+                If the catalog is `hive` then there will always be at least the `default` schema.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#schema
+              minLength: 1
+            tableName:
+              type: string
+              description: |
+                TableName is the desired name of the table to be created in Presto,
+                or in the case where "unmanaged" is set to false, the name of an existing table within Presto.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#table
+              minLength: 1
+            columns:
+              type: array
+              description: |
+                A list of columns that match the schema of the PrestoTable.
+                For each list item, you must specify a `name` field, which is the name of an individual column for the Presto table,
+                and a `type` field, which corresponds to a valid type in Presto.
+                More info: https://prestosql.io/docs/current/language/types.html
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    minLength: 1
+                  type:
+                    type: string
+                    minLength: 1
+            properties:
+              type: array
+              description: |
+                Properties is a map containing string key and value pairs. Each key-value pair is a table property for
+                configuring the table. The available properties depend on the "catalog" being used.
+                Note: this is an optional field.
+            comment:
+              type: string
+              description: |
+                Sets a comment on the Presto table. Comments are just arbitrary strings that have no meaning to Presto,
+                but can be used to store arbitrary information about a table.
+                Note: this is an optional field.
+              minLength: 1
+            view:
+              type: boolean
+              description: |
+                View controls whether the reporting-operator needs to create a view within Presto.
+                If true, the reporting-operator uses the "query" field as the SELECT statement for creating the view.
+                Note: this is an optional field.
+            createTableAs:
+              type: boolean
+              description: |
+                CreateTableAs controls whether the reporting-operator needs to create a table within Presto.
+                If true, the reporting-operator uses the "query" field as the SELECT statemtnt for creating the table.
+                Note: this is an optional field.
+            query:
+              type: string
+              description: |
+                Query is a string containing a SQL SELECT query used for creating a table or view.
+                Note: this is an optional field.
+                More info: https://prestosql.io/docs/current/overview/concepts.html#query
+              minLength: 1
+          oneOf:
+          - required:
+            - createTableAs
+            - query
+            properties:
+              createTableAs:
+                enum:
+                - true
+              unmanaged:
+                enum:
+                - false
+            allOf:
+            - not:
+                required:
+                - view
+          - required:
+            - view
+            - query
+            properties:
+              view:
+                enum:
+                - true
+              unmanaged:
+                enum:
+                - false
+            allOf:
+            - not:
+                required:
+                - createTableAs
+          - properties:
+              unmanaged:
+                enum:
+                - true
+            allOf:
+            - not:
+                required:
+                - view
+            - not:
+                required:
+                - createTableAs
 

--- a/manifests/reports/cluster-capacity-daily.yaml
+++ b/manifests/reports/cluster-capacity-daily.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-cpu-capacity-daily
 spec:
   query: "cluster-cpu-capacity"
-  # this configures the this report to aggregate the hourly one
+  # this configures the report to aggregate the hourly one
   inputs:
   - name: ClusterCpuCapacityReportName
     value: cluster-cpu-capacity-hourly
@@ -19,7 +19,7 @@ metadata:
   name: cluster-memory-capacity-daily
 spec:
   query: "cluster-memory-capacity"
-  # this configures the this report to aggregate the hourly one
+  # this configures the this to aggregate the hourly one
   inputs:
   - name: ClusterMemoryCapacityReportName
     value: cluster-memory-capacity-hourly

--- a/manifests/reports/cluster-usage-daily.yaml
+++ b/manifests/reports/cluster-usage-daily.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-cpu-usage-daily
 spec:
   query: "cluster-cpu-usage"
-  # this configures the this report to aggregate the hourly one
+  # this configures the report to aggregate the hourly one
   inputs:
   - name: ClusterCpuUsageReportName
     value: cluster-cpu-usage-hourly
@@ -19,7 +19,7 @@ metadata:
   name: cluster-memory-usage-daily
 spec:
   query: "cluster-memory-usage"
-  # this configures the this report to aggregate the hourly one
+  # this configures the report to aggregate the hourly one
   inputs:
   - name: ClusterMemoryUsageReportName
     value: cluster-memory-usage-hourly


### PR DESCRIPTION
This would add schema validation to the `PrestoTable` CRD.

To-Do:
- [x] Add a `description` field to each property
- [x] Test different valid configurations
- [x] Ensure that the `spec.anyOf` correctly identifies valid configurations.

This is the output of `oc explain prestotables` after adding the top-level description fields:
```
[tflannag@localhost operator-metering]$ oc explain prestotables
KIND:     PrestoTable
VERSION:  metering.openshift.io/v1

DESCRIPTION:
     PrestoTable is a custom resource that represents a database table
     accessible from within Presto. When a PrestoTable resource is created, the
     reporting-operator creates a table within Presto according to the
     configuration provided, or exposes an existing table. More info:
     https://prestosql.io/docs/current/index.html

FIELDS:
   apiVersion	<string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/api-conventions.md#resources

   kind	<string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds

   metadata	<Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata

   spec	<Object> -required-
     PrestoTableSpec is the desired specification of a PrestoTable custom
     resource. Required fields: unmanaged, catalog, schema, tableName, and
     columns. More info:
     https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md

[tflannag@localhost operator-metering]$ 
```