### PR TITLE
Set XDG_CACHE_HOME to /tmp

### DIFF
--- a/Dockerfile.reporting-operator
+++ b/Dockerfile.reporting-operator
@@ -3,6 +3,7 @@ FROM openshift/origin-release:golang-1.12 as build
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering
 
+ENV XDG_CACHE_HOME='/tmp'
 RUN make reporting-operator-bin RUN_UPDATE_CODEGEN=false CHECK_GO_FILES=false
 
 FROM centos:7

--- a/Dockerfile.reporting-operator.okd
+++ b/Dockerfile.reporting-operator.okd
@@ -3,6 +3,8 @@ FROM openshift/origin-release:golang-1.12 as build
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering
 
+ENV XDG_CACHE_HOME='/tmp'
+
 RUN make reporting-operator-bin RUN_UPDATE_CODEGEN=false CHECK_GO_FILES=false
 
 FROM openshift/origin-base:latest

--- a/Dockerfile.reporting-operator.rhel
+++ b/Dockerfile.reporting-operator.rhel
@@ -3,6 +3,7 @@ FROM openshift/golang-builder:1.12 AS build
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering
 
+ENV XDG_CACHE_HOME='/tmp'
 RUN make reporting-operator-bin RUN_UPDATE_CODEGEN=false CHECK_GO_FILES=false
 
 FROM openshift/ose-base:latest

--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -40,4 +40,6 @@ RUN go build -o $TEST2JSON_BIN /go/src/gotools/test2json/main.go \
 
 RUN go get -u github.com/jstemmer/go-junit-report
 
+ENV XDG_CACHE_HOME='/tmp'
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
Running builds as in CI is failing with failed to initialize build cache at /go/.cache: open /go/.cache/log.txt: permission denied