### PR TITLE
images,charts: Fix default image overrides from preventing overriding image in MeteringConfig

### DIFF
--- a/charts/openshift-metering/templates/_ghostunnel_helpers.tpl
+++ b/charts/openshift-metering/templates/_ghostunnel_helpers.tpl
@@ -1,0 +1,9 @@
+{{- define "ghostunnel-image" -}}
+{{- if or .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag -}}
+{{- .Values.__ghostunnel.image.repository | default .Values.__ghostunnel.image.defaultRepository }}:{{ .Values.__ghostunnel.image.tag | default .Values.__ghostunnel.image.defaultTag -}}
+{{- else if .Values.__ghostunnel.image.defaultOverride -}}
+{{- .Values.__ghostunnel.image.defaultOverride -}}
+{{- else -}}
+{{- .Values.__ghostunnel.image.defaultRepository }}:{{ .Values.__ghostunnel.image.defaultTag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openshift-metering/templates/hadoop/_hadoop_helpers.tpl
+++ b/charts/openshift-metering/templates/hadoop/_hadoop_helpers.tpl
@@ -1,0 +1,9 @@
+{{- define "hadoop-image" -}}
+{{- if or .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag -}}
+{{- .Values.hadoop.spec.image.repository | default .Values.hadoop.spec.image.defaultRepository }}:{{ .Values.hadoop.spec.image.tag | default .Values.hadoop.spec.image.defaultTag -}}
+{{- else if .Values.hadoop.spec.image.defaultOverride -}}
+{{- .Values.hadoop.spec.image.defaultOverride -}}
+{{- else -}}
+{{-  .Values.hadoop.spec.image.defaultRepository }}:{{ .Values.hadoop.spec.image.defaultTag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
       # would always be resolvable, because on Openshift, clusterIP services
       # NAT loses sourceIPs, breaking HDFS clustering.
       - name: wait-for-namenode
-        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
+        image: "{{ include "hadoop-image" . }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command:
         - '/bin/bash'
@@ -143,7 +143,7 @@ spec:
         - name: namenode-empty
           mountPath: /hadoop/dfs/name
       - name: copy-starter-hadoop
-        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
+        image: "{{ include "hadoop-image" . }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/copy-hadoop-config.sh"]
         env:
@@ -177,7 +177,7 @@ spec:
           defaultMode: 0775
       containers:
       - name: hdfs-datanode
-        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
+        image: "{{ include "hadoop-image" . }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/entrypoint.sh"]
         args: ["/hadoop-scripts/datanode-entrypoint.sh"]

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
 {{- end }}
       initContainers:
       - name: copy-starter-hadoop
-        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
+        image: "{{ include "hadoop-image" . }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/copy-hadoop-config.sh"]
         env:
@@ -139,7 +139,7 @@ spec:
 {{- end }}
       containers:
       - name: hdfs-namenode
-        image: "{{ .Values.hadoop.spec.image.override | default (printf "%s:%s" .Values.hadoop.spec.image.repository .Values.hadoop.spec.image.tag) }}"
+        image: "{{ include "hadoop-image" . }}"
         imagePullPolicy: {{ .Values.hadoop.spec.image.pullPolicy }}
         command: ["/hadoop-scripts/entrypoint.sh"]
         args: ["/hadoop-scripts/namenode-entrypoint.sh"]

--- a/charts/openshift-metering/templates/hive/_hive_helpers.tpl
+++ b/charts/openshift-metering/templates/hive/_hive_helpers.tpl
@@ -36,3 +36,13 @@
       key: aws-secret-access-key
 {{- end }}
 {{- end }}
+
+{{- define "hive-image" -}}
+{{- if or .Values.hive.spec.image.repository .Values.hive.spec.image.tag -}}
+{{- .Values.hive.spec.image.repository | default .Values.hive.spec.image.defaultRepository }}:{{ .Values.hive.spec.image.tag | default .Values.hive.spec.image.defaultTag -}}
+{{- else if .Values.hive.spec.image.defaultOverride -}}
+{{- .Values.hive.spec.image.defaultOverride -}}
+{{- else -}}
+{{-  .Values.hive.spec.image.defaultRepository }}:{{ .Values.hive.spec.image.defaultTag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
 {{- end }}
       initContainers:
       - name: copy-starter-hive
-        image: "{{ .Values.hive.spec.image.override | default (printf "%s:%s" .Values.hive.spec.image.repository .Values.hive.spec.image.tag) }}"
+        image: "{{ include "hive-image" . }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         command: ["/hive-scripts/copy-hadoop-config.sh"]
 {{- if or .Values.hive.spec.config.azure.secretName .Values.hive.spec.config.azure.createSecret }}
@@ -108,7 +108,7 @@ spec:
       - name: metastore
         command: ["/hive-scripts/entrypoint.sh"]
         args: ["/opt/hive/bin/hive", "--service", "metastore"]
-        image: "{{ .Values.hive.spec.image.override | default (printf "%s:%s" .Values.hive.spec.image.repository .Values.hive.spec.image.tag) }}"
+        image: "{{ include "hive-image" . }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         ports:
 {{- if not .Values.hive.spec.metastore.config.tls.enabled }}
@@ -191,7 +191,7 @@ spec:
 {{ toYaml .Values.hive.spec.metastore.resources | indent 10 }}
 {{- if .Values.hive.spec.metastore.config.tls.enabled }}
       - name: ghostunnel-server
-        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
+        image: "{{ include "ghostunnel-image" . }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: HIVE_METASTORE_CA_CRTFILE

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
       initContainers:
 {{- if .Values.hive.spec.server.config.metastoreTLS.enabled }}
       - name: copy-hive-tls
-        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
+        image: "{{ include "ghostunnel-image" . }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_CLIENT_CA_CRTFILE
@@ -97,7 +97,7 @@ spec:
           mountPath: /hive-metastore-auth-tls-secrets
 {{- end }}
       - name: copy-starter-hive
-        image: "{{ .Values.hive.spec.image.override | default (printf "%s:%s" .Values.hive.spec.image.repository .Values.hive.spec.image.tag) }}"
+        image: "{{ include "hive-image" . }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         command: ["/hive-scripts/copy-hadoop-config.sh"]
 {{- if or .Values.hive.spec.config.azure.secretName .Values.hive.spec.config.azure.createSecret }}
@@ -133,7 +133,7 @@ spec:
       - name: hiveserver2
         command: ["/hive-scripts/entrypoint.sh"]
         args: ["/opt/hive/bin/hive", "--service", "hiveserver2"]
-        image: "{{ .Values.hive.spec.image.override | default (printf "%s:%s" .Values.hive.spec.image.repository .Values.hive.spec.image.tag) }}"
+        image: "{{ include "hive-image" . }}"
         imagePullPolicy: {{ .Values.hive.spec.image.pullPolicy }}
         ports:
 {{- if not .Values.hive.spec.server.config.tls.enabled }}
@@ -219,7 +219,7 @@ spec:
 {{ toYaml .Values.hive.spec.server.resources | indent 10 }}
 {{- if .Values.hive.spec.server.config.metastoreTLS.enabled }}
       - name: ghostunnel-client
-        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
+        image: "{{ include "ghostunnel-image" . }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_CLIENT_CA_CRTFILE
@@ -243,7 +243,7 @@ spec:
 {{- end }}
 {{- if .Values.hive.spec.server.config.tls.enabled }}
       - name: ghostunnel-server
-        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
+        image: "{{ include "ghostunnel-image" . }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_SERVER_CA_CRTFILE

--- a/charts/openshift-metering/templates/presto/_presto_helpers.tpl
+++ b/charts/openshift-metering/templates/presto/_presto_helpers.tpl
@@ -100,3 +100,13 @@ connector.name=tpch
       key: aws-secret-access-key
 {{- end }}
 {{- end }}
+
+{{- define "presto-image" -}}
+{{- if or .Values.presto.spec.image.repository .Values.presto.spec.image.tag -}}
+{{- .Values.presto.spec.image.repository | default .Values.presto.spec.image.defaultRepository }}:{{ .Values.presto.spec.image.tag | default .Values.presto.spec.image.defaultTag -}}
+{{- else if .Values.presto.spec.image.defaultOverride -}}
+{{- .Values.presto.spec.image.defaultOverride -}}
+{{- else -}}
+{{-  .Values.presto.spec.image.defaultRepository }}:{{ .Values.presto.spec.image.defaultTag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
 {{- end }}
       initContainers:
       - name: copy-presto-config
-        image: "{{ .Values.presto.spec.image.override | default (printf "%s:%s" .Values.presto.spec.image.repository .Values.presto.spec.image.tag) }}"
+        image: "{{ include "presto-image" . }}"
         imagePullPolicy: {{ .Values.presto.spec.image.pullPolicy }}
         command: ['/presto-common/initialize_presto.sh']
         # Copy the mounted configuration data into the presto-etc emptyDir volume so we can write to the config files
@@ -166,7 +166,7 @@ spec:
             memory: 100Mi
       containers:
       - name: presto
-        image: "{{ .Values.presto.spec.image.override | default (printf "%s:%s" .Values.presto.spec.image.repository .Values.presto.spec.image.tag) }}"
+        image: "{{ include "presto-image" . }}"
         imagePullPolicy: {{ .Values.presto.spec.image.pullPolicy }}
         command: ['/presto-common/entrypoint.sh']
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
@@ -216,7 +216,7 @@ spec:
 {{ toYaml .Values.presto.spec.coordinator.resources | indent 10 }}
 {{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
       - name: ghostunnel-client
-        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
+        image: "{{ include "ghostunnel-image" . }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_CLIENT_CA_CRTFILE

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
 {{- end }}
       initContainers:
       - name: copy-presto-config
-        image: "{{ .Values.presto.spec.image.override | default (printf "%s:%s" .Values.presto.spec.image.repository .Values.presto.spec.image.tag) }}"
+        image: "{{ include "presto-image" . }}"
         imagePullPolicy: {{ .Values.presto.spec.image.pullPolicy }}
         command: ['/presto-common/initialize_presto.sh']
         # Copy the mounted configuration data into the presto-etc emptyDir volume so we can write to the config files
@@ -166,7 +166,7 @@ spec:
             memory: 100Mi
       containers:
       - name: presto
-        image: "{{ .Values.presto.spec.image.override | default (printf "%s:%s" .Values.presto.spec.image.repository .Values.presto.spec.image.tag) }}"
+        image: "{{ include "presto-image" . }}"
         imagePullPolicy: {{ .Values.presto.spec.image.pullPolicy }}
         command: ['/presto-common/entrypoint.sh']
         args: ['/opt/presto/presto-server/bin/launcher', 'run']
@@ -216,7 +216,7 @@ spec:
 {{ toYaml .Values.presto.spec.worker.resources | indent 10 }}
 {{- if .Values.presto.spec.config.connectors.hive.tls.enabled }}
       - name: ghostunnel-client
-        image: "{{ .Values.__ghostunnel.image.override | default (printf "%s:%s" .Values.__ghostunnel.image.repository .Values.__ghostunnel.image.tag) }}"
+        image: "{{ include "ghostunnel-image" . }}"
         imagePullPolicy: {{ .Values.__ghostunnel.image.pullPolicy }}
         env:
         - name: GHOSTUNNEL_CLIENT_CA_CRTFILE

--- a/charts/openshift-metering/templates/reporting-operator/_helpers.tpl
+++ b/charts/openshift-metering/templates/reporting-operator/_helpers.tpl
@@ -1,0 +1,21 @@
+{{- define "reporting-operator-image" -}}
+{{- $operatorValues :=  index .Values "reporting-operator" -}}
+{{- if or $operatorValues.spec.image.repository $operatorValues.spec.image.tag -}}
+{{- $operatorValues.spec.image.repository | default $operatorValues.spec.image.defaultRepository }}:{{ $operatorValues.spec.image.tag | default $operatorValues.spec.image.defaultTag -}}
+{{- else if $operatorValues.spec.image.defaultOverride -}}
+{{- $operatorValues.spec.image.defaultOverride -}}
+{{- else -}}
+{{-  $operatorValues.spec.image.defaultRepository }}:{{ $operatorValues.spec.image.defaultTag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "reporting-operator-auth-proxy-image" -}}
+{{- $operatorValues :=  index .Values "reporting-operator" -}}
+{{- if or $operatorValues.spec.authProxy.image.repository $operatorValues.spec.authProxy.image.tag -}}
+{{- $operatorValues.spec.authProxy.image.repository | default $operatorValues.spec.authProxy.image.defaultRepository }}:{{ $operatorValues.spec.authProxy.image.tag | default $operatorValues.spec.authProxy.image.defaultTag -}}
+{{- else if $operatorValues.spec.authProxy.image.defaultOverride -}}
+{{- $operatorValues.spec.authProxy.image.defaultOverride -}}
+{{- else -}}
+{{-  $operatorValues.spec.authProxy.image.defaultRepository }}:{{ $operatorValues.spec.authProxy.image.defaultTag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -76,7 +76,7 @@ spec:
 {{- end }}
       containers:
       - name: reporting-operator
-        image: "{{ $operatorValues.spec.image.override | default (printf "%s:%s" $operatorValues.spec.image.repository $operatorValues.spec.image.tag) }}"
+        image: "{{ include "reporting-operator-image" . }}"
         imagePullPolicy: {{ $operatorValues.spec.image.pullPolicy }}
         env:
         - name: POD_NAME
@@ -358,7 +358,7 @@ spec:
 {{- end }}
 {{- if $operatorValues.spec.authProxy.enabled }}
       - name: reporting-operator-auth-proxy
-        image: "{{ $operatorValues.spec.authProxy.image.override | default (printf "%s:%s" $operatorValues.spec.authProxy.image.repository $operatorValues.spec.authProxy.image.tag) }}"
+        image: "{{ include "reporting-operator-auth-proxy-image" . }}"
         imagePullPolicy: {{ $operatorValues.spec.authProxy.image.pullPolicy }}
         env:
         - name: NAMESPACE

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -246,9 +246,11 @@ reporting-operator:
 
     image:
       pullPolicy: Always
-      repository: quay.io/openshift/origin-metering-reporting-operator
-      tag: "4.2"
-      override: null
+      defaultRepository: quay.io/openshift/origin-metering-reporting-operator
+      defaultTag: "4.2"
+      defaultOverride: null
+      repository: null
+      tag: null
       pullSecrets: []
 
     updateStrategy:
@@ -404,9 +406,11 @@ reporting-operator:
 
       image:
         pullPolicy: Always
-        repository: quay.io/openshift/origin-oauth-proxy
-        tag: "4.2"
-        override: null
+        defaultRepository: quay.io/openshift/origin-oauth-proxy
+        defaultTag: "4.2"
+        defaultOverride: null
+        repository: null
+        tag: null
         pullSecrets: []
 
       authenticatedEmails:
@@ -450,9 +454,11 @@ presto:
 
     image:
       pullPolicy: Always
-      repository: quay.io/openshift/origin-metering-presto
-      tag: "4.2"
-      override: null
+      defaultRepository: quay.io/openshift/origin-metering-presto
+      defaultTag: "4.2"
+      defaultOverride: null
+      repository: null
+      tag: null
 
     config:
       environment: production
@@ -689,9 +695,11 @@ hive:
 
     image:
       pullPolicy: Always
-      repository: quay.io/openshift/origin-metering-hive
-      tag: "4.2"
-      override: null
+      defaultRepository: quay.io/openshift/origin-metering-hive
+      defaultTag: "4.2"
+      defaultOverride: null
+      repository: null
+      tag: null
       pullSecrets: []
 
     metastore:
@@ -824,9 +832,11 @@ hive:
 __ghostunnel:
   image:
     pullPolicy: Always
-    repository: quay.io/openshift/origin-ghostunnel
-    tag: "4.2"
-    override: null
+    defaultRepository: quay.io/openshift/origin-ghostunnel
+    defaultTag: "4.2"
+    defaultOverride: null
+    repository: null
+    tag: null
 
 hadoop:
   spec:
@@ -865,9 +875,11 @@ hadoop:
 
     image:
       pullPolicy: Always
-      repository: quay.io/openshift/origin-metering-hadoop
-      tag: "4.2"
-      override: null
+      defaultRepository: quay.io/openshift/origin-metering-hadoop
+      defaultTag: "4.2"
+      defaultOverride: null
+      repository: null
+      tag: null
       pullSecrets: null
 
     hdfs:

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -17,67 +17,41 @@ _reporting_op_default_spec: "{{ meteringconfig_default_values['reporting-operato
 _hadoop_default_spec: "{{ meteringconfig_default_values.hadoop.spec }}"
 _ghostunnel_default: "{{ meteringconfig_default_values.__ghostunnel }}"
 
-# Default image repository and tag from the defaults
-meteringconfig_reporting_operator_default_image_repo: "{{ _reporting_op_default_spec.image.repository }}"
-meteringconfig_reporting_operator_default_image_tag: "{{ _reporting_op_default_spec.image.tag }}"
-meteringconfig_oauth_proxy_default_image_repo: "{{ _reporting_op_default_spec.authProxy.image.repository }}"
-meteringconfig_oauth_proxy_default_image_tag: "{{ _reporting_op_default_spec.authProxy.image.tag }}"
-meteringconfig_presto_default_image_repo: "{{ _presto_default_spec.image.repository }}"
-meteringconfig_presto_default_image_tag: "{{ _presto_default_spec.image.tag }}"
-meteringconfig_hive_default_image_repo: "{{ _hive_default_spec.image.repository }}"
-meteringconfig_hive_default_image_tag: "{{ _hive_default_spec.image.tag }}"
-meteringconfig_hadoop_default_image_repo: "{{ _hadoop_default_spec.image.repository }}"
-meteringconfig_hadoop_default_image_tag: "{{ _hadoop_default_spec.image.tag }}"
-meteringconfig_ghostunnel_default_image_repo: "{{ _ghostunnel_default.image.repository }}"
-meteringconfig_ghostunnel_default_image_tag: "{{ _ghostunnel_default.image.tag }}"
-
-meteringconfig_reporting_operator_override_image: "{{ lookup('env', 'METERING_REPORTING_OPERATOR_IMAGE') }}"
-meteringconfig_oauth_proxy_override_image: "{{ lookup('env', 'OAUTH_PROXY_IMAGE') }}"
-meteringconfig_presto_override_image: "{{ lookup('env', 'METERING_PRESTO_IMAGE') }}"
-meteringconfig_hive_override_image: "{{ lookup('env', 'METERING_HIVE_IMAGE') }}"
-meteringconfig_hadoop_override_image: "{{ lookup('env', 'METERING_HADOOP_IMAGE') }}"
-meteringconfig_ghostunnel_override_image: "{{ lookup('env', 'GHOSTUNNEL_IMAGE') }}"
-
-_storage_spec: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides) | json_query('storage') | default({}, true) }}"
+meteringconfig_reporting_operator_default_image_override: "{{ lookup('env', 'METERING_REPORTING_OPERATOR_IMAGE') }}"
+meteringconfig_oauth_proxy_default_image_override: "{{ lookup('env', 'OAUTH_PROXY_IMAGE') }}"
+meteringconfig_presto_default_image_override: "{{ lookup('env', 'METERING_PRESTO_IMAGE') }}"
+meteringconfig_hive_default_image_override: "{{ lookup('env', 'METERING_HIVE_IMAGE') }}"
+meteringconfig_hadoop_default_image_override: "{{ lookup('env', 'METERING_HADOOP_IMAGE') }}"
+meteringconfig_ghostunnel_default_image_override: "{{ lookup('env', 'GHOSTUNNEL_IMAGE') }}"
 
 # Override the default images we use with env vars if set, falling back to the values.yaml configured default if not set.
 meteringconfig_default_image_overrides:
   reporting-operator:
     spec:
       image:
-        repository: "{{ meteringconfig_reporting_operator_default_image_repo }}"
-        tag: "{{ meteringconfig_reporting_operator_default_image_tag }}"
-        override: "{{ meteringconfig_reporting_operator_override_image }}"
+        defaultOverride: "{{ meteringconfig_reporting_operator_default_image_override }}"
 
       authProxy:
         image:
-          repository: "{{ meteringconfig_oauth_proxy_default_image_repo }}"
-          tag: "{{ meteringconfig_oauth_proxy_default_image_tag }}"
-          override: "{{ meteringconfig_oauth_proxy_override_image }}"
+          defaultOverride: "{{ meteringconfig_oauth_proxy_default_image_override }}"
 
   presto:
     spec:
       image:
-        repository: "{{ meteringconfig_presto_default_image_repo }}"
-        tag: "{{ meteringconfig_presto_default_image_tag }}"
-        override: "{{ meteringconfig_presto_override_image }}"
+        defaultOverride: "{{ meteringconfig_presto_default_image_override }}"
   hive:
     spec:
       image:
-        repository: "{{ meteringconfig_hive_default_image_repo }}"
-        tag: "{{ meteringconfig_hive_default_image_tag }}"
-        override: "{{ meteringconfig_hive_override_image }}"
+        defaultOverride: "{{ meteringconfig_hive_default_image_override }}"
   hadoop:
     spec:
       image:
-        repository: "{{ meteringconfig_hadoop_default_image_repo }}"
-        tag: "{{ meteringconfig_hadoop_default_image_tag }}"
-        override: "{{ meteringconfig_hadoop_override_image }}"
+        defaultOverride: "{{ meteringconfig_hadoop_default_image_override }}"
   __ghostunnel:
     image:
-      repository: "{{ meteringconfig_ghostunnel_default_image_repo }}"
-      tag: "{{ meteringconfig_ghostunnel_default_image_tag }}"
-      override: "{{ meteringconfig_ghostunnel_override_image }}"
+      defaultOverride: "{{ meteringconfig_ghostunnel_default_image_override }}"
+
+_storage_spec: "{{ meteringconfig_default_values | combine(meteringconfig_spec_overrides) | json_query('storage') | default({}, true) }}"
 
 _base_storage_overrides:
   s3:


### PR DESCRIPTION
Previously the helm logic always used the image-overrides from the
environment for component images no matter what. Instead, switch to
using more logic in helm templates to determine what options the user
has set to define a proper precedence.

The precedence for image values is the following:

- If the MeteringConfig sets image.repository or image.tag for a
  component, then the value specified will be used. If only one is set,
  then the unset repo/tag option will fallback to the corresponding
  image.repositoryDefault or image.tagDefault defined in the default
  values.yaml in the chart.
- Otherwise, if image.defaultOverride is set, it will be used.
- If no overrides are set, then it defaults to the
  image.repositoryDefault and image.tagDefault.

The default values have moved to image.repositoryDefault and
image.tagDefault so we can distinguish between the user overriding
image/tag values so we can correctly use image.defaultOverride when the
user hasn't specified any image overrides in their MeteringConfig.