### PR TITLE
hack: Update the target directory location for the minikube directory.

### DIFF
--- a/hack/run-metering-operator-local.sh
+++ b/hack/run-metering-operator-local.sh
@@ -22,7 +22,7 @@ VOLUMES=(\
     -v /tmp/ansible-operator/runner \
 )
 if [ -d "$HOME/.minikube" ]; then
-    VOLUMES+=(-v "$HOME/.minikube")
+    VOLUMES+=(-v "$HOME/.minikube:$HOME/.minikube")
 fi
 
 docker run \


### PR DESCRIPTION
I was still getting an error when running `make run-metering-operator-local` saying that the `$HOME/.minikube/*` certificates were missing, but `minikube ssh -- ls $HOME/.minikube` verified they were there. 

After adding a target directory location, I was able to run the metering operator locally.