### PR TITLE
hack,Makefile: Update the deploy scripts to use the deploy-metering binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ verify-docker: metering-src-docker-build
 		make verify
 
 .PHONY: run-metering-operator-local
-run-metering-operator-local: metering-ansible-operator-docker-build
+run-metering-operator-local: $(DEPLOY_METERING_BIN_OUT) metering-ansible-operator-docker-build
 	export \
 		METERING_OPERATOR_IMAGE_REPO=$(METERING_OPERATOR_IMAGE_REPO) \
 		METERING_OPERATOR_IMAGE_TAG=$(METERING_OPERATOR_IMAGE_TAG); \

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,11 @@ CHECK_GO_FILES ?= true
 REPORTING_OPERATOR_BIN_DEPENDENCIES =
 CODEGEN_SOURCE_GO_FILES =
 CODEGEN_OUTPUT_GO_FILES =
-REPORTING_OPERATOR_GO_FILES =
+GOFILES =
 
 # Adds all the Go files in the repo as a dependency to the build-reporting-operator target
 ifeq ($(CHECK_GO_FILES), true)
-	REPORTING_OPERATOR_GO_FILES := $(shell find $(ROOT_DIR) -name '*.go')
+	GOFILES := $(shell find $(ROOT_DIR) -name '*.go' | grep -v -E '(./vendor)')
 endif
 
 # Adds the update-codegen dependency to the build-reporting-operator target
@@ -199,17 +199,17 @@ run-metering-operator-local: metering-ansible-operator-docker-build
 
 reporting-operator-bin: $(REPORTING_OPERATOR_BIN_OUT)
 
-reporting-operator-local: $(REPORTING_OPERATOR_GO_FILES)
+reporting-operator-local: $(GOFILES)
 	$(MAKE) build-reporting-operator REPORTING_OPERATOR_BIN_OUT=$(REPORTING_OPERATOR_BIN_OUT_LOCAL) GOOS=$(shell go env GOOS)
 
 .PHONY: run-reporting-operator-local
 run-reporting-operator-local: reporting-operator-local
 	./hack/run-reporting-operator-local.sh $(REPORTING_OPERATOR_ARGS)
 
-$(REPORTING_OPERATOR_BIN_OUT): $(REPORTING_OPERATOR_GO_FILES)
+$(REPORTING_OPERATOR_BIN_OUT): $(GOFILES)
 	$(MAKE) build-reporting-operator
 
-build-reporting-operator: $(REPORTING_OPERATOR_BIN_DEPENDENCIES) $(REPORTING_OPERATOR_GO_FILES)
+build-reporting-operator: $(REPORTING_OPERATOR_BIN_DEPENDENCIES) $(GOFILES)
 	@:$(call check_defined, REPORTING_OPERATOR_BIN_OUT, Path to output binary location)
 	mkdir -p $(dir $(REPORTING_OPERATOR_BIN_OUT))
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) go build $(GO_BUILD_ARGS) -o $(REPORTING_OPERATOR_BIN_OUT) $(REPORTING_OPERATOR_PKG)
@@ -223,7 +223,7 @@ metering-manifests:
 $(TEST2JSON_BIN_OUT): gotools/test2json/main.go
 	go build -o $(TEST2JSON_BIN_OUT) gotools/test2json/main.go
 
-$(DEPLOY_METERING_BIN_OUT): cmd/deploy-metering/main.go
+$(DEPLOY_METERING_BIN_OUT): $(GOFILES)
 	go build -o $(DEPLOY_METERING_BIN_OUT) $(GO_PKG)/cmd/deploy-metering
 
 .PHONY: \

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -8,7 +8,8 @@ source "${ROOT_DIR}/hack/common.sh"
 
 : "${UNINSTALL_METERING_BEFORE_INSTALL:=true}"
 : "${INSTALL_METERING:=true}"
-: "${INSTALL_METHOD:=openshift-direct}"
+: "${INSTALL_METHOD:=openshift}"
+: "${UNINSTALL_METHOD:=openshift}"
 : "${METERING_CREATE_PULL_SECRET:=false}"
 : "${METERING_PULL_SECRET_NAME:=metering-pull-secret}"
 : "${DEPLOY_METERING_OPERATOR_LOCAL:=false}"
@@ -20,7 +21,8 @@ fi
 
 if [ "$UNINSTALL_METERING_BEFORE_INSTALL" == "true" ]; then
     echo "Uninstalling metering"
-    kubectl delete ns "$METERING_NAMESPACE" || true
+    export METERING_DELETE_NAMESPACE=true
+    uninstall_metering "${UNINSTALL_METHOD}"
 else
     echo "Skipping uninstall"
 fi
@@ -128,4 +130,3 @@ if [ "$DEPLOY_REPORTING_OPERATOR_LOCAL" == "true" ]; then
     done
     echo "reporting-operator is healthy"
 fi
-

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -39,11 +39,10 @@ function kubectl_files() {
 
 function install_metering() {
     INSTALL_METHOD=$1
-    echo "Installing metering using "$INSTALL_METHOD" install method"
-    if [[ "$INSTALL_METHOD" == "direct" || "$INSTALL_METHOD" == "generic-direct" ]]; then
-        "$ROOT_DIR/hack/install.sh"
-    elif [ "$INSTALL_METHOD" == "openshift-direct" ]; then
-        "$ROOT_DIR/hack/openshift-install.sh"
+    echo "Installing metering using the "$INSTALL_METHOD" install method"
+    if [[ "$INSTALL_METHOD" == "openshift" ]]; then
+        "$ROOT_DIR/bin/deploy-metering" install --log-level debug
+    # TODO: update the deploy package/cli to handle OLM
     elif [ "$INSTALL_METHOD" == "olm" ]; then
         "$ROOT_DIR/hack/olm-install.sh"
     else
@@ -54,11 +53,10 @@ function install_metering() {
 
 function uninstall_metering() {
     INSTALL_METHOD=$1
-    echo "Uninstalling metering using "$INSTALL_METHOD" uninstall method"
-    if [[ "$INSTALL_METHOD" == "direct" || "$INSTALL_METHOD" == "generic-direct" ]]; then
-        "$ROOT_DIR/hack/uninstall.sh"
-    elif [ "$INSTALL_METHOD" == "openshift-direct" ]; then
-        "$ROOT_DIR/hack/openshift-uninstall.sh"
+    echo "Uninstalling metering using the "$INSTALL_METHOD" uninstall method"
+    if [[ "$INSTALL_METHOD" == "openshift" ]]; then
+        "$ROOT_DIR/bin/deploy-metering" uninstall --log-level debug
+    # TODO: update the deploy package/cli to handle OLM
     elif [ "$INSTALL_METHOD" == "olm" ]; then
         "$ROOT_DIR/hack/olm-uninstall.sh"
     else

--- a/hack/run-metering-operator-local.sh
+++ b/hack/run-metering-operator-local.sh
@@ -6,7 +6,7 @@ source "${ROOT_DIR}/hack/common.sh"
 
 : "${METERING_OPERATOR_IMAGE:=${METERING_OPERATOR_IMAGE_REPO}:${METERING_OPERATOR_IMAGE_TAG}}"
 : "${LOCAL_METERING_OPERATOR_RUN_INSTALL:=true}"
-: "${METERING_INSTALL_SCRIPT:=./hack/openshift-install.sh}"
+: "${INSTALL_METHOD:=openshift}"
 : "${METERING_OPERATOR_CONTAINER_NAME:=metering-operator}"
 : "${ENABLE_DEBUG:=false}"
 : "${DISABLE_OCP_FEATURES:=false}"
@@ -15,7 +15,7 @@ set -ex
 
 if [ "$LOCAL_METERING_OPERATOR_RUN_INSTALL" == "true" ]; then
     export SKIP_METERING_OPERATOR_DEPLOYMENT=true
-    "$METERING_INSTALL_SCRIPT"
+    install_metering "${INSTALL_METHOD}"
 fi
 
 VOLUMES=(\


### PR DESCRIPTION
This is based on top of #940, which adds a CLI for deploying metering resources.

In this PR, all the `./hack/*install.sh` and `./hack/*uninstall.sh` scripts are replaced (except for olm) in the deploy scripts and now use the `deploy-metering` binary to manage the metering resources. Also, the `./hack/run-metering-operator-local.sh` now calls the `./hack/lib/util.sh install_metering()` helper function to install metering resources. 

At this moment, only Openshift/OCP and OLM installs are tested in e2e/integration suite. In the future, we can think about testing upstream installs (e.g. `install_metering upstream`) and alter the `install_metering` helper function to call `./bin/deploy-metering install --platform upstream` (or `export DEPLOY_PLATFORM="upstream"` and forgo the platform flag.)