### PR TITLE
Bug 1744314: Use 4.2 oauth-proxy image and support override image via envvar for ART OLM manifest manipulation

### DIFF
--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -188,6 +188,10 @@ olm:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-ghostunnel:4.2
+  - name: oauth-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-oauth-proxy:4.2
 
   csv:
     version: "4.2.0"

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -402,8 +402,8 @@ reporting-operator:
 
       image:
         pullPolicy: Always
-        repository: openshift/oauth-proxy
-        tag: v1.1.0
+        repository: quay.io/openshift/origin-oauth-proxy
+        tag: 4.2
         pullSecrets: []
 
       authenticatedEmails:

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -20,6 +20,8 @@ _ghostunnel_default: "{{ meteringconfig_default_values.__ghostunnel }}"
 # Default image repository and tag from the defaults
 meteringconfig_reporting_operator_default_image_repo: "{{ _reporting_op_default_spec.image.repository }}"
 meteringconfig_reporting_operator_default_image_tag: "{{ _reporting_op_default_spec.image.tag }}"
+meteringconfig_oauth_proxy_default_image_repo: "{{ _reporting_op_default_spec.authProxy.image.repository }}"
+meteringconfig_oauth_proxy_default_image_tag: "{{ _reporting_op_default_spec.authProxy.image.tag }}"
 meteringconfig_presto_default_image_repo: "{{ _presto_default_spec.image.repository }}"
 meteringconfig_presto_default_image_tag: "{{ _presto_default_spec.image.tag }}"
 meteringconfig_hive_default_image_repo: "{{ _hive_default_spec.image.repository }}"
@@ -38,6 +40,12 @@ meteringconfig_default_image_overrides:
       image:
         repository: "{{ lookup('env','METERING_REPORTING_OPERATOR_IMAGE').split(':')[0] | default(meteringconfig_reporting_operator_default_image_repo, true) }}"
         tag: "{{ lookup('env','METERING_REPORTING_OPERATOR_IMAGE').split(':')[1] | default(meteringconfig_reporting_operator_default_image_tag, true) }}"
+
+      authProxy:
+        image:
+          repository: "{{ lookup('env','OAUTH_PROXY_IMAGE').split(':')[0] | default(meteringconfig_oauth_proxy_default_image_repo, true) }}"
+          tag: "{{ lookup('env','OAUTH_PROXY_IMAGE').split(':')[1] | default(meteringconfig_oauth_proxy_default_image_tag, true) }}"
+
   presto:
     spec:
       presto:

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
@@ -56,6 +56,8 @@ spec:
           value: "quay.io/openshift/origin-metering-hadoop:4.2"
         - name: GHOSTUNNEL_IMAGE
           value: "quay.io/openshift/origin-ghostunnel:4.2"
+        - name: OAUTH_PROXY_IMAGE
+          value: "quay.io/openshift/origin-oauth-proxy:4.2"
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner

--- a/manifests/deploy/openshift/olm/bundle/4.2/image-references
+++ b/manifests/deploy/openshift/olm/bundle/4.2/image-references
@@ -27,4 +27,8 @@ spec:
       kind: DockerImage
       name: quay.io/openshift/origin-ghostunnel:4.2
     name: ghostunnel
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-oauth-proxy:4.2
+    name: oauth-proxy
 

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
@@ -478,6 +478,8 @@ spec:
                     value: "quay.io/openshift/origin-metering-hadoop:4.2"
                   - name: GHOSTUNNEL_IMAGE
                     value: "quay.io/openshift/origin-ghostunnel:4.2"
+                  - name: OAUTH_PROXY_IMAGE
+                    value: "quay.io/openshift/origin-oauth-proxy:4.2"
                   volumeMounts:
                   - mountPath: /tmp/ansible-operator/runner
                     name: runner


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1744314