### PR TITLE
Add OpenAPIV3 schema validation to the HiveTable CRD.

### DIFF
--- a/Documentation/hivetables.md
+++ b/Documentation/hivetables.md
@@ -2,24 +2,27 @@
 
 A `HiveTable` is a custom resource that represents a database table within Hive.
 
-When created, a HiveTable resource causes the reporting-operator to create a table within Hive according to the configuration provided.
+When a `HiveTable` resource is created, the reporting-operator creates a table within Hive according to the configuration provided.
+
+A `HiveTable` resource is also implicitly created when a `PrometheusMetricsImporter` ReportDataSource is defined, and the `status.tableRef` field is empty. The metering-operator then creates a `HiveTable` resource, and once that table has been created, the `statue.tableRef` field is updated and references the newly created table within Hive.
 
 ## Fields
-
+##### Required fields:
 - `databaseName`: The name of the Hive database to use. This generally should be `default` or the value of the databaseName in a `Hive` [StorageLocation][storage-locations].
 - `tableName`: The name of the table to create in Hive.
 - `columns`: A list of columns that match the schema of the of the HiveTable. Columns in `partitionedBy` and `columns` must not overlap.
   - `name`: The name of the column.
   - `type`: The column data type. [See the Hive Language Manual section on types for more details][hiveTypes]. Currently the only complex types supported are map's of primitive types.
+##### Optional fields:
 - `partitionedBy`: A list of columns that are used as partition columns. Columns in `partitionedBy` and `columns` must not overlap.
   - `name`: The name of the column.
   - `type`: The column data type. [See the Hive Language Manual section on types for more details][hiveTypes]. Currently the only complex types supported are map's of primitive types.
 - `clusteredBy`: A list of columns from `columns` to use for [bucketed tables][hiveBucketedTables]. Must set `numBuckets` if specified.
 - `sortedBy`: A list of column names from `columns` to use for [bucketed tables][hiveBucketedTables]. Must set `clusteredBy` and `numBuckets` if specified.
   - `name`: The name of the column from `columns`.
-  - `descending`: Optional: if true, the column is descending, if false, it's ascending. If unspecified, it defaults to the hive default behavior.
+  - `descending`: if true, the column is descending, if false, it's ascending. If unspecified, it defaults to the hive default behavior.
 - `numBuckets`: The number of buckets to create for a [bucketed table][hiveBucketedTables]. Must set `clusteredBy` if set.
-- `location`: Optional: Specifies the HDFS path to store this table in. Can be any URI supported by Hive. Currently supports `s3a://`, `hdfs://` and `/local/path` based URIs.
+- `location`: Specifies the HDFS path to store this table in. Can be any URI supported by Hive. Currently supports `s3a://`, `hdfs://` and `/local/path` based URIs.
 - `rowFormat`: Controls the [Hive row format][hiveRowFormat]. This controls how Hive serializes and deserializes rows. See the [Hive Documentation on Row Formats & SerDe for more details][hiveRowFormat].
 - `fileFormat`: The file format used for storing files in the filesystem. See the [Hive Documentation on File Storage Format for a list of options and more details][hiveFileFormat].
 - `tableProperties`: Allows tagging the table definition with your own key/value metadata. Some predefined properties exist to control behavior of the table as well. See the [Hive table properties documentation][hiveTableProperties] for details.
@@ -27,10 +30,55 @@ When created, a HiveTable resource causes the reporting-operator to create a tab
 - `managePartitions`: If true, configures the reporting-operator ensure the Table partitions match those specified in `partitions`.
 - `partitions`: A list of partitions that this table should have. Only valid if `managePartitions` is true.
   - `partitionSpec`: A map of string keys and string values where each key is expected to be the name of a partition column, and the value is the value of the partition column.
-  - `location`: Specifies where the data for this partition is stored. This should be a sub-directory of `location`.
+  - `location`: Specifies where the data for this partition is stored. This should be a sub-directory of `spec.location`.
 
 ## Example HiveTables
+##### Minimal HiveTable:
+```
+apiVersion: metering.openshift.io/v1
+kind: HiveTable
+metadata:
+  name: example_hive_table
+spec:
+  columns:
+  - name: period_start
+    type: TIMESTAMP
+  - name: period_end
+    type: TIMESTAMP
+  - name: namespace
+    type: STRING
+  - name: pod_request_cpu_core_seconds
+    type: DOUBLE
+  databaseName: metering
+  tableName: example_hive_table_namespace_cpu_request
+```
 
+##### HiveTable created from a `PrometheusMetricsImporter` ReportDataSource:
+```
+apiVersion: metering.openshift.io/v1
+kind: HiveTable
+metadata:
+  name: example_hive_table
+spec:
+  columns:
+  - name: amount
+    type: double
+  - name: timestamp
+    type: timestamp
+  - name: timePrecision
+    type: double
+  - name: labels
+    type: map<string, string>
+  databaseName: metering
+  managePartitions: false
+  partitionedBy:
+  - name: dt
+    type: string
+  partitions: null
+  tableName: example_node_allocatable_cpu_cores
+```
+
+##### Specifying a SerDe row format and a HDFS storage location:
 ```
 apiVersion: metering.openshift.io/v1
 kind: HiveTable

--- a/charts/metering-ansible-operator/templates/crds/hive.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/hive.crd.yaml
@@ -21,3 +21,253 @@ spec:
   - name: Table Name
     type: string
     JSONPath: .status.tableName
+  validation:
+    openAPIV3Schema:
+      description: |
+        HiveTable is a custom resource that represents a database table within Hive.
+        When created, a HiveTable resource causes the reporting-operator to create a
+        table witin Hive according to the configuration provided.
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: |
+            HiveTableSpec is the desired specification of a HiveTable custom resource.
+            Required fields: database, tableName, and columns.
+            More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/hivetables.md
+          required:
+          - databaseName
+          - tableName
+          - columns
+          properties:
+            databaseName:
+              type: string
+              description: |
+                DatabaseName is the name of the Hive database to use.
+                Generally, this field should be set to "default", or the value of the "databaseName" in a Hive StorageLocation.
+                More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/storagelocations.md
+              minLength: 1
+            tableName:
+              type: string
+              description: |
+                TableName is the desired name of the table to be created in Hive.
+              minLength: 1
+            columns:
+              type: array
+              description: |
+                A list of columns that match the schema of the HiveTable.
+                For each list item, you must specify a `name` field, which is the name of an individual column for the Hive table,
+                and a `type` field, which corresponds to a valid type in Hive.
+                Note: the only complex types supported are map's of primitive types.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column.
+                    minLength: 1
+                  type:
+                    type: string
+                    description: |
+                      The column data type.
+                    minLength: 1
+            partitionedBy:
+              type: array
+              description: |
+                A list of columns that are used as partition columns.
+                Columns in "partitionedBy" and "columns" must not overlap.
+                For each list item, you must specify both a `name` and `type` field.
+                Note: this is an optional field.
+              minItems: 1
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column.
+                    minLength: 1
+                  type:
+                    type: string
+                    description: |
+                      The column data type.
+                    minLength: 1
+            clusteredBy:
+              type: array
+              description: |
+                A list of columns from "columns" to use for bucketed tables.
+                This field must be set if "numBuckets" is specified.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              minItems: 1
+              items:
+                type: string
+            sortedBy:
+              type: array
+              description: |
+                A list of column names from "columns" to use for bucketed tables.
+                This field must be set if "clusteredBy" and "numBuckets" are specified.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              required:
+              - name
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column from "columns".
+                    minLength: 1
+                  descending:
+                    type: boolean
+                    description: |
+                      Descending controls whether the column is descending or ascending.
+                      If "descending" is true, then the column is descending, else ascending.
+                      If this field is unspecified, then it defaults to Hive's default behavior.
+                      Note: this is an optional field.
+            numBuckets:
+              type: integer
+              description: |
+                The number of buckets to create for a bucketed table.
+                If this field is set, then "clusteredBy" also needs to be set.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              format: int32
+              minimum: 0
+            location:
+              type: string
+              description: |
+                Location specifies the HDFS path to store this Hive table.
+                This field can be set to any URI supported by Hive.
+                Currently, `sda://`, `hdfs://`, and `/local/path` are supported based URIs.
+                Note: this is an optional field.
+              format: uri
+              minLength: 1
+            rowFormat:
+              type: string
+              description: |
+                RowFormat controls how Hive serializes and deserializes rows.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RowFormats&SerDe
+              minLength: 1
+            fileFormat:
+              type: string
+              description: |
+                FileFormat controls the file format used for storing files in the filesystem.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-StorageFormatsStorageFormatsRowFormat,StorageFormat,andSerDe
+              minLength: 1
+            tableProperties:
+              type: array
+              description: |
+                TableProperties is an array and allows you to tag the table definition with your
+                own metadata key/value pairs. Some predefined properties exist to control
+                behavior of the table as well.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-listTableProperties
+            external:
+              type: boolean
+              description: |
+                External controls whether an external table is created, instead of a managed table.
+                If external is set to true, this causes Hive to point to an existing location,
+                as specified by the "location" field.
+                Note: this is an optional field.
+            managePartitions:
+              type: boolean
+              description: |
+                ManagePartitions controls whether the reporting-operator needs to check
+                if the table partitions match the partitions listed in the "partitions" field.
+                Note: this is an optional field.
+            partitions:
+              type: array
+              description: |
+                A list of partitions that this Hive table should contain.
+                Note: this is an optional field.
+              nullable: true
+              items:
+                type: object
+                required:
+                - partitionSpec
+                - location
+                properties:
+                  partitionSpec:
+                    type: array
+                    description: |
+                      PartitionSpec is a map containing string keys and values, where each key
+                      is expected to be the name of a partition column, and the value is the
+                      value of the partition column.
+                  location:
+                    type: string
+                    description: |
+                      Location specifies where the data for this partition is stored.
+                      This should be a sub-directory of the "location" field.
+                    minLength: 1
+                    format: uri
+          anyOf:
+          - required:
+            - numBuckets
+            - clusteredBy
+            properties:
+              external:
+                enum:
+                - true
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+          - required:
+            - external
+            - location
+            properties:
+              external:
+                enum:
+                - true
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+          - required:
+            - managePartitions
+            - partitions
+            properties:
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+              external:
+                enum:
+                - true
+          # note: allow the minimal configuration, and enforce the schemas defined above
+          - allOf:
+            - not:
+                required:
+                - numBuckets
+            - not:
+                required:
+                - clusteredBy
+            - not:
+                required:
+                - sortedBy
+            - not:
+                required:
+                - location
+            properties:
+              external:
+                enum:
+                - false
+              managePartitions:
+                enum:
+                - false

--- a/manifests/deploy/openshift/metering-ansible-operator/hive.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/hive.crd.yaml
@@ -21,4 +21,254 @@ spec:
   - name: Table Name
     type: string
     JSONPath: .status.tableName
+  validation:
+    openAPIV3Schema:
+      description: |
+        HiveTable is a custom resource that represents a database table within Hive.
+        When created, a HiveTable resource causes the reporting-operator to create a
+        table witin Hive according to the configuration provided.
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: |
+            HiveTableSpec is the desired specification of a HiveTable custom resource.
+            Required fields: database, tableName, and columns.
+            More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/hivetables.md
+          required:
+          - databaseName
+          - tableName
+          - columns
+          properties:
+            databaseName:
+              type: string
+              description: |
+                DatabaseName is the name of the Hive database to use.
+                Generally, this field should be set to "default", or the value of the "databaseName" in a Hive StorageLocation.
+                More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/storagelocations.md
+              minLength: 1
+            tableName:
+              type: string
+              description: |
+                TableName is the desired name of the table to be created in Hive.
+              minLength: 1
+            columns:
+              type: array
+              description: |
+                A list of columns that match the schema of the HiveTable.
+                For each list item, you must specify a `name` field, which is the name of an individual column for the Hive table,
+                and a `type` field, which corresponds to a valid type in Hive.
+                Note: the only complex types supported are map's of primitive types.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column.
+                    minLength: 1
+                  type:
+                    type: string
+                    description: |
+                      The column data type.
+                    minLength: 1
+            partitionedBy:
+              type: array
+              description: |
+                A list of columns that are used as partition columns.
+                Columns in "partitionedBy" and "columns" must not overlap.
+                For each list item, you must specify both a `name` and `type` field.
+                Note: this is an optional field.
+              minItems: 1
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column.
+                    minLength: 1
+                  type:
+                    type: string
+                    description: |
+                      The column data type.
+                    minLength: 1
+            clusteredBy:
+              type: array
+              description: |
+                A list of columns from "columns" to use for bucketed tables.
+                This field must be set if "numBuckets" is specified.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              minItems: 1
+              items:
+                type: string
+            sortedBy:
+              type: array
+              description: |
+                A list of column names from "columns" to use for bucketed tables.
+                This field must be set if "clusteredBy" and "numBuckets" are specified.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              required:
+              - name
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column from "columns".
+                    minLength: 1
+                  descending:
+                    type: boolean
+                    description: |
+                      Descending controls whether the column is descending or ascending.
+                      If "descending" is true, then the column is descending, else ascending.
+                      If this field is unspecified, then it defaults to Hive's default behavior.
+                      Note: this is an optional field.
+            numBuckets:
+              type: integer
+              description: |
+                The number of buckets to create for a bucketed table.
+                If this field is set, then "clusteredBy" also needs to be set.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              format: int32
+              minimum: 0
+            location:
+              type: string
+              description: |
+                Location specifies the HDFS path to store this Hive table.
+                This field can be set to any URI supported by Hive.
+                Currently, `sda://`, `hdfs://`, and `/local/path` are supported based URIs.
+                Note: this is an optional field.
+              format: uri
+              minLength: 1
+            rowFormat:
+              type: string
+              description: |
+                RowFormat controls how Hive serializes and deserializes rows.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RowFormats&SerDe
+              minLength: 1
+            fileFormat:
+              type: string
+              description: |
+                FileFormat controls the file format used for storing files in the filesystem.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-StorageFormatsStorageFormatsRowFormat,StorageFormat,andSerDe
+              minLength: 1
+            tableProperties:
+              type: array
+              description: |
+                TableProperties is an array and allows you to tag the table definition with your
+                own metadata key/value pairs. Some predefined properties exist to control
+                behavior of the table as well.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-listTableProperties
+            external:
+              type: boolean
+              description: |
+                External controls whether an external table is created, instead of a managed table.
+                If external is set to true, this causes Hive to point to an existing location,
+                as specified by the "location" field.
+                Note: this is an optional field.
+            managePartitions:
+              type: boolean
+              description: |
+                ManagePartitions controls whether the reporting-operator needs to check
+                if the table partitions match the partitions listed in the "partitions" field.
+                Note: this is an optional field.
+            partitions:
+              type: array
+              description: |
+                A list of partitions that this Hive table should contain.
+                Note: this is an optional field.
+              nullable: true
+              items:
+                type: object
+                required:
+                - partitionSpec
+                - location
+                properties:
+                  partitionSpec:
+                    type: array
+                    description: |
+                      PartitionSpec is a map containing string keys and values, where each key
+                      is expected to be the name of a partition column, and the value is the
+                      value of the partition column.
+                  location:
+                    type: string
+                    description: |
+                      Location specifies where the data for this partition is stored.
+                      This should be a sub-directory of the "location" field.
+                    minLength: 1
+                    format: uri
+          anyOf:
+          - required:
+            - numBuckets
+            - clusteredBy
+            properties:
+              external:
+                enum:
+                - true
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+          - required:
+            - external
+            - location
+            properties:
+              external:
+                enum:
+                - true
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+          - required:
+            - managePartitions
+            - partitions
+            properties:
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+              external:
+                enum:
+                - true
+          # note: allow the minimal configuration, and enforce the schemas defined above
+          - allOf:
+            - not:
+                required:
+                - numBuckets
+            - not:
+                required:
+                - clusteredBy
+            - not:
+                required:
+                - sortedBy
+            - not:
+                required:
+                - location
+            properties:
+              external:
+                enum:
+                - false
+              managePartitions:
+                enum:
+                - false
 

--- a/manifests/deploy/openshift/olm/bundle/4.2/hive.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/hive.crd.yaml
@@ -21,4 +21,254 @@ spec:
   - name: Table Name
     type: string
     JSONPath: .status.tableName
+  validation:
+    openAPIV3Schema:
+      description: |
+        HiveTable is a custom resource that represents a database table within Hive.
+        When created, a HiveTable resource causes the reporting-operator to create a
+        table witin Hive according to the configuration provided.
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: |
+            HiveTableSpec is the desired specification of a HiveTable custom resource.
+            Required fields: database, tableName, and columns.
+            More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/hivetables.md
+          required:
+          - databaseName
+          - tableName
+          - columns
+          properties:
+            databaseName:
+              type: string
+              description: |
+                DatabaseName is the name of the Hive database to use.
+                Generally, this field should be set to "default", or the value of the "databaseName" in a Hive StorageLocation.
+                More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/storagelocations.md
+              minLength: 1
+            tableName:
+              type: string
+              description: |
+                TableName is the desired name of the table to be created in Hive.
+              minLength: 1
+            columns:
+              type: array
+              description: |
+                A list of columns that match the schema of the HiveTable.
+                For each list item, you must specify a `name` field, which is the name of an individual column for the Hive table,
+                and a `type` field, which corresponds to a valid type in Hive.
+                Note: the only complex types supported are map's of primitive types.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column.
+                    minLength: 1
+                  type:
+                    type: string
+                    description: |
+                      The column data type.
+                    minLength: 1
+            partitionedBy:
+              type: array
+              description: |
+                A list of columns that are used as partition columns.
+                Columns in "partitionedBy" and "columns" must not overlap.
+                For each list item, you must specify both a `name` and `type` field.
+                Note: this is an optional field.
+              minItems: 1
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column.
+                    minLength: 1
+                  type:
+                    type: string
+                    description: |
+                      The column data type.
+                    minLength: 1
+            clusteredBy:
+              type: array
+              description: |
+                A list of columns from "columns" to use for bucketed tables.
+                This field must be set if "numBuckets" is specified.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              minItems: 1
+              items:
+                type: string
+            sortedBy:
+              type: array
+              description: |
+                A list of column names from "columns" to use for bucketed tables.
+                This field must be set if "clusteredBy" and "numBuckets" are specified.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              required:
+              - name
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: |
+                      The name of the column from "columns".
+                    minLength: 1
+                  descending:
+                    type: boolean
+                    description: |
+                      Descending controls whether the column is descending or ascending.
+                      If "descending" is true, then the column is descending, else ascending.
+                      If this field is unspecified, then it defaults to Hive's default behavior.
+                      Note: this is an optional field.
+            numBuckets:
+              type: integer
+              description: |
+                The number of buckets to create for a bucketed table.
+                If this field is set, then "clusteredBy" also needs to be set.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+              format: int32
+              minimum: 0
+            location:
+              type: string
+              description: |
+                Location specifies the HDFS path to store this Hive table.
+                This field can be set to any URI supported by Hive.
+                Currently, `sda://`, `hdfs://`, and `/local/path` are supported based URIs.
+                Note: this is an optional field.
+              format: uri
+              minLength: 1
+            rowFormat:
+              type: string
+              description: |
+                RowFormat controls how Hive serializes and deserializes rows.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RowFormats&SerDe
+              minLength: 1
+            fileFormat:
+              type: string
+              description: |
+                FileFormat controls the file format used for storing files in the filesystem.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-StorageFormatsStorageFormatsRowFormat,StorageFormat,andSerDe
+              minLength: 1
+            tableProperties:
+              type: array
+              description: |
+                TableProperties is an array and allows you to tag the table definition with your
+                own metadata key/value pairs. Some predefined properties exist to control
+                behavior of the table as well.
+                Note: this is an optional field.
+                More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-listTableProperties
+            external:
+              type: boolean
+              description: |
+                External controls whether an external table is created, instead of a managed table.
+                If external is set to true, this causes Hive to point to an existing location,
+                as specified by the "location" field.
+                Note: this is an optional field.
+            managePartitions:
+              type: boolean
+              description: |
+                ManagePartitions controls whether the reporting-operator needs to check
+                if the table partitions match the partitions listed in the "partitions" field.
+                Note: this is an optional field.
+            partitions:
+              type: array
+              description: |
+                A list of partitions that this Hive table should contain.
+                Note: this is an optional field.
+              nullable: true
+              items:
+                type: object
+                required:
+                - partitionSpec
+                - location
+                properties:
+                  partitionSpec:
+                    type: array
+                    description: |
+                      PartitionSpec is a map containing string keys and values, where each key
+                      is expected to be the name of a partition column, and the value is the
+                      value of the partition column.
+                  location:
+                    type: string
+                    description: |
+                      Location specifies where the data for this partition is stored.
+                      This should be a sub-directory of the "location" field.
+                    minLength: 1
+                    format: uri
+          anyOf:
+          - required:
+            - numBuckets
+            - clusteredBy
+            properties:
+              external:
+                enum:
+                - true
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+          - required:
+            - external
+            - location
+            properties:
+              external:
+                enum:
+                - true
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+          - required:
+            - managePartitions
+            - partitions
+            properties:
+              managePartitions:
+                enum:
+                - true
+              partitions:
+                type: array
+              external:
+                enum:
+                - true
+          # note: allow the minimal configuration, and enforce the schemas defined above
+          - allOf:
+            - not:
+                required:
+                - numBuckets
+            - not:
+                required:
+                - clusteredBy
+            - not:
+                required:
+                - sortedBy
+            - not:
+                required:
+                - location
+            properties:
+              external:
+                enum:
+                - false
+              managePartitions:
+                enum:
+                - false
 


### PR DESCRIPTION
## Overview
This would add schema validation to the `HiveTable` CRD. I verified that you need at the minimum, the `tableName`, `columns`, and `databaseName` for a `HiveTable` resource to turn into a valid table in Presto.

## To-Do:
- [x] Add `oneOf` to top-level `spec.properties` to enforce certain configurations.
- [x] Update `hivetables.md` to clarify what fields are required, and optional.
- [x] Update `hivetables.md` and add more examples.