### PR TITLE
cmd,pkg/deploy: Support passing an object to the MeteringConfig resource.

### DIFF
--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	meteringv1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
 	metering "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -52,18 +53,18 @@ type CRD struct {
 // platform to deploy on, whether or not to delete the metering CRDs,
 // or namespace during an install, the location to the manifests dir, etc.
 type Config struct {
-	Namespace                string
-	Platform                 string
-	DeployManifestsDirectory string
-	MeteringCR               string
 	SkipMeteringDeployment   bool
 	DeleteCRDs               bool
 	DeleteCRB                bool
 	DeleteNamespace          bool
 	DeletePVCs               bool
 	DeleteAll                bool
+	Namespace                string
+	Platform                 string
+	DeployManifestsDirectory string
 	Repo                     string
 	Tag                      string
+	MeteringConfig           meteringv1.MeteringConfig
 }
 
 // Deployer holds all the information needed to handle the deployment

--- a/pkg/operator/deploy/helpers.go
+++ b/pkg/operator/deploy/helpers.go
@@ -28,10 +28,10 @@ func getBoolEnv(env string, defaultVal bool) (bool, error) {
 	return val, nil
 }
 
-// decodeYAMLManifestToObject is a helper function that takes the path to a manifest file, e.g. the
+// DecodeYAMLManifestToObject is a helper function that takes the path to a manifest file, e.g. the
 // deployment YAML file, and opens that file using os.Open, which returns an io.Reader object that
 // can be passed to the YAML/JSON decoder to build up the @resource parameter for usage in the clientsets.
-func decodeYAMLManifestToObject(path string, resource interface{}) error {
+func DecodeYAMLManifestToObject(path string, resource interface{}) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("Failed to open %s, got: %v", path, err)

--- a/pkg/operator/deploy/install.go
+++ b/pkg/operator/deploy/install.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	meteringv1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -66,22 +65,15 @@ func (deploy *Deployer) installNamespace() error {
 }
 
 func (deploy *Deployer) installMeteringConfig() error {
-	var res meteringv1.MeteringConfig
-
-	err := decodeYAMLManifestToObject(deploy.config.MeteringCR, &res)
-	if err != nil {
-		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
-	}
-
-	mc, err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Get(res.Name, metav1.GetOptions{})
+	mc, err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Get(deploy.config.MeteringConfig.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Create(&res)
+		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Create(&deploy.config.MeteringConfig)
 		if err != nil {
 			return fmt.Errorf("Failed to create the MeteringConfig resource: %v", err)
 		}
 		deploy.logger.Infof("Created the MeteringConfig resource")
 	} else if err == nil {
-		mc.Spec = res.Spec
+		mc.Spec = deploy.config.MeteringConfig.Spec
 
 		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Update(mc)
 		if err != nil {
@@ -132,7 +124,7 @@ func (deploy *Deployer) installMeteringResources() error {
 func (deploy *Deployer) installMeteringDeployment(deploymentName string) error {
 	var res appsv1.Deployment
 
-	err := decodeYAMLManifestToObject(deploymentName, &res)
+	err := DecodeYAMLManifestToObject(deploymentName, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the metering YAML manifest: %v", err)
 	}
@@ -174,7 +166,7 @@ func (deploy *Deployer) installMeteringDeployment(deploymentName string) error {
 func (deploy *Deployer) installMeteringServiceAccount(serviceAccountPath string) error {
 	var res corev1.ServiceAccount
 
-	err := decodeYAMLManifestToObject(serviceAccountPath, &res)
+	err := DecodeYAMLManifestToObject(serviceAccountPath, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -198,7 +190,7 @@ func (deploy *Deployer) installMeteringServiceAccount(serviceAccountPath string)
 func (deploy *Deployer) installMeteringRoleBinding(roleBindingPath string) error {
 	var res rbacv1.RoleBinding
 
-	err := decodeYAMLManifestToObject(roleBindingPath, &res)
+	err := DecodeYAMLManifestToObject(roleBindingPath, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -231,7 +223,7 @@ func (deploy *Deployer) installMeteringRoleBinding(roleBindingPath string) error
 func (deploy *Deployer) installMeteringRole(rolePath string) error {
 	var res rbacv1.Role
 
-	err := decodeYAMLManifestToObject(rolePath, &res)
+	err := DecodeYAMLManifestToObject(rolePath, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -258,7 +250,7 @@ func (deploy *Deployer) installMeteringRole(rolePath string) error {
 func (deploy *Deployer) installMeteringClusterRoleBinding(clusterrolebindingFile string) error {
 	var res rbacv1.ClusterRoleBinding
 
-	err := decodeYAMLManifestToObject(clusterrolebindingFile, &res)
+	err := DecodeYAMLManifestToObject(clusterrolebindingFile, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -289,7 +281,7 @@ func (deploy *Deployer) installMeteringClusterRoleBinding(clusterrolebindingFile
 func (deploy *Deployer) installMeteringClusterRole(clusterrolePath string) error {
 	var res rbacv1.ClusterRole
 
-	err := decodeYAMLManifestToObject(clusterrolePath, &res)
+	err := DecodeYAMLManifestToObject(clusterrolePath, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -324,7 +316,7 @@ func (deploy *Deployer) installMeteringCRDs() error {
 }
 
 func (deploy *Deployer) installMeteringCRD(resource CRD) error {
-	err := decodeYAMLManifestToObject(resource.Path, resource.CRD)
+	err := DecodeYAMLManifestToObject(resource.Path, resource.CRD)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}

--- a/pkg/operator/deploy/uninstall.go
+++ b/pkg/operator/deploy/uninstall.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	meteringv1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -27,14 +26,7 @@ func (deploy *Deployer) uninstallNamespace() error {
 }
 
 func (deploy *Deployer) uninstallMeteringConfig() error {
-	var res meteringv1.MeteringConfig
-
-	err := decodeYAMLManifestToObject(deploy.config.MeteringCR, &res)
-	if err != nil {
-		return fmt.Errorf("Failed while attempting to build up the MeteringConfig from the YAML file, got: %v", err)
-	}
-
-	err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Delete(res.Name, &metav1.DeleteOptions{})
+	err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Delete(deploy.config.MeteringConfig.Name, &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		deploy.logger.Warnf("The MeteringConfig resource doesn't exist")
 	} else if err == nil {
@@ -124,7 +116,7 @@ func (deploy *Deployer) uninstallMeteringPVCs() error {
 func (deploy *Deployer) uninstallMeteringDeployment(deploymentName string) error {
 	var res appsv1.Deployment
 
-	err := decodeYAMLManifestToObject(deploymentName, &res)
+	err := DecodeYAMLManifestToObject(deploymentName, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -144,7 +136,7 @@ func (deploy *Deployer) uninstallMeteringDeployment(deploymentName string) error
 func (deploy *Deployer) uninstallMeteringServiceAccount(serviceAccountPath string) error {
 	var res corev1.ServiceAccount
 
-	err := decodeYAMLManifestToObject(serviceAccountPath, &res)
+	err := DecodeYAMLManifestToObject(serviceAccountPath, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -164,7 +156,7 @@ func (deploy *Deployer) uninstallMeteringServiceAccount(serviceAccountPath strin
 func (deploy *Deployer) uninstallMeteringRoleBinding(roleBindingPath string) error {
 	var res rbacv1.RoleBinding
 
-	err := decodeYAMLManifestToObject(roleBindingPath, &res)
+	err := DecodeYAMLManifestToObject(roleBindingPath, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -192,7 +184,7 @@ func (deploy *Deployer) uninstallMeteringRoleBinding(roleBindingPath string) err
 func (deploy *Deployer) uninstallMeteringRole(rolePath string) error {
 	var res rbacv1.Role
 
-	err := decodeYAMLManifestToObject(rolePath, &res)
+	err := DecodeYAMLManifestToObject(rolePath, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -215,7 +207,7 @@ func (deploy *Deployer) uninstallMeteringRole(rolePath string) error {
 func (deploy *Deployer) uninstallMeteringClusterRole(clusterrolePath string) error {
 	var res rbacv1.ClusterRole
 
-	err := decodeYAMLManifestToObject(clusterrolePath, &res)
+	err := DecodeYAMLManifestToObject(clusterrolePath, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -237,7 +229,7 @@ func (deploy *Deployer) uninstallMeteringClusterRole(clusterrolePath string) err
 func (deploy *Deployer) uninstallMeteringClusterRoleBinding(meteringClusterRoleBindingFile string) error {
 	var res rbacv1.ClusterRoleBinding
 
-	err := decodeYAMLManifestToObject(meteringClusterRoleBindingFile, &res)
+	err := DecodeYAMLManifestToObject(meteringClusterRoleBindingFile, &res)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}
@@ -273,7 +265,7 @@ func (deploy *Deployer) uninstallMeteringCRDs() error {
 }
 
 func (deploy *Deployer) uninstallMeteringCRD(resource CRD) error {
-	err := decodeYAMLManifestToObject(resource.Path, resource.CRD)
+	err := DecodeYAMLManifestToObject(resource.Path, resource.CRD)
 	if err != nil {
 		return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 	}


### PR DESCRIPTION
This would refactor the `deploy.Config` structure to take a `MeteringConfig` object, instead of a file that contains a `MeteringConfig` yaml file. This makes for a cleaner structure and makes testing different configurations easier.