### PR TITLE
bug 1755130: charts,manifests: Fix link to about report docs in OLM CSV package description

### DIFF
--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -233,7 +233,7 @@ olm:
 
       * **Configure AWS Billing Data Source** - Assign Pod $$ costs on using your [AWS billing reports stored in S3](https://docs.openshift.com/container-platform/4.2/metering/configuring-metering/metering-configure-aws-billing-correlation.html).
 
-      * **Use Reports** - Customize what how you process data. [Specify what you want to report on, set the schedule, and reporting time period](https://docs.openshift.com/container-platform/4.2/metering/metering-about-reports.html#metering-reports_metering-about-reports).
+      * **Use Reports** - Customize what how you process data. [Specify what you want to report on, set the schedule, and reporting time period](https://docs.openshift.com/container-platform/4.2/metering/reports/metering-about-reports.html#metering-reports_metering-about-reports).
 
     keywords: ['metering', 'metrics', 'reporting', 'prometheus', 'chargeback']
     icon:

--- a/manifests/deploy/ocp-testing/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
@@ -245,7 +245,7 @@ spec:
 
     * **Configure AWS Billing Data Source** - Assign Pod $$ costs on using your [AWS billing reports stored in S3](https://docs.openshift.com/container-platform/4.2/metering/configuring-metering/metering-configure-aws-billing-correlation.html).
 
-    * **Use Reports** - Customize what how you process data. [Specify what you want to report on, set the schedule, and reporting time period](https://docs.openshift.com/container-platform/4.2/metering/metering-about-reports.html#metering-reports_metering-about-reports).
+    * **Use Reports** - Customize what how you process data. [Specify what you want to report on, set the schedule, and reporting time period](https://docs.openshift.com/container-platform/4.2/metering/reports/metering-about-reports.html#metering-reports_metering-about-reports).
 
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.2.0"

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
@@ -245,7 +245,7 @@ spec:
 
     * **Configure AWS Billing Data Source** - Assign Pod $$ costs on using your [AWS billing reports stored in S3](https://docs.openshift.com/container-platform/4.2/metering/configuring-metering/metering-configure-aws-billing-correlation.html).
 
-    * **Use Reports** - Customize what how you process data. [Specify what you want to report on, set the schedule, and reporting time period](https://docs.openshift.com/container-platform/4.2/metering/metering-about-reports.html#metering-reports_metering-about-reports).
+    * **Use Reports** - Customize what how you process data. [Specify what you want to report on, set the schedule, and reporting time period](https://docs.openshift.com/container-platform/4.2/metering/reports/metering-about-reports.html#metering-reports_metering-about-reports).
 
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.2.0"


### PR DESCRIPTION
See PR title. Fixes a broken link in our package description, which is shown in the OperatorHub UI.