### PR TITLE
pkg/operator: Queue hive StorageLocation when missing DatabaseName

### DIFF
--- a/pkg/operator/aws_usage_hive.go
+++ b/pkg/operator/aws_usage_hive.go
@@ -71,6 +71,7 @@ func (op *Reporting) createAWSUsageHiveTableCR(logger logrus.FieldLogger, dataSo
 			return nil, fmt.Errorf("storage incorrectly configured for ReportDataSource %s, err: %s", dataSource.Name, err)
 		}
 		if hiveStorage.Spec.Hive.DatabaseName == "" {
+			op.enqueueStorageLocation(hiveStorage)
 			return nil, fmt.Errorf("StorageLocation %s Hive database %s does not exist yet", hiveStorage.Name, hiveStorage.Spec.Hive.DatabaseName)
 		}
 		dbName = hiveStorage.Status.Hive.DatabaseName

--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -116,6 +116,7 @@ func (op *Reporting) handlePrometheusMetricsDataSource(logger log.FieldLogger, d
 			return fmt.Errorf("storage incorrectly configured for ReportDataSource %s, err: %v", dataSource.Name, err)
 		}
 		if hiveStorage.Status.Hive.DatabaseName == "" {
+			op.enqueueStorageLocation(hiveStorage)
 			return fmt.Errorf("StorageLocation %s Hive database %s does not exist yet", hiveStorage.Name, hiveStorage.Spec.Hive.DatabaseName)
 		}
 		params := hive.TableParameters{
@@ -503,6 +504,7 @@ func (op *Reporting) handleReportQueryViewDataSource(logger log.FieldLogger, dat
 			return fmt.Errorf("storage incorrectly configured for ReportDataSource %s, err: %v", dataSource.Name, err)
 		}
 		if hiveStorage.Status.Hive.DatabaseName == "" {
+			op.enqueueStorageLocation(hiveStorage)
 			return fmt.Errorf("StorageLocation %s Hive database %s does not exist yet", hiveStorage.Name, hiveStorage.Spec.Hive.DatabaseName)
 		}
 		prestoTables, err := op.prestoTableLister.PrestoTables(dataSource.Namespace).List(labels.Everything())

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -394,6 +394,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *metering.Report) 
 			return fmt.Errorf("storage incorrectly configured for Report %s, err: %v", report.Name, err)
 		}
 		if hiveStorage.Status.Hive.DatabaseName == "" {
+			op.enqueueStorageLocation(hiveStorage)
 			return fmt.Errorf("StorageLocation %s Hive database %s does not exist yet", hiveStorage.Name, hiveStorage.Spec.Hive.DatabaseName)
 		}
 


### PR DESCRIPTION
When something depends on a storageLocation, it should queue it if it's
not yet initialized with the DatabaseName in it's status.