### PR TITLE
*: Update to go 1.12

### DIFF
--- a/Dockerfile.reporting-operator
+++ b/Dockerfile.reporting-operator
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.10 as build
+FROM openshift/origin-release:golang-1.12 as build
 
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering

--- a/Dockerfile.reporting-operator.okd
+++ b/Dockerfile.reporting-operator.okd
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.10 as build
+FROM openshift/origin-release:golang-1.12 as build
 
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering

--- a/Dockerfile.reporting-operator.rhel
+++ b/Dockerfile.reporting-operator.rhel
@@ -1,4 +1,4 @@
-FROM openshift/golang-builder:1.10 AS build
+FROM openshift/golang-builder:1.12 AS build
 
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering

--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -4,7 +4,7 @@ FROM quay.io/openshift/origin-metering-helm:latest as helm
 # image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli as cli
 
-FROM openshift/origin-release:golang-1.10
+FROM openshift/origin-release:golang-1.12
 
 # our copy of faq and jq
 COPY hack/faq.repo /etc/yum.repos.d/ecnahc515-faq-epel-7.repo

--- a/Documentation/dev/developer-guide.md
+++ b/Documentation/dev/developer-guide.md
@@ -4,7 +4,7 @@ This document describes setting up your environment, as well as installing Meter
 
 ## Development Dependencies
 
-- Go 1.10 or higher
+- Go 1.12 or higher
 - Helm CLI 2.6.2 or higher
 - Make
 - Docker

--- a/hack/ocp-util/ocp-image-pull-and-rename.sh
+++ b/hack/ocp-util/ocp-image-pull-and-rename.sh
@@ -12,8 +12,8 @@ docker tag 'rhel7:7-released' 'rhel7'
 docker tag 'rhel7:7-released' 'rhel'
 
 # golang
-docker pull 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/golang-builder:1.10'
-docker tag 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/golang-builder:1.10' openshift/golang-builder:1.10
+docker pull 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/golang-builder:1.12'
+docker tag 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/golang-builder:1.12' openshift/golang-builder:1.12
 
 # openshift base
 docker pull 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift/ose-base:latest'

--- a/pkg/operator/prestostore/importer.go
+++ b/pkg/operator/prestostore/importer.go
@@ -72,9 +72,9 @@ func NewPrometheusImporter(logger logrus.FieldLogger, promConn prom.API, prometh
 		logger:                logger,
 		promConn:              promConn,
 		prometheusMetricsRepo: prometheusMetricsRepo,
-		clock:             clock,
-		cfg:               cfg,
-		metricsCollectors: collectors,
+		clock:                 clock,
+		cfg:                   cfg,
+		metricsCollectors:     collectors,
 	}
 }
 


### PR DESCRIPTION
Updates Dockerfiles to all use Go 1.12 and dev-guide to require Go 1.12