### PR TITLE
Dockerfile.src: Run yum clean and remove yum cache before running yum

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -9,7 +9,10 @@ FROM openshift/origin-release:golang-1.10
 # our copy of faq and jq
 COPY hack/faq.repo /etc/yum.repos.d/ecnahc515-faq-epel-7.repo
 
+# ensure fresh metadata rather than cached metadata in the base by running
+# yum clean all && rm -rf /var/yum/cache/* first
 RUN INSTALL_PKGS="curl jq-1.6-2.el7 faq rh-python36" && \
+    yum clean all && rm -rf /var/cache/yum/* && \
     yum -y install centos-release-scl && \
     yum -y remove jq && \
     yum install --setopt=skip_missing_names_on_install=False -y $INSTALL_PKGS && \


### PR DESCRIPTION
Without this, we sometimes get errors updating metadata such as:

http://mirror.math.princeton.edu/pub/epel/7/x86_64/repodata/59cd2d904711571ac63cfec0fec0641233dc027173c6667914bbcc2e10ea11dd-primary.sqlite.bz2: [Errno 14] HTTP Error 404 - Not Found