### PR TITLE
Dockerfiles: yum clean and rm yum cache before yum install

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -7,6 +7,7 @@ FROM quay.io/openshift/origin-ansible-operator:latest
 
 USER root
 RUN INSTALL_PKGS="curl bash ca-certificates less which inotify-tools openssl" \
+    && yum clean all && rm -rf /var/cache/yum/* \
     && yum -y install epel-release \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \

--- a/Dockerfile.reporting-operator.okd
+++ b/Dockerfile.reporting-operator.okd
@@ -7,7 +7,8 @@ RUN make reporting-operator-bin RUN_UPDATE_CODEGEN=false CHECK_GO_FILES=false
 
 FROM openshift/origin-base:latest
 
-RUN yum install --setopt=skip_missing_names_on_install=False -y \
+RUN yum clean all && rm -rf /var/cache/yum/* && \
+    yum install --setopt=skip_missing_names_on_install=False -y \
         ca-certificates bash
 
 COPY --from=build /go/src/github.com/operator-framework/operator-metering/bin/reporting-operator /usr/local/bin/reporting-operator


### PR DESCRIPTION
Base images are seemingly keeping cached information and it's causing
our images to fail to yum install, so clear the yum cache before using
yum.