### PR TITLE
Fix image overrides from environment for components

### DIFF
--- a/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
       # would always be resolvable, because on Openshift, clusterIP services
       # NAT loses sourceIPs, breaking HDFS clustering.
       - name: wait-for-namenode
-        image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
+        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command:
         - '/bin/bash'
@@ -143,7 +143,7 @@ spec:
         - name: namenode-empty
           mountPath: /hadoop/dfs/name
       - name: copy-starter-hadoop
-        image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
+        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/copy-hadoop-config.sh"]
         env:
@@ -177,7 +177,7 @@ spec:
           defaultMode: 0775
       containers:
       - name: hdfs-datanode
-        image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
+        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/entrypoint.sh"]
         args: ["/hadoop-scripts/datanode-entrypoint.sh"]

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
 {{- end }}
       initContainers:
       - name: copy-starter-hadoop
-        image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
+        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/copy-hadoop-config.sh"]
         env:
@@ -139,7 +139,7 @@ spec:
 {{- end }}
       containers:
       - name: hdfs-namenode
-        image: "{{ .Values.hadoop.spec.image.repository }}:{{ .Values.hadoop.spec.image.tag }}"
+        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/entrypoint.sh"]
         args: ["/hadoop-scripts/namenode-entrypoint.sh"]

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
 {{- end }}
       initContainers:
       - name: copy-starter-hive
-        image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
+        image: "{{ .Values.hive.spec.image.override | default (printf "%s:%s" .Values.hive.spec.image.repository .Values.hive.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         command: ["/hive-scripts/copy-hadoop-config.sh"]
 {{- if or .Values.hive.spec.config.azure.secretName .Values.hive.spec.config.azure.createSecret }}
@@ -108,7 +108,7 @@ spec:
       - name: metastore
         command: ["/hive-scripts/entrypoint.sh"]
         args: ["/opt/hive/bin/hive", "--service", "metastore"]
-        image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
+        image: "{{ .Values.hive.spec.image.override | default (printf "%s:%s" .Values.hive.spec.image.repository .Values.hive.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         ports:
 {{- if not .Values.hive.spec.metastore.config.tls.enabled }}
@@ -191,7 +191,7 @@ spec:
 {{ toYaml .Values.hive.spec.metastore.resources | indent 10 }}
 {{- if .Values.hive.spec.metastore.config.tls.enabled }}
       - name: ghostunnel-server
-        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: HIVE_METASTORE_CA_CRTFILE

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
       initContainers:
 {{- if .Values.hive.spec.server.config.metastoreTLS.enabled }}
       - name: copy-hive-tls
-        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_CLIENT_CA_CRTFILE
@@ -97,7 +97,7 @@ spec:
           mountPath: /hive-metastore-auth-tls-secrets
 {{- end }}
       - name: copy-starter-hive
-        image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
+        image: "{{ .Values.hive.spec.image.override | default (printf "%s:%s" .Values.hive.spec.image.repository .Values.hive.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         command: ["/hive-scripts/copy-hadoop-config.sh"]
 {{- if or .Values.hive.spec.config.azure.secretName .Values.hive.spec.config.azure.createSecret }}
@@ -133,7 +133,7 @@ spec:
       - name: hiveserver2
         command: ["/hive-scripts/entrypoint.sh"]
         args: ["/opt/hive/bin/hive", "--service", "hiveserver2"]
-        image: "{{ .Values.hive.spec.image.repository }}:{{ .Values.hive.spec.image.tag }}"
+        image: "{{ .Values.hive.spec.image.override | default (printf "%s:%s" .Values.hive.spec.image.repository .Values.hive.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         ports:
 {{- if not .Values.hive.spec.server.config.tls.enabled }}
@@ -219,7 +219,7 @@ spec:
 {{ toYaml .Values.hive.spec.server.resources | indent 10 }}
 {{- if .Values.hive.spec.server.config.metastoreTLS.enabled }}
       - name: ghostunnel-client
-        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_CLIENT_CA_CRTFILE
@@ -243,7 +243,7 @@ spec:
 {{- end }}
 {{- if .Values.hive.spec.server.config.tls.enabled }}
       - name: ghostunnel-server
-        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_SERVER_CA_CRTFILE

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
 {{- end }}
       initContainers:
       - name: copy-presto-config
-        image: "{{ .Values.presto.spec.image.repository }}:{{ .Values.presto.spec.image.tag }}"
+        image: "{{ .Values.presto.spec.image.override | default (printf "%s:%s" .Values.presto.spec.image.repository .Values.presto.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.presto.spec.image.pullPolicy }}
         command: ['/presto-common/initialize_presto.sh']
         # Copy the mounted configuration data into the presto-etc emptyDir volume so we can write to the config files
@@ -166,7 +166,7 @@ spec:
             memory: 100Mi
       containers:
       - name: presto
-        image: "{{ .Values.presto.spec.image.repository }}:{{ .Values.presto.spec.image.tag }}"
+        image: "{{ .Values.presto.spec.image.override | default (printf "%s:%s" .Values.presto.spec.image.repository .Values.presto.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.presto.spec.image.pullPolicy }}
         command: ['/presto-common/entrypoint.sh']
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
@@ -216,7 +216,7 @@ spec:
 {{ toYaml .Values.presto.spec.coordinator.resources | indent 10 }}
 {{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
       - name: ghostunnel-client
-        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_CLIENT_CA_CRTFILE

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
 {{- end }}
       initContainers:
       - name: copy-presto-config
-        image: "{{ .Values.presto.spec.image.repository }}:{{ .Values.presto.spec.image.tag }}"
+        image: "{{ .Values.presto.spec.image.override | default (printf "%s:%s" .Values.presto.spec.image.repository .Values.presto.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.presto.spec.image.pullPolicy }}
         command: ['/presto-common/initialize_presto.sh']
         # Copy the mounted configuration data into the presto-etc emptyDir volume so we can write to the config files
@@ -166,7 +166,7 @@ spec:
             memory: 100Mi
       containers:
       - name: presto
-        image: "{{ .Values.presto.spec.image.repository }}:{{ .Values.presto.spec.image.tag }}"
+        image: "{{ .Values.presto.spec.image.override | default (printf "%s:%s" .Values.presto.spec.image.repository .Values.presto.spec.image.tag) }}"
         imagePullPolicy: {{ .Values.presto.spec.image.pullPolicy }}
         command: ['/presto-common/entrypoint.sh']
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
@@ -216,7 +216,7 @@ spec:
 {{ toYaml .Values.presto.spec.worker.resources | indent 10 }}
 {{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
       - name: ghostunnel-client
-        image: {{ .Values.__ghostunnel.image.repository }}:{{ .Values.__ghostunnel.image.tag }}
+        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_CLIENT_CA_CRTFILE

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -76,7 +76,7 @@ spec:
 {{- end }}
       containers:
       - name: reporting-operator
-        image: "{{ $operatorValues.spec.image.repository }}:{{ $operatorValues.spec.image.tag }}"
+        image: "{{ $operatorValues.spec.image.override | default (printf "%s:%s" $operatorValues.spec.image.repository $operatorValues.spec.image.tag) }}"
         imagePullPolicy: {{ $operatorValues.spec.image.pullPolicy }}
         env:
         - name: POD_NAME
@@ -358,7 +358,7 @@ spec:
 {{- end }}
 {{- if $operatorValues.spec.authProxy.enabled }}
       - name: reporting-operator-auth-proxy
-        image: "{{ $operatorValues.spec.authProxy.image.repository }}:{{ $operatorValues.spec.authProxy.image.tag }}"
+        image: "{{ $operatorValues.spec.authProxy.image.override | default (printf "%s:%s" $operatorValues.spec.authProxy.image.repository $operatorValues.spec.authProxy.image.tag) }}"
         imagePullPolicy: {{ $operatorValues.spec.authProxy.image.pullPolicy }}
         env:
         - name: NAMESPACE

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -247,7 +247,8 @@ reporting-operator:
     image:
       pullPolicy: Always
       repository: quay.io/openshift/origin-metering-reporting-operator
-      tag: 4.2
+      tag: "4.2"
+      override: null
       pullSecrets: []
 
     updateStrategy:
@@ -404,7 +405,8 @@ reporting-operator:
       image:
         pullPolicy: Always
         repository: quay.io/openshift/origin-oauth-proxy
-        tag: 4.2
+        tag: "4.2"
+        override: null
         pullSecrets: []
 
       authenticatedEmails:
@@ -449,7 +451,8 @@ presto:
     image:
       pullPolicy: Always
       repository: quay.io/openshift/origin-metering-presto
-      tag: 4.2
+      tag: "4.2"
+      override: null
 
     config:
       environment: production
@@ -687,7 +690,8 @@ hive:
     image:
       pullPolicy: Always
       repository: quay.io/openshift/origin-metering-hive
-      tag: 4.2
+      tag: "4.2"
+      override: null
       pullSecrets: []
 
     metastore:
@@ -821,7 +825,8 @@ __ghostunnel:
   image:
     pullPolicy: Always
     repository: quay.io/openshift/origin-ghostunnel
-    tag: 4.2
+    tag: "4.2"
+    override: null
 
 hadoop:
   spec:
@@ -861,7 +866,8 @@ hadoop:
     image:
       pullPolicy: Always
       repository: quay.io/openshift/origin-metering-hadoop
-      tag: 4.2
+      tag: "4.2"
+      override: null
       pullSecrets: null
 
     hdfs:

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -31,6 +31,13 @@ meteringconfig_hadoop_default_image_tag: "{{ _hadoop_default_spec.image.tag }}"
 meteringconfig_ghostunnel_default_image_repo: "{{ _ghostunnel_default.image.repository }}"
 meteringconfig_ghostunnel_default_image_tag: "{{ _ghostunnel_default.image.tag }}"
 
+meteringconfig_reporting_operator_override_image: "{{ lookup('env', 'METERING_REPORTING_OPERATOR_IMAGE') }}"
+meteringconfig_oauth_proxy_override_image: "{{ lookup('env', 'OAUTH_PROXY_IMAGE') }}"
+meteringconfig_presto_override_image: "{{ lookup('env', 'METERING_PRESTO_IMAGE') }}"
+meteringconfig_hive_override_image: "{{ lookup('env', 'METERING_HIVE_IMAGE') }}"
+meteringconfig_hadoop_override_image: "{{ lookup('env', 'METERING_HADOOP_IMAGE') }}"
+meteringconfig_ghostunnel_override_image: "{{ lookup('env', 'GHOSTUNNEL_IMAGE') }}"
+
 _storage_spec: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides) | json_query('storage') | default({}, true) }}"
 
 # Override the default images we use with env vars if set, falling back to the values.yaml configured default if not set.
@@ -38,33 +45,39 @@ meteringconfig_default_image_overrides:
   reporting-operator:
     spec:
       image:
-        repository: "{{ lookup('env','METERING_REPORTING_OPERATOR_IMAGE').split(':')[0] | default(meteringconfig_reporting_operator_default_image_repo, true) }}"
-        tag: "{{ lookup('env','METERING_REPORTING_OPERATOR_IMAGE').split(':')[1] | default(meteringconfig_reporting_operator_default_image_tag, true) }}"
+        repository: "{{ meteringconfig_reporting_operator_default_image_repo }}"
+        tag: "{{ meteringconfig_reporting_operator_default_image_tag }}"
+        override: "{{ meteringconfig_reporting_operator_override_image }}"
 
       authProxy:
         image:
-          repository: "{{ lookup('env','OAUTH_PROXY_IMAGE').split(':')[0] | default(meteringconfig_oauth_proxy_default_image_repo, true) }}"
-          tag: "{{ lookup('env','OAUTH_PROXY_IMAGE').split(':')[1] | default(meteringconfig_oauth_proxy_default_image_tag, true) }}"
+          repository: "{{ meteringconfig_oauth_proxy_default_image_repo }}"
+          tag: "{{ meteringconfig_oauth_proxy_default_image_tag }}"
+          override: "{{ meteringconfig_oauth_proxy_override_image }}"
 
   presto:
     spec:
       image:
-        repository: "{{ lookup('env','METERING_PRESTO_IMAGE').split(':')[0] | default(meteringconfig_presto_default_image_repo, true) }}"
-        tag: "{{ lookup('env','METERING_PRESTO_IMAGE').split(':')[1] | default(meteringconfig_presto_default_image_tag, true) }}"
+        repository: "{{ meteringconfig_presto_default_image_repo }}"
+        tag: "{{ meteringconfig_presto_default_image_tag }}"
+        override: "{{ meteringconfig_presto_override_image }}"
   hive:
     spec:
       image:
-        repository: "{{ lookup('env','METERING_HIVE_IMAGE').split(':')[0] | default(meteringconfig_hive_default_image_repo, true) }}"
-        tag: "{{ lookup('env','METERING_HIVE_IMAGE').split(':')[1] | default(meteringconfig_hive_default_image_tag, true) }}"
+        repository: "{{ meteringconfig_hive_default_image_repo }}"
+        tag: "{{ meteringconfig_hive_default_image_tag }}"
+        override: "{{ meteringconfig_hive_override_image }}"
   hadoop:
     spec:
       image:
-        repository: "{{ lookup('env','METERING_HADOOP_IMAGE').split(':')[0] | default(meteringconfig_hadoop_default_image_repo, true) }}"
-        tag: "{{ lookup('env','METERING_HADOOP_IMAGE').split(':')[1] | default(meteringconfig_hadoop_default_image_tag, true) }}"
+        repository: "{{ meteringconfig_hadoop_default_image_repo }}"
+        tag: "{{ meteringconfig_hadoop_default_image_tag }}"
+        override: "{{ meteringconfig_hadoop_override_image }}"
   __ghostunnel:
     image:
-      repository: "{{ lookup('env','GHOSTUNNEL_IMAGE').split(':')[0] | default(meteringconfig_ghostunnel_default_image_repo, true) }}"
-      tag: "{{ lookup('env','GHOSTUNNEL_IMAGE').split(':')[1] | default(meteringconfig_ghostunnel_default_image_tag, true) }}"
+      repository: "{{ meteringconfig_ghostunnel_default_image_repo }}"
+      tag: "{{ meteringconfig_ghostunnel_default_image_tag }}"
+      override: "{{ meteringconfig_ghostunnel_override_image }}"
 
 _base_storage_overrides:
   s3:

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -48,10 +48,9 @@ meteringconfig_default_image_overrides:
 
   presto:
     spec:
-      presto:
-        image:
-          repository: "{{ lookup('env','METERING_PRESTO_IMAGE').split(':')[0] | default(meteringconfig_presto_default_image_repo, true) }}"
-          tag: "{{ lookup('env','METERING_PRESTO_IMAGE').split(':')[1] | default(meteringconfig_presto_default_image_tag, true) }}"
+      image:
+        repository: "{{ lookup('env','METERING_PRESTO_IMAGE').split(':')[0] | default(meteringconfig_presto_default_image_repo, true) }}"
+        tag: "{{ lookup('env','METERING_PRESTO_IMAGE').split(':')[1] | default(meteringconfig_presto_default_image_tag, true) }}"
   hive:
     spec:
       image:


### PR DESCRIPTION
- Fixes presto image overrides. The override was using the wrong structure for the helm values
- Adds a new image.override option to each component's helm values, allowing overriding the entire container image field in the pod template
- Updates image overrides in metering-ansible-operator's meteringconfig role to use the new image.override option. Fixes a bug in testing with images with ports in the image name, as is the case when testing staging OLM package bundles.