### PR TITLE
Add a cobra cli that manages the deployment process of metering.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ include build/check_defined.mk
 # Package
 GO_PKG := github.com/operator-framework/operator-metering
 REPORTING_OPERATOR_PKG := $(GO_PKG)/cmd/reporting-operator
+DEPLOY_PKG := $(GO_PKG)/cmd/deploy
 # these are directories/files which get auto-generated or get reformated by
 # gofmt
 VERIFY_FILE_PATHS := cmd pkg test manifests Gopkg.lock
@@ -54,6 +55,7 @@ GO_BUILD_ARGS := -ldflags '-extldflags "-static"'
 GOOS = "linux"
 CGO_ENABLED = 0
 
+DEPLOY_BIN_OUT = bin/operator-metering
 REPORTING_OPERATOR_BIN_OUT = bin/reporting-operator
 REPORTING_OPERATOR_BIN_OUT_LOCAL = bin/reporting-operator-local
 RUN_UPDATE_CODEGEN ?= true
@@ -221,6 +223,9 @@ metering-manifests:
 bin/test2json: gotools/test2json/main.go
 	go build -o bin/test2json gotools/test2json/main.go
 
+deploy:
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) go build $(GO_BUILD_ARGS) -o $(DEPLOY_BIN_OUT) $(DEPLOY_PKG)
+
 .PHONY: \
 	test vendor fmt verify \
 	update-codegen verify-codegen \
@@ -228,6 +233,7 @@ bin/test2json: gotools/test2json/main.go
 	docker-build-all docker-tag-all docker-push-all \
 	metering-test-docker \
 	metering-src-docker-build \
+	deploy \
 	build-reporting-operator reporting-operator-bin reporting-operator-local \
 	metering-manifests \
 	install-kube-prometheus-helm

--- a/cmd/deploy-metering/main.go
+++ b/cmd/deploy-metering/main.go
@@ -52,54 +52,24 @@ var (
 )
 
 func init() {
-	uninstallCmd.Flags().StringVar(&cfg.Namespace, "namespace", "", "The namespace to install the metering resources. This can also be specified through the METERING_NAMESPACE ENV var.")
-	uninstallCmd.Flags().StringVar(&cfg.Platform, "platform", "openshift", "The platform to install the metering stack on. Supported options are 'openshift', 'upstream', or 'ocp-testing'. This can also be specified through the DEPLOY_PLATFORM ENV var.")
-	uninstallCmd.Flags().StringVar(&cfg.MeteringCR, "meteringconfig", "", "The absolute/relative path to the MeteringConfig custom resource. This can also be specified through the METERING_CR_FILE ENV var")
-	uninstallCmd.Flags().StringVar(&cfg.ManifestLocation, "manifest-dir", "", "The absolute/relative path to the metering manfiest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR")
+	rootCmd.PersistentFlags().StringVar(&cfg.Namespace, "namespace", "", "The namespace to install the metering resources. This can also be specified through the METERING_NAMESPACE ENV var.")
+	rootCmd.PersistentFlags().StringVar(&cfg.Platform, "platform", "openshift", "The platform to install the metering stack on. Supported options are 'openshift', 'upstream', or 'ocp-testing'. This can also be specified through the DEPLOY_PLATFORM ENV var.")
+	rootCmd.PersistentFlags().StringVar(&cfg.MeteringCR, "meteringconfig", "", "The absolute/relative path to the MeteringConfig custom resource. This can also be specified through the METERING_CR_FILE ENV var.")
+	rootCmd.PersistentFlags().StringVar(&cfg.DeployManifestsDirectory, "deploy-manifests-dir", "manifests/deploy", "The absolute/relative path to the metering manifest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR.")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", log.DebugLevel.String(), "The logging level when deploying metering")
+
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRDs, "delete-crd", false, "If true, this would delete the metering CRDs during an uninstall. This can also be specified through the METERING_DELETE_CRDS ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRB, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteNamespace, "delete-namespace", false, "If true, this would delete the namespace during an uninstall. This can also be specified through the METERING_DELETE_NAMESPACE ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeletePVCs, "delete-pvc", true, "If true, this would delete the PVCs used by metering resources during an uninstall. This can also be specified through the METERING_DELETE_PVCS ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteAll, "delete-all", false, "If true, this would delete the all metering resources during an uninstall. This can also be specified through the METERING_DELETE_ALL ENV var.")
 
-	installCmd.Flags().StringVar(&cfg.Namespace, "namespace", "", "The namespace to install the metering resources. This can also be specified through the METERING_NAMESPACE ENV var.")
-	installCmd.Flags().StringVar(&cfg.Platform, "platform", "openshift", "The platform to install the metering stack on. Supported options are 'openshift', 'upstream', or 'ocp-testing'. This can also be specified through the DEPLOY_PLATFORM ENV var.")
-	installCmd.Flags().StringVar(&cfg.MeteringCR, "meteringconfig", "", "The absolute/relative path to the MeteringConfig custom resource. This can also be specified through the METERING_CR_FILE ENV var")
-	installCmd.Flags().StringVar(&cfg.DeployManifestsDirectory, "deploy-manifests-dir", "manifests/deploy", "The absolute/relative path to the metering manfiest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR")
-	installCmd.Flags().StringVar(&cfg.Repo, "repo", "", "The name of the metering-ansible-operator image repository. This can also be specified through the METERING_OPERATOR_IMAGE_REPO ENV var")
-	installCmd.Flags().StringVar(&cfg.Tag, "tag", "", "The name of the metering-ansible-operator image tag. This can also be specified through the METERING_OPERATOR_IMAGE_TAG ENV var")
+	installCmd.Flags().StringVar(&cfg.Repo, "repo", "", "The name of the metering-ansible-operator image repository. This can also be specified through the METERING_OPERATOR_IMAGE_REPO ENV var.")
+	installCmd.Flags().StringVar(&cfg.Tag, "tag", "", "The name of the metering-ansible-operator image tag. This can also be specified through the METERING_OPERATOR_IMAGE_TAG ENV var.")
 	installCmd.Flags().BoolVar(&cfg.SkipMeteringDeployment, "skip-metering-operator-deployment", false, "If true, only create the metering namespace, CRDs, and MeteringConfig resources. This can also be specified through the SKIP_METERING_OPERATOR_DEPLOY ENV var.")
 
-	installEnv := map[string]string{
-		"METERING_NAMESPACE":                "namespace",
-		"DEPLOY_PLATFORM":                   "platform",
-		"METERING_CR_FILE":                  "meteringconfig",
-		"SKIP_METERING_OPERATOR_DEPLOYMENT": "skip-metering-operator-deployment",
-		"DEPLOY_MANIFESTS_DIR":              "deploy-manifests-dir",
-		"METERING_OPERATOR_IMAGE_REPO":      "repo",
-		"METERING_OPERATOR_IMAGE_TAG":       "tag",
-	}
-
-	err := mapEnvVarToFlag(installEnv, installCmd.Flags())
-	if err != nil {
+	if err := initFlagsFromEnv(); err != nil {
 		log.WithError(err).Fatalf("Failed to update flags from ENV vars: %v", err)
-	}
-
-	uninstallEnv := map[string]string{
-		"METERING_NAMESPACE":        "namespace",
-		"DEPLOY_PLATFORM":           "platform",
-		"METERING_CR_FILE":          "meteringconfig",
-		"DEPLOY_MANIFESTS_DIR":      "deploy-manifests-dir",
-		"METERING_DELETE_CRB":       "delete-crb",
-		"METERING_DELETE_CRDS":      "delete-crd",
-		"METERING_DELETE_PVCS":      "delete-pvc",
-		"METERING_DELETE_NAMESPACE": "delete-namespace",
-		"METERING_DELETE_ALL":       "delete-all",
-	}
-
-	err = mapEnvVarToFlag(uninstallEnv, uninstallCmd.Flags())
-	if err != nil {
-		log.WithError(err).Fatalf("Failed to update flags from ENV vars (uninstall): %v", err)
 	}
 }
 
@@ -185,6 +155,56 @@ func setupLogger(logLevelStr string) log.FieldLogger {
 	logger.Logger.Level = logLevel
 
 	return logger
+}
+
+func initFlagsFromEnv() error {
+	flagEnvConf := []struct {
+		cmd *cobra.Command
+		env map[string]string
+	}{
+		{
+			cmd: rootCmd,
+			env: map[string]string{
+				"METERING_NAMESPACE":        "namespace",
+				"DEPLOY_PLATFORM":           "platform",
+				"METERING_CR_FILE":          "meteringconfig",
+				"DEPLOY_MANIFESTS_DIR":      "deploy-manifests-dir",
+				"METERING_DEPLOY_LOG_LEVEL": "log-level",
+			},
+		},
+		{
+			cmd: uninstallCmd,
+			env: map[string]string{
+				"METERING_DELETE_CRB":       "delete-crb",
+				"METERING_DELETE_CRDS":      "delete-crd",
+				"METERING_DELETE_PVCS":      "delete-pvc",
+				"METERING_DELETE_NAMESPACE": "delete-namespace",
+				"METERING_DELETE_ALL":       "delete-all",
+			},
+		},
+		{
+			cmd: installCmd,
+			env: map[string]string{
+				"SKIP_METERING_OPERATOR_DEPLOYMENT": "skip-metering-operator-deployment",
+				"METERING_OPERATOR_IMAGE_REPO":      "repo",
+				"METERING_OPERATOR_IMAGE_TAG":       "tag",
+			},
+		},
+	}
+
+	for _, flagConf := range flagEnvConf {
+		flagSet := flagConf.cmd.Flags()
+
+		if flagConf.cmd.HasPersistentFlags() {
+			flagSet = flagConf.cmd.PersistentFlags()
+		}
+
+		if err := mapEnvVarToFlag(flagConf.env, flagSet); err != nil {
+			log.WithError(err).Fatalf("Failed to update flags from ENV vars (%s): %v", flagConf.cmd.Name(), err)
+		}
+	}
+
+	return nil
 }
 
 // mapEnvVarToFlag takes a mapping of ENV var names to flag names and iterates

--- a/cmd/deploy-metering/main.go
+++ b/cmd/deploy-metering/main.go
@@ -23,7 +23,7 @@ var (
 	logLevel   string
 
 	rootCmd = &cobra.Command{
-		Use:   "operator-metering",
+		Use:   "deploy-metering",
 		Short: "Deploying the metering operator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()

--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -65,7 +65,7 @@ func init() {
 	installCmd.Flags().StringVar(&cfg.Namespace, "namespace", "", "The namespace to install the metering resources. This can also be specified through the METERING_NAMESPACE ENV var.")
 	installCmd.Flags().StringVar(&cfg.Platform, "platform", "openshift", "The platform to install the metering stack on. Supported options are 'openshift', 'upstream', or 'ocp-testing'. This can also be specified through the DEPLOY_PLATFORM ENV var.")
 	installCmd.Flags().StringVar(&cfg.MeteringCR, "meteringconfig", "", "The absolute/relative path to the MeteringConfig custom resource. This can also be specified through the METERING_CR_FILE ENV var")
-	installCmd.Flags().StringVar(&cfg.ManifestLocation, "manifest-dir", "", "The absolute/relative path to the metering manfiest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR")
+	installCmd.Flags().StringVar(&cfg.DeployManifestsDirectory, "deploy-manifests-dir", "manifests/deploy", "The absolute/relative path to the metering manfiest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR")
 	installCmd.Flags().StringVar(&cfg.Repo, "repo", "", "The name of the metering-ansible-operator image repository. This can also be specified through the METERING_OPERATOR_IMAGE_REPO ENV var")
 	installCmd.Flags().StringVar(&cfg.Tag, "tag", "", "The name of the metering-ansible-operator image tag. This can also be specified through the METERING_OPERATOR_IMAGE_TAG ENV var")
 	installCmd.Flags().BoolVar(&cfg.SkipMeteringDeployment, "skip-metering-operator-deployment", false, "If true, only create the metering namespace, CRDs, and MeteringConfig resources. This can also be specified through the SKIP_METERING_OPERATOR_DEPLOY ENV var.")
@@ -75,7 +75,7 @@ func init() {
 		"DEPLOY_PLATFORM":                   "platform",
 		"METERING_CR_FILE":                  "meteringconfig",
 		"SKIP_METERING_OPERATOR_DEPLOYMENT": "skip-metering-operator-deployment",
-		"INSTALLER_MANIFESTS_DIR":           "manifest-dir",
+		"DEPLOY_MANIFESTS_DIR":              "deploy-manifests-dir",
 		"METERING_OPERATOR_IMAGE_REPO":      "repo",
 		"METERING_OPERATOR_IMAGE_TAG":       "tag",
 	}
@@ -89,7 +89,7 @@ func init() {
 		"METERING_NAMESPACE":        "namespace",
 		"DEPLOY_PLATFORM":           "platform",
 		"METERING_CR_FILE":          "meteringconfig",
-		"INSTALLER_MANIFESTS_DIR":   "manifest-dir",
+		"DEPLOY_MANIFESTS_DIR":      "deploy-manifests-dir",
 		"METERING_DELETE_CRB":       "delete-crb",
 		"METERING_DELETE_CRDS":      "delete-crd",
 		"METERING_DELETE_PVCS":      "delete-pvc",

--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
+	"fmt"
 	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	meteringclientv1 "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1"
 	"github.com/operator-framework/operator-metering/pkg/operator/deploy"
@@ -13,9 +17,105 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var (
+	cfg        deploy.Config
+	deployType string
+	logLevel   string
+
+	rootCmd = &cobra.Command{
+		Use:   "operator-metering",
+		Short: "Deploying the metering operator",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	installCmd = &cobra.Command{
+		Use:     "install",
+		Short:   "Install the metering operator",
+		Example: "operator-metering install --platform upstream",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			deployType = "install"
+		},
+		RunE: runDeployMetering,
+	}
+
+	uninstallCmd = &cobra.Command{
+		Use:     "uninstall",
+		Short:   "Uninstall the metering operator",
+		Example: "operator-metering uninstall --delete--all",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			deployType = "uninstall"
+		},
+		RunE: runDeployMetering,
+	}
+)
+
+func init() {
+	uninstallCmd.Flags().StringVar(&cfg.Namespace, "namespace", "", "The namespace to install the metering resources. This can also be specified through the METERING_NAMESPACE ENV var.")
+	uninstallCmd.Flags().StringVar(&cfg.Platform, "platform", "openshift", "The platform to install the metering stack on. Supported options are 'openshift', 'upstream', or 'ocp-testing'. This can also be specified through the DEPLOY_PLATFORM ENV var.")
+	uninstallCmd.Flags().StringVar(&cfg.MeteringCR, "meteringconfig", "", "The absolute/relative path to the MeteringConfig custom resource. This can also be specified through the METERING_CR_FILE ENV var")
+	uninstallCmd.Flags().StringVar(&cfg.ManifestLocation, "manifest-dir", "", "The absolute/relative path to the metering manfiest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR")
+	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRDs, "delete-crd", false, "If true, this would delete the metering CRDs during an uninstall. This can also be specified through the METERING_DELETE_CRDS ENV var.")
+	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRB, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
+	uninstallCmd.Flags().BoolVar(&cfg.DeleteNamespace, "delete-namespace", false, "If true, this would delete the namespace during an uninstall. This can also be specified through the METERING_DELETE_NAMESPACE ENV var.")
+	uninstallCmd.Flags().BoolVar(&cfg.DeletePVCs, "delete-pvc", true, "If true, this would delete the PVCs used by metering resources during an uninstall. This can also be specified through the METERING_DELETE_PVCS ENV var.")
+	uninstallCmd.Flags().BoolVar(&cfg.DeleteAll, "delete-all", false, "If true, this would delete the all metering resources during an uninstall. This can also be specified through the METERING_DELETE_ALL ENV var.")
+
+	installCmd.Flags().StringVar(&cfg.Namespace, "namespace", "", "The namespace to install the metering resources. This can also be specified through the METERING_NAMESPACE ENV var.")
+	installCmd.Flags().StringVar(&cfg.Platform, "platform", "openshift", "The platform to install the metering stack on. Supported options are 'openshift', 'upstream', or 'ocp-testing'. This can also be specified through the DEPLOY_PLATFORM ENV var.")
+	installCmd.Flags().StringVar(&cfg.MeteringCR, "meteringconfig", "", "The absolute/relative path to the MeteringConfig custom resource. This can also be specified through the METERING_CR_FILE ENV var")
+	installCmd.Flags().StringVar(&cfg.ManifestLocation, "manifest-dir", "", "The absolute/relative path to the metering manfiest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR")
+	installCmd.Flags().StringVar(&cfg.Repo, "repo", "", "The name of the metering-ansible-operator image repository. This can also be specified through the METERING_OPERATOR_IMAGE_REPO ENV var")
+	installCmd.Flags().StringVar(&cfg.Tag, "tag", "", "The name of the metering-ansible-operator image tag. This can also be specified through the METERING_OPERATOR_IMAGE_TAG ENV var")
+	installCmd.Flags().BoolVar(&cfg.SkipMeteringDeployment, "skip-metering-operator-deployment", false, "If true, only create the metering namespace, CRDs, and MeteringConfig resources. This can also be specified through the SKIP_METERING_OPERATOR_DEPLOY ENV var.")
+
+	installEnv := map[string]string{
+		"METERING_NAMESPACE":                "namespace",
+		"DEPLOY_PLATFORM":                   "platform",
+		"METERING_CR_FILE":                  "meteringconfig",
+		"SKIP_METERING_OPERATOR_DEPLOYMENT": "skip-metering-operator-deployment",
+		"INSTALLER_MANIFESTS_DIR":           "manifest-dir",
+		"METERING_OPERATOR_IMAGE_REPO":      "repo",
+		"METERING_OPERATOR_IMAGE_TAG":       "tag",
+	}
+
+	err := mapEnvVarToFlag(installEnv, installCmd.Flags())
+	if err != nil {
+		log.WithError(err).Fatalf("Failed to update flags from ENV vars: %v", err)
+	}
+
+	uninstallEnv := map[string]string{
+		"METERING_NAMESPACE":        "namespace",
+		"DEPLOY_PLATFORM":           "platform",
+		"METERING_CR_FILE":          "meteringconfig",
+		"INSTALLER_MANIFESTS_DIR":   "manifest-dir",
+		"METERING_DELETE_CRB":       "delete-crb",
+		"METERING_DELETE_CRDS":      "delete-crd",
+		"METERING_DELETE_PVCS":      "delete-pvc",
+		"METERING_DELETE_NAMESPACE": "delete-namespace",
+		"METERING_DELETE_ALL":       "delete-all",
+	}
+
+	err = mapEnvVarToFlag(uninstallEnv, uninstallCmd.Flags())
+	if err != nil {
+		log.WithError(err).Fatalf("Failed to update flags from ENV vars (uninstall): %v", err)
+	}
+}
+
 func main() {
-	logger := setupLogger("info")
-	config := deploy.Config{}
+	rootCmd.AddCommand(installCmd, uninstallCmd)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		log.WithError(err).Fatalf("Failed to deploy metering: %v", err)
+	}
+}
+
+func runDeployMetering(cmd *cobra.Command, args []string) error {
+	var err error
+
+	logger := setupLogger(logLevel)
 
 	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
@@ -24,49 +124,46 @@ func main() {
 
 	restconfig, err := kubeconfig.ClientConfig()
 	if err != nil {
-		logger.Fatalf("Failed to initialize the kubernetes client config: %v", err)
+		return fmt.Errorf("Failed to initialize the kubernetes client config: %v", err)
 	}
 
 	client, err := kubernetes.NewForConfig(restconfig)
 	if err != nil {
-		logger.Fatalf("Failed to initialize the kubernetes clientset: %v", err)
+		return fmt.Errorf("Failed to initialize the kubernetes clientset: %v", err)
 	}
 
 	apiextClient, err := apiextclientv1beta1.NewForConfig(restconfig)
 	if err != nil {
-		logger.Fatalf("Failed to initialize the apiextensions clientset: %v", err)
+		return fmt.Errorf("Failed to initialize the apiextensions clientset: %v", err)
 	}
 
 	meteringClient, err := meteringclientv1.NewForConfig(restconfig)
 	if err != nil {
-		logger.Fatalf("Failed to initialize the metering clientset: %v", err)
+		return fmt.Errorf("Failed to initialize the metering clientset: %v", err)
 	}
 
-	deployObj, err := deploy.NewDeployer(config, client, apiextClient, meteringClient, logger)
+	logger.Debugf("Metering Deploy Config: %#v", cfg)
+
+	deployObj, err := deploy.NewDeployer(cfg, client, apiextClient, meteringClient, logger)
 	if err != nil {
-		logger.Fatalf("Failed to deploy metering: %v", err)
-	}
-
-	deployType := os.Getenv("DEPLOY_TYPE")
-	if deployType == "" {
-		logger.Fatalf("error: you need to set the $DEPLOY_TYPE env var")
+		return fmt.Errorf("Failed to deploy metering: %v", err)
 	}
 
 	if deployType == "install" {
-		err = deployObj.Install()
+		err := deployObj.Install()
 		if err != nil {
-			logger.Fatalf("Failed to install metering resources: %v", err)
+			return fmt.Errorf("Failed to install metering: %v", err)
 		}
 		logger.Infof("Finished installing metering")
 	} else if deployType == "uninstall" {
-		err = deployObj.Uninstall()
+		err := deployObj.Uninstall()
 		if err != nil {
-			logger.Fatalf("Failed to uninstall metering resources: %v", err)
+			return fmt.Errorf("Failed to uninstall metering: %v", err)
 		}
-		logger.Infof("Finished uninstalling metering")
+		logger.Infof("Finished uninstall metering")
 	}
 
-	logger.Infof("Finished deploying metering")
+	return nil
 }
 
 func setupLogger(logLevelStr string) log.FieldLogger {
@@ -88,4 +185,25 @@ func setupLogger(logLevelStr string) log.FieldLogger {
 	logger.Logger.Level = logLevel
 
 	return logger
+}
+
+// mapEnvVarToFlag takes a mapping of ENV var names to flag names and iterates
+// over that mapping attempting to set the flag value with the ENV var key name.
+// see: https://github.com/spf13/viper/issues/461
+func mapEnvVarToFlag(vars map[string]string, flagset *pflag.FlagSet) error {
+	for env, flag := range vars {
+		flagObj := flagset.Lookup(flag)
+		if flagObj == nil {
+			return fmt.Errorf("The %s flag doesn't exist", flag)
+		}
+
+		if val := os.Getenv(env); val != "" {
+			if err := flagObj.Value.Set(val); err != nil {
+				return fmt.Errorf("Failed to set the %s flag: %v", flag, err)
+			}
+		}
+
+	}
+
+	return nil
 }

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -100,30 +100,24 @@ func NewDeployer(
 		config:         cfg,
 	}
 
-	meteringNamespace := os.Getenv("METERING_NAMESPACE")
-	if meteringNamespace == "" {
-		return nil, fmt.Errorf("Failed to set $METERING_NAMESPACE")
+	if deploy.config.Namespace == "" {
+		return deploy, fmt.Errorf("Failed to set the --namespace flag or $METERING_NAMESPACE ENV var")
 	}
-
-	deploy.config.Namespace = meteringNamespace
 	deploy.logger.Infof("Metering Deploy Namespace: %s", deploy.config.Namespace)
 
-	manifestOverrideLocation := os.Getenv("INSTALLER_MANIFESTS_DIR")
-	if manifestOverrideLocation != "" {
-		deploy.config.ManifestLocation, err = filepath.Abs(manifestOverrideLocation)
+	if deploy.config.ManifestLocation != "" {
+		deploy.config.ManifestLocation, err = filepath.Abs(deploy.config.ManifestLocation)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to override the manifest location: %v", err)
+			return nil, fmt.Errorf("Failed to override the manifest location %s: %v", deploy.config.ManifestLocation, err)
+		}
+
+		_, err = os.Stat(deploy.config.ManifestLocation)
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("Failed to set $INSTALL_MANIFESTS_DIR or --manifest-dir to a valid path: %v", err)
 		}
 
 		deploy.logger.Infof("Overrided manifest location: %s", deploy.config.ManifestLocation)
 	} else {
-		deployPlatform := os.Getenv("DEPLOY_PLATFORM")
-		if deployPlatform == "" {
-			deploy.config.Platform = "openshift"
-		} else {
-			deploy.config.Platform = deployPlatform
-		}
-
 		defaultManifestBase, err := filepath.Abs(manifestDeployDirname)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get the absolute path of the manifest/deploy directory: %v", err)
@@ -137,69 +131,23 @@ func NewDeployer(
 		case "ocp-testing":
 			deploy.config.ManifestLocation = filepath.Join(defaultManifestBase, ocpTestingManifestDirname, manifestAnsibleOperator)
 		default:
-			return nil, fmt.Errorf("Failed to set $DEPLOY_PLATFORM to an invalid value. Supported types: [upstream, openshift, ocp-testing]")
+			return deploy, fmt.Errorf("Failed to set $DEPLOY_PLATFORM or --platform flag to a valid value. Supported platforms: [upstream, openshift, ocp-testing]")
 		}
 
 		deploy.logger.Infof("Metering Deploy Platform: %s", deploy.config.Platform)
 	}
 
-	meteringCRFile := os.Getenv("METERING_CR_FILE")
-	if meteringCRFile == "" {
-		deploy.logger.Info("The $METERING_CR_FILE env var is unset, using the default MeteringConfig manifest")
-		deploy.config.MeteringCR = deploy.config.ManifestLocation + defaultMeteringConfig
-	} else {
-		deploy.config.MeteringCR = meteringCRFile
-	}
-
-	deploy.config.DeleteAll, err = getBoolEnv("METERING_DELETE_ALL", false)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read $METERING_DELETE_ALL: %v", err)
-	}
-
 	if deploy.config.DeleteAll {
-		deploy.config.DeleteCRDs = true
-		deploy.config.DeleteCRB = true
-		deploy.config.DeleteNamespace = true
 		deploy.config.DeletePVCs = true
-	} else {
-		deploy.config.DeleteCRDs, err = getBoolEnv("METERING_DELETE_CRDS", false)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to read $METERING_DELETE_CRDS: %v", err)
-		}
-
-		deploy.config.DeleteCRB, err = getBoolEnv("METERING_DELETE_CRB", false)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to read $METERING_DELETE_CRB: %v", err)
-		}
-
-		deploy.config.DeleteNamespace, err = getBoolEnv("METERING_DELETE_NAMESPACE", false)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to read $METERING_DELETE_NAMESPACE: %v", err)
-		}
-
-		deploy.config.DeletePVCs, err = getBoolEnv("METERING_DELETE_PVCS", true)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to read $METERING_DELETE_PVCS: %v", err)
-		}
-	}
-
-	deploy.config.SkipMeteringDeployment, err = getBoolEnv("SKIP_METERING_OPERATOR_DEPLOYMENT", false)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read $SKIP_METERING_OPERATOR_DEPLOYMENT: %v", err)
-	}
-
-	imageRepo := os.Getenv("METERING_OPERATOR_IMAGE_REPO")
-	if imageRepo != "" {
-		deploy.config.Repo = imageRepo
-	}
-
-	imageTag := os.Getenv("METERING_OPERATOR_IMAGE_TAG")
-	if imageTag != "" {
-		deploy.config.Tag = imageTag
+		deploy.config.DeleteNamespace = true
+		deploy.config.DeleteCRB = true
+		deploy.config.DeleteCRDs = true
 	}
 
 	// initialize a slice of CRD structures and assign to the deploy.crds field
 	// this is used by the install/uninstall drivers to manage the metering CRDs
+	// TODO: this is awkward that the deploy object has all fields initialized but
+	// deploy.crds at the start
 	deploy.initMeteringCRDSlice()
 
 	return deploy, nil

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -52,18 +52,18 @@ type CRD struct {
 // platform to deploy on, whether or not to delete the metering CRDs,
 // or namespace during an install, the location to the manifests dir, etc.
 type Config struct {
-	Namespace              string
-	Platform               string
-	ManifestLocation       string
-	MeteringCR             string
-	SkipMeteringDeployment bool
-	DeleteCRDs             bool
-	DeleteCRB              bool
-	DeleteNamespace        bool
-	DeletePVCs             bool
-	DeleteAll              bool
-	Repo                   string
-	Tag                    string
+	Namespace                string
+	Platform                 string
+	DeployManifestsDirectory string
+	MeteringCR               string
+	SkipMeteringDeployment   bool
+	DeleteCRDs               bool
+	DeleteCRB                bool
+	DeleteNamespace          bool
+	DeletePVCs               bool
+	DeleteAll                bool
+	Repo                     string
+	Tag                      string
 }
 
 // Deployer holds all the information needed to handle the deployment
@@ -71,12 +71,13 @@ type Config struct {
 // to provision and remove all the metering resources, and a customized
 // deployment configuration.
 type Deployer struct {
-	config         Config
-	crds           []CRD
-	logger         log.FieldLogger
-	client         *kubernetes.Clientset
-	apiExtClient   apiextclientv1beta1.CustomResourceDefinitionsGetter
-	meteringClient *metering.MeteringV1Client
+	config                           Config
+	crds                             []CRD
+	ansibleOperatorManifestsLocation string
+	logger                           log.FieldLogger
+	client                           *kubernetes.Clientset
+	apiExtClient                     apiextclientv1beta1.CustomResourceDefinitionsGetter
+	meteringClient                   *metering.MeteringV1Client
 }
 
 // NewDeployer creates a new reference to a deploy structure, and then calls helper
@@ -101,40 +102,46 @@ func NewDeployer(
 	}
 
 	if deploy.config.Namespace == "" {
-		return deploy, fmt.Errorf("Failed to set the --namespace flag or $METERING_NAMESPACE ENV var")
+		return deploy, fmt.Errorf("Failed to set $METERING_NAMESPACE or --namespace flag")
 	}
 	deploy.logger.Infof("Metering Deploy Namespace: %s", deploy.config.Namespace)
 
-	if deploy.config.ManifestLocation != "" {
-		deploy.config.ManifestLocation, err = filepath.Abs(deploy.config.ManifestLocation)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to override the manifest location %s: %v", deploy.config.ManifestLocation, err)
-		}
+	if deploy.config.DeployManifestsDirectory == "" {
+		return nil, fmt.Errorf("Failed to set the $DEPLOY_MANIFESTS_DIR or --deploy-manifests-dir flag to a non-empty value")
+	}
 
-		_, err = os.Stat(deploy.config.ManifestLocation)
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("Failed to set $INSTALL_MANIFESTS_DIR or --manifest-dir to a valid path: %v", err)
-		}
+	deployDir, err := filepath.Abs(deploy.config.DeployManifestsDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get the absolute path of the manifest/deploy directory %s: %v", deploy.config.DeployManifestsDirectory, err)
+	}
 
-		deploy.logger.Infof("Overrided manifest location: %s", deploy.config.ManifestLocation)
-	} else {
-		defaultManifestBase, err := filepath.Abs(manifestDeployDirname)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get the absolute path of the manifest/deploy directory: %v", err)
-		}
+	dirStat, err := os.Stat(deploy.config.DeployManifestsDirectory)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("Failed to get the stat the manifest/deploy directory %s: %v", deploy.config.DeployManifestsDirectory, err)
+	}
+	if !dirStat.IsDir() {
+		return nil, fmt.Errorf("Specified deploy directory '%s' is not a directory", deploy.config.DeployManifestsDirectory)
+	}
 
-		switch strings.ToLower(deploy.config.Platform) {
-		case "upstream":
-			deploy.config.ManifestLocation = filepath.Join(defaultManifestBase, upstreamManifestDirname, manifestAnsibleOperator)
-		case "openshift":
-			deploy.config.ManifestLocation = filepath.Join(defaultManifestBase, openshiftManifestDirname, manifestAnsibleOperator)
-		case "ocp-testing":
-			deploy.config.ManifestLocation = filepath.Join(defaultManifestBase, ocpTestingManifestDirname, manifestAnsibleOperator)
-		default:
-			return deploy, fmt.Errorf("Failed to set $DEPLOY_PLATFORM or --platform flag to a valid value. Supported platforms: [upstream, openshift, ocp-testing]")
-		}
+	var ansibleOperatorManifestDir string
 
-		deploy.logger.Infof("Metering Deploy Platform: %s", deploy.config.Platform)
+	switch strings.ToLower(deploy.config.Platform) {
+	case "upstream":
+		ansibleOperatorManifestDir = filepath.Join(deployDir, upstreamManifestDirname, manifestAnsibleOperator)
+	case "openshift":
+		ansibleOperatorManifestDir = filepath.Join(deployDir, openshiftManifestDirname, manifestAnsibleOperator)
+	case "ocp-testing":
+		ansibleOperatorManifestDir = filepath.Join(deployDir, ocpTestingManifestDirname, manifestAnsibleOperator)
+	default:
+		return deploy, fmt.Errorf("Failed to set $DEPLOY_PLATFORM or --platform flag to a valid value. Supported platforms: [upstream, openshift, ocp-testing]")
+	}
+
+	dirStat, err = os.Stat(ansibleOperatorManifestDir)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("Failed to stat the %s deploy platform directory '%s': %v", deploy.config.Platform, ansibleOperatorManifestDir, err)
+	}
+	if !dirStat.IsDir() {
+		return nil, fmt.Errorf("Specified %s deploy platform directory '%s' is not a directory", deploy.config.Platform, ansibleOperatorManifestDir)
 	}
 
 	if deploy.config.DeleteAll {
@@ -144,10 +151,11 @@ func NewDeployer(
 		deploy.config.DeleteCRDs = true
 	}
 
+	deploy.logger.Infof("Metering Deploy Platform: %s", deploy.config.Platform)
+	deploy.ansibleOperatorManifestsLocation = ansibleOperatorManifestDir
+
 	// initialize a slice of CRD structures and assign to the deploy.crds field
 	// this is used by the install/uninstall drivers to manage the metering CRDs
-	// TODO: this is awkward that the deploy object has all fields initialized but
-	// deploy.crds at the start
 	deploy.initMeteringCRDSlice()
 
 	return deploy, nil

--- a/pkg/operator/deploy/helpers.go
+++ b/pkg/operator/deploy/helpers.go
@@ -53,37 +53,37 @@ func (deploy *Deployer) initMeteringCRDSlice() {
 
 	crds = append(crds, CRD{
 		Name: "hivetables.metering.openshift.io",
-		Path: filepath.Join(deploy.config.ManifestLocation, hivetableFile),
+		Path: filepath.Join(deploy.ansibleOperatorManifestsLocation, hivetableFile),
 		CRD:  new(apiextv1beta1.CustomResourceDefinition),
 	})
 	crds = append(crds, CRD{
 		Name: "prestotables.metering.openshift.io",
-		Path: filepath.Join(deploy.config.ManifestLocation, prestotableFile),
+		Path: filepath.Join(deploy.ansibleOperatorManifestsLocation, prestotableFile),
 		CRD:  new(apiextv1beta1.CustomResourceDefinition),
 	})
 	crds = append(crds, CRD{
 		Name: "storagelocations.metering.openshift.io",
-		Path: filepath.Join(deploy.config.ManifestLocation, storagelocationFile),
+		Path: filepath.Join(deploy.ansibleOperatorManifestsLocation, storagelocationFile),
 		CRD:  new(apiextv1beta1.CustomResourceDefinition),
 	})
 	crds = append(crds, CRD{
 		Name: "reports.metering.openshift.io",
-		Path: filepath.Join(deploy.config.ManifestLocation, reportFile),
+		Path: filepath.Join(deploy.ansibleOperatorManifestsLocation, reportFile),
 		CRD:  new(apiextv1beta1.CustomResourceDefinition),
 	})
 	crds = append(crds, CRD{
 		Name: "reportqueries.metering.openshift.io",
-		Path: filepath.Join(deploy.config.ManifestLocation, reportqueryFile),
+		Path: filepath.Join(deploy.ansibleOperatorManifestsLocation, reportqueryFile),
 		CRD:  new(apiextv1beta1.CustomResourceDefinition),
 	})
 	crds = append(crds, CRD{
 		Name: "reportdatasources.metering.openshift.io",
-		Path: filepath.Join(deploy.config.ManifestLocation, reportdatasourceFile),
+		Path: filepath.Join(deploy.ansibleOperatorManifestsLocation, reportdatasourceFile),
 		CRD:  new(apiextv1beta1.CustomResourceDefinition),
 	})
 	crds = append(crds, CRD{
 		Name: "meteringconfigs.metering.openshift.io",
-		Path: filepath.Join(deploy.config.ManifestLocation, meteringconfigFile),
+		Path: filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringconfigFile),
 		CRD:  new(apiextv1beta1.CustomResourceDefinition),
 	})
 

--- a/pkg/operator/deploy/install.go
+++ b/pkg/operator/deploy/install.go
@@ -96,32 +96,32 @@ func (deploy *Deployer) installMeteringConfig() error {
 }
 
 func (deploy *Deployer) installMeteringResources() error {
-	err := deploy.installMeteringDeployment(filepath.Join(deploy.config.ManifestLocation, meteringDeploymentFile))
+	err := deploy.installMeteringDeployment(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringDeploymentFile))
 	if err != nil {
 		return fmt.Errorf("Failed to create the metering deployment: %v", err)
 	}
 
-	err = deploy.installMeteringServiceAccount(filepath.Join(deploy.config.ManifestLocation, meteringServiceAccountFile))
+	err = deploy.installMeteringServiceAccount(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringServiceAccountFile))
 	if err != nil {
 		return fmt.Errorf("Failed to create the metering service account: %v", err)
 	}
 
-	err = deploy.installMeteringRole(filepath.Join(deploy.config.ManifestLocation, meteringRoleFile))
+	err = deploy.installMeteringRole(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringRoleFile))
 	if err != nil {
 		return fmt.Errorf("Failed to create the metering role: %v", err)
 	}
 
-	err = deploy.installMeteringRoleBinding(filepath.Join(deploy.config.ManifestLocation, meteringRoleBindingFile))
+	err = deploy.installMeteringRoleBinding(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringRoleBindingFile))
 	if err != nil {
 		return fmt.Errorf("Failed to create the metering role binding: %v", err)
 	}
 
-	err = deploy.installMeteringClusterRole(filepath.Join(deploy.config.ManifestLocation, meteringClusterRoleFile))
+	err = deploy.installMeteringClusterRole(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringClusterRoleFile))
 	if err != nil {
 		return fmt.Errorf("Failed to create the metering cluster role: %v", err)
 	}
 
-	err = deploy.installMeteringClusterRoleBinding(filepath.Join(deploy.config.ManifestLocation, meteringClusterRoleBindingFile))
+	err = deploy.installMeteringClusterRoleBinding(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringClusterRoleBindingFile))
 	if err != nil {
 		return fmt.Errorf("Failed to create the metering cluster role binding: %v", err)
 	}

--- a/pkg/operator/deploy/install.go
+++ b/pkg/operator/deploy/install.go
@@ -73,7 +73,7 @@ func (deploy *Deployer) installMeteringConfig() error {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
 
-	mc, err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Get("operator-metering", metav1.GetOptions{})
+	mc, err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Get(res.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Create(&res)
 		if err != nil {

--- a/pkg/operator/deploy/uninstall.go
+++ b/pkg/operator/deploy/uninstall.go
@@ -47,33 +47,33 @@ func (deploy *Deployer) uninstallMeteringConfig() error {
 }
 
 func (deploy *Deployer) uninstallMeteringResources() error {
-	err := deploy.uninstallMeteringDeployment(filepath.Join(deploy.config.ManifestLocation, meteringDeploymentFile))
+	err := deploy.uninstallMeteringDeployment(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringDeploymentFile))
 	if err != nil {
 		return fmt.Errorf("Failed to delete the metering service account: %v", err)
 	}
 
-	err = deploy.uninstallMeteringServiceAccount(filepath.Join(deploy.config.ManifestLocation, meteringServiceAccountFile))
+	err = deploy.uninstallMeteringServiceAccount(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringServiceAccountFile))
 	if err != nil {
 		return fmt.Errorf("Failed to delete the metering service account: %v", err)
 	}
 
-	err = deploy.uninstallMeteringRole(filepath.Join(deploy.config.ManifestLocation, meteringRoleFile))
+	err = deploy.uninstallMeteringRole(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringRoleFile))
 	if err != nil {
 		return fmt.Errorf("Failed to delete the metering role: %v", err)
 	}
 
-	err = deploy.uninstallMeteringRoleBinding(filepath.Join(deploy.config.ManifestLocation, meteringRoleBindingFile))
+	err = deploy.uninstallMeteringRoleBinding(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringRoleBindingFile))
 	if err != nil {
 		return fmt.Errorf("Failed to delete the metering role binding: %v", err)
 	}
 
 	if deploy.config.DeleteCRB {
-		err = deploy.uninstallMeteringClusterRole(filepath.Join(deploy.config.ManifestLocation, meteringClusterRoleFile))
+		err = deploy.uninstallMeteringClusterRole(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringClusterRoleFile))
 		if err != nil {
 			return fmt.Errorf("Failed to delete the metering cluster role: %v", err)
 		}
 
-		err = deploy.uninstallMeteringClusterRoleBinding(filepath.Join(deploy.config.ManifestLocation, meteringClusterRoleBindingFile))
+		err = deploy.uninstallMeteringClusterRoleBinding(filepath.Join(deploy.ansibleOperatorManifestsLocation, meteringClusterRoleBindingFile))
 		if err != nil {
 			return fmt.Errorf("Failed to delete the metering cluster role binding: %v", err)
 		}

--- a/pkg/operator/deploy/uninstall.go
+++ b/pkg/operator/deploy/uninstall.go
@@ -16,7 +16,7 @@ import (
 func (deploy *Deployer) uninstallNamespace() error {
 	err := deploy.client.CoreV1().Namespaces().Delete(deploy.config.Namespace, &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		return fmt.Errorf("The %s namespace doesn't exist", deploy.config.Namespace)
+		deploy.logger.Warnf("The %s namespace doesn't exist", deploy.config.Namespace)
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the %s namespace", deploy.config.Namespace)
 	} else {


### PR DESCRIPTION
### Overview
This PR adds a cobra cli that adds commands/flags which are used to customize the deployment process of metering.

### Building the CLI:
```bash
$ make bin/deploy-metering
```
This creates the `deploy-metering` binary in `./bin/`

### Design
Most of the logic for setting the `Deployer` internal states have moved away from all environment variables, to a mixture of cli flags and environment variables. In the current iteration of this CLI, the value of the cli flags take precedence of the value of the environment variables:
```bash
$ export METERING_NAMESPACE="metering"
$ ./bin/deploy-metering install --namespace test
INFO[09-17-2019 14:54:42] Setting the log level to info                 app=deploy
INFO[09-17-2019 14:54:42] Metering Deploy Namespace: test               app=deploy
...
```

### Example Usage:
##### Vanilla Openshift Install:
```bash
$ ./bin/deploy-metering install
```
##### Vanilla Upstream install:
```bash
$ ./bin/deploy-metering install --platform upstream
```
##### Vanilla Openshift Uninstall:
```bash
$ ./bin/deploy-metering uninstall
```
##### Delete the `$METERING_NAMESPACE` (`--namespace`) namespace:
```bash
$ ./bin/deploy-metering uninstall --delete-namespace
```
