### PR TITLE
charts,images,manifests: Set ghostunnel image from envvars

### DIFF
--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -184,6 +184,10 @@ olm:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-metering-hadoop:4.2
+  - name: ghostunnel
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-ghostunnel:4.2
 
   csv:
     version: "4.2.0"

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -15,6 +15,7 @@ _presto_default_spec: "{{ meteringconfig_default_values.presto.spec }}"
 _hive_default_spec: "{{ meteringconfig_default_values.hive.spec }}"
 _reporting_op_default_spec: "{{ meteringconfig_default_values['reporting-operator'].spec }}"
 _hadoop_default_spec: "{{ meteringconfig_default_values.hadoop.spec }}"
+_ghostunnel_default: "{{ meteringconfig_default_values.__ghostunnel }}"
 
 # Default image repository and tag from the defaults
 meteringconfig_reporting_operator_default_image_repo: "{{ _reporting_op_default_spec.image.repository }}"
@@ -25,6 +26,8 @@ meteringconfig_hive_default_image_repo: "{{ _hive_default_spec.image.repository 
 meteringconfig_hive_default_image_tag: "{{ _hive_default_spec.image.tag }}"
 meteringconfig_hadoop_default_image_repo: "{{ _hadoop_default_spec.image.repository }}"
 meteringconfig_hadoop_default_image_tag: "{{ _hadoop_default_spec.image.tag }}"
+meteringconfig_ghostunnel_default_image_repo: "{{ _ghostunnel_default.image.repository }}"
+meteringconfig_ghostunnel_default_image_tag: "{{ _ghostunnel_default.image.tag }}"
 
 _storage_spec: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides) | json_query('storage') | default({}, true) }}"
 
@@ -51,6 +54,10 @@ meteringconfig_default_image_overrides:
       image:
         repository: "{{ lookup('env','METERING_HADOOP_IMAGE').split(':')[0] | default(meteringconfig_hadoop_default_image_repo, true) }}"
         tag: "{{ lookup('env','METERING_HADOOP_IMAGE').split(':')[1] | default(meteringconfig_hadoop_default_image_tag, true) }}"
+  __ghostunnel:
+    image:
+      repository: "{{ lookup('env','GHOSTUNNEL_IMAGE').split(':')[0] | default(meteringconfig_ghostunnel_default_image_repo, true) }}"
+      tag: "{{ lookup('env','GHOSTUNNEL_IMAGE').split(':')[1] | default(meteringconfig_ghostunnel_default_image_tag, true) }}"
 
 _base_storage_overrides:
   s3:

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
@@ -54,6 +54,8 @@ spec:
           value: "quay.io/openshift/origin-metering-hive:4.2"
         - name: METERING_HADOOP_IMAGE
           value: "quay.io/openshift/origin-metering-hadoop:4.2"
+        - name: GHOSTUNNEL_IMAGE
+          value: "quay.io/openshift/origin-ghostunnel:4.2"
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner

--- a/manifests/deploy/openshift/olm/bundle/4.2/image-references
+++ b/manifests/deploy/openshift/olm/bundle/4.2/image-references
@@ -23,4 +23,8 @@ spec:
       kind: DockerImage
       name: quay.io/openshift/origin-metering-hadoop:4.2
     name: metering-hadoop
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-ghostunnel:4.2
+    name: ghostunnel
 

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
@@ -476,6 +476,8 @@ spec:
                     value: "quay.io/openshift/origin-metering-hive:4.2"
                   - name: METERING_HADOOP_IMAGE
                     value: "quay.io/openshift/origin-metering-hadoop:4.2"
+                  - name: GHOSTUNNEL_IMAGE
+                    value: "quay.io/openshift/origin-ghostunnel:4.2"
                   volumeMounts:
                   - mountPath: /tmp/ansible-operator/runner
                     name: runner


### PR DESCRIPTION
The image-references file maps to the in envvars values in the CSV and
are automatically replaced by ART's automation for publishing OLM
manifests. This enables the automation to also update the image used for
ghostunnel.