### PR TITLE
Update OCP metering-ansible-operator Root CA CSR creation

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -23,9 +23,7 @@ RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 # put tini into our path
 RUN ln -f -s /tini /usr/bin/tini
 
-RUN pip install --no-cache-dir --upgrade openshift
-RUN pip install boto3
-RUN pip install pyOpenSSL
+RUN pip install --no-cache-dir --upgrade openshift boto3 cryptography
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -6,7 +6,7 @@ FROM openshift/ose-cli:latest as cli
 FROM openshift/ose-ansible-operator:latest
 
 USER root
-RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-boto3 openssl" \
+RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-boto3 python2-openshift python2-cryptography openssl" \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \
@@ -16,8 +16,7 @@ COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=cli /usr/bin/oc /usr/bin/oc
 RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 
-RUN yum -y update python-openshift
-RUN yum install pyOpenSSL
+RUN yum -y update python2-openshift python2-cryptography
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
@@ -52,6 +52,7 @@
       path: "{{ certificates_dir.path }}/ca.csr"
       privatekey_path: "{{ certificates_dir.path }}/ca.key"
       common_name: Operator Metering Root CA
+      use_common_name_for_san: false
       basicConstraints:
       - 'CA:TRUE'
       basicConstraints_critical: true


### PR DESCRIPTION
- Use python2-cryptography because openssl_csr requires a newer version of pyOpenSSL than available in the OCP rpm repos.
- Change the generated metering Root CA common name to a hostname to fix issues caused by using python cryptography package instead of pyOpenSSL.