### PR TITLE
hack: Update the OLM uninstall to delete the CSV created from the subscription.

### DIFF
--- a/hack/olm-uninstall.sh
+++ b/hack/olm-uninstall.sh
@@ -31,6 +31,9 @@ if [ "$METERING_NAMESPACE" != "openshift-metering" ]; then
         export OLM_MANIFESTS_DIR="$TMPDIR"
 fi
 
+SUBSCRIPTION_NAME="$(faq -f yaml '.metadata.name' "$OLM_MANIFESTS_DIR/metering.subscription.yaml")"
+CSV_NAME="$(kubectl -n $METERING_NAMESPACE get subscriptions $SUBSCRIPTION_NAME -o yaml | faq -f yaml '.status.currentCSV')"
+
 msg "Removing Metering Resource"
 kube-remove \
     "$METERING_CR_FILE"
@@ -46,3 +49,6 @@ kube-remove \
 msg "Removing Metering Catalog Source Config"
 kubectl delete -f \
     "$OLM_MANIFESTS_DIR/metering.catalogsourceconfig.yaml"
+
+msg "Removing Metering Catalog Source Version"
+kubectl -n $METERING_NAMESPACE delete csv $CSV_NAME


### PR DESCRIPTION
Currently, when running `./hack/olm-uninstall.sh`, all the relevant resources are deleted besides the CSV and metering-operator pod. If we query the `status.currentCSV` field in the subscription before deleting it, we can get the name of the CSV and delete it safely. 

Once the CSV is deleted, the metering-operator will start to terminate.