### PR TITLE
charts,manifests: Remove the required properties in the Report CRD.

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/report.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/report.crd.yaml
@@ -185,9 +185,7 @@ spec:
                       type: string
                       pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
               oneOf:
-              - required:
-                - hourly
-                properties:
+              - properties:
                   period:
                     enum:
                     - hourly
@@ -204,9 +202,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - daily
-                properties:
+              - properties:
                   period:
                     enum:
                     - daily
@@ -223,9 +219,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - weekly
-                properties:
+              - properties:
                   period:
                     enum:
                     - weekly
@@ -242,9 +236,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - monthly
-                properties:
+              - properties:
                   period:
                     enum:
                     - monthly
@@ -261,9 +253,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - cron
-                properties:
+              - properties:
                   period:
                     enum:
                     - cron

--- a/manifests/deploy/openshift/metering-ansible-operator/report.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/report.crd.yaml
@@ -185,9 +185,7 @@ spec:
                       type: string
                       pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
               oneOf:
-              - required:
-                - hourly
-                properties:
+              - properties:
                   period:
                     enum:
                     - hourly
@@ -204,9 +202,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - daily
-                properties:
+              - properties:
                   period:
                     enum:
                     - daily
@@ -223,9 +219,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - weekly
-                properties:
+              - properties:
                   period:
                     enum:
                     - weekly
@@ -242,9 +236,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - monthly
-                properties:
+              - properties:
                   period:
                     enum:
                     - monthly
@@ -261,9 +253,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - cron
-                properties:
+              - properties:
                   period:
                     enum:
                     - cron

--- a/manifests/deploy/openshift/olm/bundle/4.2/report.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/report.crd.yaml
@@ -185,9 +185,7 @@ spec:
                       type: string
                       pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
               oneOf:
-              - required:
-                - hourly
-                properties:
+              - properties:
                   period:
                     enum:
                     - hourly
@@ -204,9 +202,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - daily
-                properties:
+              - properties:
                   period:
                     enum:
                     - daily
@@ -223,9 +219,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - weekly
-                properties:
+              - properties:
                   period:
                     enum:
                     - weekly
@@ -242,9 +236,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - monthly
-                properties:
+              - properties:
                   period:
                     enum:
                     - monthly
@@ -261,9 +253,7 @@ spec:
                 - not:
                     required:
                     - cron
-              - required:
-                - cron
-                properties:
+              - properties:
                   period:
                     enum:
                     - cron


### PR DESCRIPTION
This was invaliding reports that didn't provide a schedule like hourly or daily.