### PR TITLE
Document testing OCP install of metering using ART published OLM manifest bundle

### DIFF
--- a/Documentation/dev/mirroring-ocp-images.md
+++ b/Documentation/dev/mirroring-ocp-images.md
@@ -1,0 +1,47 @@
+# Mirroring OCP images into your cluster
+
+This guide will walk through:
+
+- Configuring your OCP 4 cluster's registry to be accessible from outside the cluster
+- Configuring docker so that you can pull images from the Red Hat internal docker registry: `brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888`
+- Running the mirroring script provided to pull images from brew-pulp and push them into your OCP 4 cluster's in-cluster registry.
+
+# Configure access to your cluster's in-cluster image registry
+
+First, you need to ensure your registry is accessible outside the cluster so we can push images into it.
+Follow https://docs.openshift.com/container-platform/4.1/registry/securing-exposing-registry.html to do this.
+
+The short version is to run the following command:
+
+```
+oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+```
+
+Your registry is always secured with authentication, so exposing it outside the cluster should be safe.
+
+Next, you need configure docker to trust your registry.
+Because the in-cluster cluster registry is using a self-signed certificate, you will need to configure your docker daemon to trust the cluster CA:
+
+Get your registry hostname by running the following:
+
+```
+oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}'
+```
+
+And then follow the instructions in https://docs.docker.com/registry/insecure/ to add the registry to your insecure registry list.
+You can also copy the cluster's CA into the correct directory within `/etc/docker/certs.d/` by following the instructions in the same page.
+
+# Mirror images from Brew into your cluster's in-cluster image registry
+
+Make sure you're connected to the Red Hat in-cluster network (VPNed or using an ethernet connection on the Red Hat network) and run the `hack/mirror-ose-images-into-cluster.sh` script in the repo.
+This script does a few things:
+
+- Sets up a namespace for pushing the images into.
+- Creates a serviceaccount and grants it permissions to push images to the in-cluster registry.
+- Uses the serviceaccount to `docker login` to the in-cluster registry.
+- Pulls images from the Red Hat internal registry to your local workstation.
+- Pushes them into your in-cluster image registry.
+
+```
+./hack/mirror-ose-images-into-cluster.sh
+```

--- a/Documentation/dev/testing-ocp-images.md
+++ b/Documentation/dev/testing-ocp-images.md
@@ -2,38 +2,9 @@
 
 This document covers how to mirror OCP images from the internal Red Hat container image repository to your in-cluster registry, and how to install Metering so that it uses the OCP images.
 
-# Setup
+# Mirror OCP images into your cluster
 
-Before we install, you need to correctly configure your docker daemon, and mirror the images.
-
-# Configure access to your cluster's in-cluster image registry
-
-Next, you need to login to your cluster's in-cluster image registry.
-Because the in-cluster cluster registry is using a self-signed certificate, you will need to configure your docker daemon to trust the cluster CA:
-
-Get your registry hostname by running the following:
-
-```
-oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}'
-```
-
-And then follow the instructions in https://docs.docker.com/registry/insecure/ to add the registry to your insecure registry list.
-You can also copy the cluster's CA into the correct directory within `/etc/docker/certs.d/` by following the instructions in the same page.
-
-# Mirror images from Brew into your cluster's in-cluster image registry
-
-Make sure you're connected to the Red Hat in-cluster network (VPNed or otherwise) and run the `hack/mirror-ose-images-into-cluster.sh` script in the repo.
-This script does a few things:
-
-- Sets up a namespace for pushing the images into.
-- Creates a serviceaccount and grants it permissions to push images to the in-cluster registry.
-- Uses the serviceaccount to `docker login` to the in-cluster registry.
-- Pulls images from the Red Hat internal registry to your local workstation.
-- Pushes them into your in-cluster image registry.
-
-```
-./hack/mirror-ose-images-into-cluster.sh
-```
+Follow the [Mirroring OCP images into your cluster](mirroring-ocp-images.md) guide for instructions.
 
 # Install
 

--- a/Documentation/dev/testing-olm-ocp-install.md
+++ b/Documentation/dev/testing-olm-ocp-install.md
@@ -1,0 +1,135 @@
+# Testing OLM install with OCP content
+
+This document is a summarization of https://docs.google.com/document/d/1t81RSsZbUoGO4r5OgJ1bqAESKt2fM25MvV6pcgQUPSk/edit#, please review this before proceeding as it covers how to request access to the necessary Quay organizations for pulling the OLM app bundles within Quay.io.
+
+# Disable built-in OperatorSources in OCP 4.1:
+
+Disable ClusterVersionOperator management of the Marketplace redhat-operators OperatorSource so we can delete the existing one and install ours.
+
+Store the following yaml in a file named `cvo-overrides.yaml`
+
+```
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  overrides:
+  - kind: OperatorSource
+    name: redhat-operators
+    namespace: openshift-marketplace
+    unmanaged: true
+  - kind: OperatorSource
+    name: community-operators
+    namespace: openshift-marketplace
+    unmanaged: true
+```
+
+Then run:
+
+```
+oc apply -f cvo-overrides.yaml
+```
+
+Delete the redhat-operators OperatorSource:
+
+```
+oc -n openshift-marketplace delete operatorsource redhat-operators
+```
+
+# Disable built-in OperatorSources in OCP 4.2:
+
+Store the following in a file called `operatorhub.yaml`:
+
+```
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+  name: cluster
+spec:
+  disableAllDefaultSources: true
+```
+
+Then apply it:
+
+```
+oc apply -f operatorhub.yaml
+```
+
+# Configure credentials
+
+Next create a secret containing credentials containing your Quay credentials for accessing the app bundles ART builds.
+
+Replace `$QUAY_AUTH_TOKEN` with the actual literal value of your `$QUAY_AUTH_TOKEN` and store this in a file named `marketplace-secret.yaml`
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: marketplacesecret
+  namespace: openshift-marketplace
+type: Opaque
+stringData:
+    token: "$QUAY_AUTH_TOKEN"
+```
+
+Next, create it:
+
+```
+oc apply -n openshift-marketplace -f marketplace-secret.yaml
+```
+
+# Configure operator source
+
+Copy the following and store it in a file named `art-applications-operator-source.yaml`:
+
+```
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: art-applications
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  # change to redhat-operators-art for pre-staged content, and use
+  # redhat-operators-stage for testing staging images
+  # redhat-operators to test live images
+  # registryNamespace: redhat-operators-art
+  # registryNamespace: redhat-operators-stage
+  # registryNamespace: redhat-operators
+  authorizationToken:
+    secretName: marketplacesecret
+```
+
+Once you've copied and the file, install the operator source:
+
+```
+oc apply -n openshift-marketplace -f art-applications-operator-source.yaml
+```
+
+# Configure images to be mirrored
+
+First, make sure you have [grpcurl](https://github.com/fullstorydev/grpcurl) installed, this will be used to query package information from the operator-registry pod containing our OLM package.
+
+Next, open a port-forward to the `art-applications` operator-registry:
+
+```
+kubectl -n openshift-marketplace port-forward svc/art-applications 50051 &
+```
+
+Once we have the port-forward opened, we'll use the following script to print the images we're going to use, and then use eval on the output to set the environment variables we need so that our image mirroring script mirrors the correct content into the cluster:
+
+```
+hack/get-metering-package-images.sh
+eval "$(hack/get-metering-package-images.sh)"
+```
+
+# Mirror images from Brew into your cluster's in-cluster image registry
+
+Follow the [Mirroring OCP images into your cluster](mirroring-ocp-images.md) guide for instructions for mirroring images.
+The previous step set some environment variables that the script will automatically use, so just follow the instructions to mirror your images into the cluster.
+
+# Install
+
+Proceed by following [Documentation/olm-install.md](../olm-install.md) and use `metering-ocp` instead of the other metering packages when searching for the package in the UI.

--- a/charts/metering-ansible-operator/ocp-testing-values.yaml
+++ b/charts/metering-ansible-operator/ocp-testing-values.yaml
@@ -1,6 +1,6 @@
 operator:
   image:
-    repository: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator
+    repository: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator
     tag: v4.2
 
 olm:
@@ -8,31 +8,31 @@ olm:
   - name: metering-ansible-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator:v4.2
   - name: metering-reporting-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-reporting-operator:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-reporting-operator:v4.2
   - name: metering-presto
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-presto:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-presto:v4.2
   - name: metering-hive
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-hive:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-hive:v4.2
   - name: metering-hadoop
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-hadoop:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-hadoop:v4.2
   - name: ghostunnel
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-ghostunnel:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-ghostunnel:v4.2
   - name: oauth-proxy
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-oauth-proxy:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-oauth-proxy:v4.2
 
   skipARTPackage: true
 

--- a/hack/get-metering-package-images.sh
+++ b/hack/get-metering-package-images.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# kubectl -n openshift-marketplace port-forward svc/art-applications 50051
+
+grpcurl -plaintext -d '{"pkgName": "metering-ocp", "channelName": "4.2"}' localhost:50051 api.Registry/GetBundleForChannel  | jq '.csvJson' -r | jq '.spec.install.spec.deployments[0].spec.template.spec.containers[] | select(.name=="operator") | .env | map(select(.name | match(".*_IMAGE"))) | map(.value |= (. | ltrimstr("image-registry.openshift-image-registry.svc:5000/"))) | .[] | "export " + .name + "=" + .value' -r

--- a/hack/mirror-ose-image.sh
+++ b/hack/mirror-ose-image.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+IMAGE_NAME=$1
+CLUSTER_REGISTRY_URL=$2
+
+OSE_IMAGE_REPO="${OSE_IMAGE_REPO:-"brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888"}"
+
+if [[ -z $IMAGE_NAME ]]; then
+        echo "must pass a image name as the first arg"
+        exit 1
+fi
+
+if [[ -z $CLUSTER_REGISTRY_URL ]]; then
+        echo "must pass the cluster registry hostname as the second arg"
+        exit 1
+fi
+
+DOCKER_COMMAND=${DOCKER_COMMAND:-docker}
+
+set -x
+"$DOCKER_COMMAND" pull "$OSE_IMAGE_REPO/$IMAGE_NAME"
+"$DOCKER_COMMAND" tag "$OSE_IMAGE_REPO/$IMAGE_NAME" "$CLUSTER_REGISTRY_URL/$IMAGE_NAME"
+"$DOCKER_COMMAND" push "$CLUSTER_REGISTRY_URL/$IMAGE_NAME"
+
+set +x
+echo "$IMAGE_NAME is added to the cluster"

--- a/manifests/deploy/ocp-testing/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/ocp-testing/metering-ansible-operator/metering-operator-deployment.yaml
@@ -24,14 +24,14 @@ spec:
         - /opt/ansible/scripts/ansible-logs.sh
         - /tmp/ansible-operator/runner
         - stdout
-        image: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator:v4.2"
+        image: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator:v4.2"
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner
           readOnly: true
       - name: operator
-        image: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator:v4.2"
+        image: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator:v4.2"
         imagePullPolicy: Always
         env:
         - name: OPERATOR_NAME
@@ -47,19 +47,19 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: METERING_ANSIBLE_OPERATOR_IMAGE
-          value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator:v4.2"
+          value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator:v4.2"
         - name: METERING_REPORTING_OPERATOR_IMAGE
-          value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-reporting-operator:v4.2"
+          value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-reporting-operator:v4.2"
         - name: METERING_PRESTO_IMAGE
-          value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-presto:v4.2"
+          value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-presto:v4.2"
         - name: METERING_HIVE_IMAGE
-          value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-hive:v4.2"
+          value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-hive:v4.2"
         - name: METERING_HADOOP_IMAGE
-          value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-hadoop:v4.2"
+          value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-hadoop:v4.2"
         - name: GHOSTUNNEL_IMAGE
-          value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-ghostunnel:v4.2"
+          value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-ghostunnel:v4.2"
         - name: OAUTH_PROXY_IMAGE
-          value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-oauth-proxy:v4.2"
+          value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-oauth-proxy:v4.2"
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner

--- a/manifests/deploy/ocp-testing/olm/bundle/4.2/image-references
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.2/image-references
@@ -5,30 +5,30 @@ spec:
   tags:
   - from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator:v4.2
     name: metering-ansible-operator
   - from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-reporting-operator:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-reporting-operator:v4.2
     name: metering-reporting-operator
   - from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-presto:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-presto:v4.2
     name: metering-presto
   - from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-hive:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-hive:v4.2
     name: metering-hive
   - from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-hadoop:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-hadoop:v4.2
     name: metering-hadoop
   - from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-ghostunnel:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-ghostunnel:v4.2
     name: ghostunnel
   - from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-oauth-proxy:v4.2
+      name: image-registry.openshift-image-registry.svc:5000/openshift/ose-oauth-proxy:v4.2
     name: oauth-proxy
 

--- a/manifests/deploy/ocp-testing/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
@@ -446,14 +446,14 @@ spec:
                   - /opt/ansible/scripts/ansible-logs.sh
                   - /tmp/ansible-operator/runner
                   - stdout
-                  image: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator:v4.2"
+                  image: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator:v4.2"
                   imagePullPolicy: Always
                   volumeMounts:
                   - mountPath: /tmp/ansible-operator/runner
                     name: runner
                     readOnly: true
                 - name: operator
-                  image: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator:v4.2"
+                  image: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator:v4.2"
                   imagePullPolicy: Always
                   env:
                   - name: OPERATOR_NAME
@@ -469,19 +469,19 @@ spec:
                       fieldRef:
                         fieldPath: metadata.name
                   - name: METERING_ANSIBLE_OPERATOR_IMAGE
-                    value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-ansible-operator:v4.2"
+                    value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-ansible-operator:v4.2"
                   - name: METERING_REPORTING_OPERATOR_IMAGE
-                    value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-reporting-operator:v4.2"
+                    value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-reporting-operator:v4.2"
                   - name: METERING_PRESTO_IMAGE
-                    value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-presto:v4.2"
+                    value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-presto:v4.2"
                   - name: METERING_HIVE_IMAGE
-                    value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-hive:v4.2"
+                    value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-hive:v4.2"
                   - name: METERING_HADOOP_IMAGE
-                    value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-metering-hadoop:v4.2"
+                    value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-metering-hadoop:v4.2"
                   - name: GHOSTUNNEL_IMAGE
-                    value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-ghostunnel:v4.2"
+                    value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-ghostunnel:v4.2"
                   - name: OAUTH_PROXY_IMAGE
-                    value: "image-registry.openshift-image-registry.svc:5000/openshift-metering-images/ose-oauth-proxy:v4.2"
+                    value: "image-registry.openshift-image-registry.svc:5000/openshift/ose-oauth-proxy:v4.2"
                   volumeMounts:
                   - mountPath: /tmp/ansible-operator/runner
                     name: runner


### PR DESCRIPTION
- Updates mirroring scripts to support different image tags per image, as is the case with the CSVs published by ART.
- Adds a script to extract the metering-ocp package CSV from the operator-registry pod created with the test ART OperatorSource. This script is used to set environment variables that are used by the image mirroring script.
- New documentation covering how to test ART published OCP OLM package bundles.