### PR TITLE
fix for azure in meteringconfig.crd 

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -92,7 +92,23 @@ spec:
                       type: object
                       required:
                       - container
-                      - secretName
+                      oneOf:
+                      - required:
+                        - secretName
+                        allOf:
+                        - not:
+                            required:
+                            - storageAccountName
+                        - not:
+                            required:
+                            - secretAccessKey
+                      - required:
+                        - storageAccountName
+                        - secretAccessKey
+                        allOf:
+                        - not:
+                            required:
+                            - secretName
                       properties:
                         createSecret:
                           type: boolean

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -92,7 +92,23 @@ spec:
                       type: object
                       required:
                       - container
-                      - secretName
+                      oneOf:
+                      - required:
+                        - secretName
+                        allOf:
+                        - not:
+                            required:
+                            - storageAccountName
+                        - not:
+                            required:
+                            - secretAccessKey
+                      - required:
+                        - storageAccountName
+                        - secretAccessKey
+                        allOf:
+                        - not:
+                            required:
+                            - secretName
                       properties:
                         createSecret:
                           type: boolean

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringconfig.crd.yaml
@@ -92,7 +92,23 @@ spec:
                       type: object
                       required:
                       - container
-                      - secretName
+                      oneOf:
+                      - required:
+                        - secretName
+                        allOf:
+                        - not:
+                            required:
+                            - storageAccountName
+                        - not:
+                            required:
+                            - secretAccessKey
+                      - required:
+                        - storageAccountName
+                        - secretAccessKey
+                        allOf:
+                        - not:
+                            required:
+                            - secretName
                       properties:
                         createSecret:
                           type: boolean


### PR DESCRIPTION
added different configs for azure in the meteringconfig.crd to allow creating secrets for testing