### PR TITLE
Always import full chunks when querying metrics

### DIFF
--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -27,10 +27,6 @@ import (
 const (
 	reportDataSourceFinalizer = metering.GroupName + "/reportdatasource"
 	partitionUpdateInterval   = 30 * time.Minute
-	// allowIncompleteChunks must be true generally if we have a large
-	// chunkSize because otherwise we will wait for an entire chunks worth of
-	// data before importing metrics into Presto.
-	allowIncompleteChunks = true
 )
 
 func (op *Reporting) runReportDataSourceWorker() {
@@ -224,7 +220,7 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 	importStatus.LastImportTime = &metav1.Time{Time: op.clock.Now().UTC()}
 
 	// run the import
-	results, err := importer.ImportFromLastTimestamp(context.Background(), allowIncompleteChunks)
+	results, err := importer.ImportFromLastTimestamp(context.Background())
 	if err != nil {
 		return fmt.Errorf("ImportFromLastTimestamp errored: %v", err)
 	}

--- a/pkg/operator/prestostore/importer.go
+++ b/pkg/operator/prestostore/importer.go
@@ -95,7 +95,7 @@ func (importer *PrometheusImporter) UpdateConfig(cfg Config) {
 // the next time range starting from where it left off if paused or stopped.
 // For more details on how querying Prometheus is done, see the package
 // pkg/promquery.
-func (importer *PrometheusImporter) ImportFromLastTimestamp(ctx context.Context, allowIncompleteChunks bool) (*PrometheusImportResults, error) {
+func (importer *PrometheusImporter) ImportFromLastTimestamp(ctx context.Context) (*PrometheusImportResults, error) {
 	importer.importLock.Lock()
 	importer.logger.Debugf("PrometheusImporter ImportFromLastTimestamp started")
 	defer importer.logger.Debugf("PrometheusImporter ImportFromLastTimestamp finished")
@@ -156,7 +156,7 @@ func (importer *PrometheusImporter) ImportFromLastTimestamp(ctx context.Context,
 		endTime = startTime.Add(cfg.MaxQueryRangeDuration)
 	}
 
-	importResults, err := ImportFromTimeRange(importer.logger, importer.clock, importer.promConn, importer.prometheusMetricsRepo, importer.metricsCollectors, ctx, startTime, endTime, cfg, allowIncompleteChunks)
+	importResults, err := ImportFromTimeRange(importer.logger, importer.clock, importer.promConn, importer.prometheusMetricsRepo, importer.metricsCollectors, ctx, startTime, endTime, cfg)
 	if err != nil {
 		importer.logger.WithFields(logrus.Fields{"startTime": startTime, "endTime": endTime}).WithError(err).Error("error collecting metrics")
 		// at this point we cannot be sure what is in Presto and what

--- a/pkg/operator/prestostore/query.go
+++ b/pkg/operator/prestostore/query.go
@@ -23,13 +23,8 @@ type PrometheusImportResults struct {
 // first error, consult timeRanges to determine how many chunks were queried.
 //
 // If the number of queries exceeds maxTimeRanges, then the timeRanges
-// exceeding that count will be skipped. The allowIncompleteChunks parameter
-// controls whether or not every chunk must be a full chunkSize, or if there
-// can be incomplete chunks. This has an effect when there is only one chunk
-// that's incomplete, and if there are multiple chunks, whether or not the
-// final chunk up to the endTime will be included even if the duration of
-// endTime - startTime isn't perfectly divisible by chunkSize.
-func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn prom.API, prometheusMetricsStorer PrometheusMetricsStorer, metricsCollectors ImporterMetricsCollectors, ctx context.Context, startTime, endTime time.Time, cfg Config, allowIncompleteChunks bool) (PrometheusImportResults, error) {
+// exceeding that count will be skipped.
+func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn prom.API, prometheusMetricsStorer PrometheusMetricsStorer, metricsCollectors ImporterMetricsCollectors, ctx context.Context, startTime, endTime time.Time, cfg Config) (PrometheusImportResults, error) {
 	metricsCollectors.ImportsRunningGauge.Inc()
 
 	queryRangeDuration := endTime.Sub(startTime)
@@ -49,7 +44,7 @@ func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn 
 		logger.Debugf("took %s to run import", importDuration)
 	}()
 
-	timeRanges := getTimeRangesChunked(startTime, endTime, cfg.ChunkSize, cfg.StepSize, cfg.MaxTimeRanges, allowIncompleteChunks)
+	timeRanges := getTimeRangesChunked(startTime, endTime, cfg.ChunkSize, cfg.StepSize, cfg.MaxTimeRanges)
 
 	var importResults PrometheusImportResults
 	if len(timeRanges) == 0 {
@@ -156,7 +151,7 @@ func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn 
 	}
 }
 
-func getTimeRangesChunked(beginTime, endTime time.Time, chunkSize, stepSize time.Duration, maxTimeRanges int64, allowIncompleteChunks bool) []prom.Range {
+func getTimeRangesChunked(beginTime, endTime time.Time, chunkSize, stepSize time.Duration, maxTimeRanges int64) []prom.Range {
 	chunkStart := truncateToSecond(beginTime)
 	chunkEnd := truncateToSecond(chunkStart.Add(chunkSize))
 
@@ -165,23 +160,14 @@ func getTimeRangesChunked(beginTime, endTime time.Time, chunkSize, stepSize time
 
 	var timeRanges []prom.Range
 	for i := int64(0); disableMax || (i < maxTimeRanges); i++ {
-		if allowIncompleteChunks {
-			if chunkEnd.After(endTime) {
-				chunkEnd = truncateToSecond(endTime)
-			}
-			if chunkEnd.Equal(chunkStart) || chunkEnd.Sub(chunkStart) < stepSize {
-				break
-			}
-		} else {
-			// Do not collect data after endTime
-			if chunkEnd.After(endTime) {
-				break
-			}
+		// Do not collect data after endTime
+		if chunkEnd.After(endTime) {
+			break
+		}
 
-			// Only get chunks that are a full chunk size
-			if chunkEnd.Sub(chunkStart) < chunkSize {
-				break
-			}
+		// Only get chunks that are a full chunk size
+		if chunkEnd.Sub(chunkStart) < chunkSize {
+			break
 		}
 		timeRanges = append(timeRanges, prom.Range{
 			Start: chunkStart.UTC(),
@@ -189,7 +175,7 @@ func getTimeRangesChunked(beginTime, endTime time.Time, chunkSize, stepSize time
 			Step:  stepSize,
 		})
 
-		if allowIncompleteChunks && chunkEnd.Equal(truncateToSecond(endTime)) {
+		if chunkEnd.Equal(truncateToSecond(endTime)) {
 			break
 		}
 

--- a/pkg/operator/prestostore/query.go
+++ b/pkg/operator/prestostore/query.go
@@ -169,7 +169,7 @@ func getTimeRangesChunked(beginTime, endTime time.Time, chunkSize, stepSize time
 			if chunkEnd.After(endTime) {
 				chunkEnd = truncateToSecond(endTime)
 			}
-			if chunkEnd.Equal(chunkStart) {
+			if chunkEnd.Equal(chunkStart) || chunkEnd.Sub(chunkStart) < stepSize {
 				break
 			}
 		} else {

--- a/pkg/operator/prestostore/query_test.go
+++ b/pkg/operator/prestostore/query_test.go
@@ -11,13 +11,12 @@ import (
 func TestGetTimeRanges(t *testing.T) {
 	janOne := time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)
 	tests := map[string]struct {
-		startTime             time.Time
-		endTime               time.Time
-		chunkSize             time.Duration
-		stepSize              time.Duration
-		maxTimeRanges         int64
-		expectedRanges        []prom.Range
-		allowIncompleteChunks bool
+		startTime      time.Time
+		endTime        time.Time
+		chunkSize      time.Duration
+		stepSize       time.Duration
+		maxTimeRanges  int64
+		expectedRanges []prom.Range
 	}{
 		"start and end are zero": {
 			chunkSize:      time.Minute * 5,
@@ -64,38 +63,12 @@ func TestGetTimeRanges(t *testing.T) {
 				},
 			},
 		},
-		"period is less than divisible by chunkSize with allowIncompleteChunks": {
-			startTime:             janOne,
-			endTime:               janOne.Add(30 * time.Minute),
-			chunkSize:             time.Hour,
-			stepSize:              time.Minute,
-			allowIncompleteChunks: true,
-			expectedRanges: []prom.Range{
-				{
-					Start: janOne,
-					End:   janOne.Add(30 * time.Minute),
-					Step:  time.Minute,
-				},
-			},
-		},
-		"period is exactly divisible by chunkSize with allowIncompleteChunks": {
-			startTime:             janOne,
-			endTime:               janOne.Add(2 * time.Hour),
-			chunkSize:             time.Hour,
-			stepSize:              time.Minute,
-			allowIncompleteChunks: true,
-			expectedRanges: []prom.Range{
-				{
-					Start: janOne,
-					End:   janOne.Add(time.Hour),
-					Step:  time.Minute,
-				},
-				{
-					Start: janOne.Add(time.Hour + time.Minute),
-					End:   janOne.Add(2 * time.Hour),
-					Step:  time.Minute,
-				},
-			},
+		"period is less than divisible by chunkSize": {
+			startTime:      janOne,
+			endTime:        janOne.Add(30 * time.Minute),
+			chunkSize:      time.Hour,
+			stepSize:       time.Minute,
+			expectedRanges: nil,
 		},
 	}
 
@@ -103,7 +76,7 @@ func TestGetTimeRanges(t *testing.T) {
 		// Fix closure captures
 		test := test
 		t.Run(name, func(t *testing.T) {
-			timeRanges := getTimeRangesChunked(test.startTime, test.endTime, test.chunkSize, test.stepSize, test.maxTimeRanges, test.allowIncompleteChunks)
+			timeRanges := getTimeRangesChunked(test.startTime, test.endTime, test.chunkSize, test.stepSize, test.maxTimeRanges)
 			assert.Equal(t, test.expectedRanges, timeRanges)
 		})
 	}

--- a/pkg/operator/promsum.go
+++ b/pkg/operator/promsum.go
@@ -237,7 +237,7 @@ func (op *Reporting) importPrometheusForTimeRange(ctx context.Context, namespace
 				promConn = op.promConn
 			}
 
-			importResults, err := prestostore.ImportFromTimeRange(dataSourceLogger, op.clock, promConn, op.prometheusMetricsRepo, metricsCollectors, ctx, start, end, importCfg, true)
+			importResults, err := prestostore.ImportFromTimeRange(dataSourceLogger, op.clock, promConn, op.prometheusMetricsRepo, metricsCollectors, ctx, start, end, importCfg)
 			if err != nil {
 				return fmt.Errorf("error importing Prometheus data for ReportDataSource %s: %v", reportDataSource.Name, err)
 			}


### PR DESCRIPTION
This PR changes metrics importing to always import metrics of the configured import chunk size.
This ensures consistency in metrics being imported.