### PR TITLE
Fix package file name on art.yaml

### DIFF
--- a/manifests/deploy/openshift/olm/bundle/art.yaml
+++ b/manifests/deploy/openshift/olm/bundle/art.yaml
@@ -8,7 +8,7 @@ updates:
     # replace spec.version value
     - search: 'version: "4.2.0"'
       replace: 'version: {FULL_VER}'
-  - file: "package.yaml"
+  - file: "metering.package.yaml"
     update_list:
     - search: "currentCSV: metering-operator.v{MAJOR}.{MINOR}.0"
       replace: "currentCSV: metering-operator.{FULL_VER}"


### PR DESCRIPTION
OCP build failing:
```
ose-metering-ansible-operator: /.../manifests/deploy/openshift/olm/bundle/package.yaml
      does not exist as defined in art.yaml
```