### PR TITLE
Add HTTP endpoint to render ReportQueries

### DIFF
--- a/pkg/operator/http.go
+++ b/pkg/operator/http.go
@@ -38,7 +38,7 @@ var ErrReportIsRunning = errors.New("the report is still running")
 var prometheusMiddleware = chiprometheus.NewMiddleware("reporting-operator")
 
 const (
-	APIV1ReportsGetEndpoint        = "/api/v1/reports/get"
+	APIV1ReportGetEndpoint         = "/api/v1/reports/get"
 	APIV2ReportEndpointPrefix      = "/api/v2/reports"
 	APIV2ReportQueryEndpointPrefix = "/api/v2/reportqueries"
 )
@@ -101,7 +101,7 @@ func newRouter(
 	router.HandleFunc(APIV2ReportEndpointPrefix+"/{namespace}/{name}/full", srv.getReportV2FullHandler)
 	router.HandleFunc(APIV2ReportEndpointPrefix+"/{namespace}/{name}/table", srv.getReportV2TableHandler)
 	router.HandleFunc(APIV2ReportQueryEndpointPrefix+"/{namespace}/{name}/render", srv.renderReportQueryV2Handler)
-	router.HandleFunc(APIV1ReportsGetEndpoint, srv.getReportV1Handler)
+	router.HandleFunc(APIV1ReportGetEndpoint, srv.getReportV1Handler)
 	router.HandleFunc("/api/v1/datasources/prometheus/collect/{namespace}", srv.collectPrometheusMetricsDataHandler)
 	router.HandleFunc("/api/v1/datasources/prometheus/collect/{namespace}/{datasourceName}", srv.collectPrometheusMetricsDataHandler)
 	router.HandleFunc("/api/v1/datasources/prometheus/store/{namespace}/{datasourceName}", srv.storePrometheusMetricsDataHandler)
@@ -512,7 +512,7 @@ func (srv *server) collectPrometheusMetricsDataHandler(w http.ResponseWriter, r 
 	var req CollectPrometheusMetricsDataRequest
 	err := decoder.Decode(&req)
 	if err != nil {
-		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode request as JSON: %v", err)
 		return
 	}
 
@@ -545,7 +545,7 @@ func (srv *server) storePrometheusMetricsDataHandler(w http.ResponseWriter, r *h
 	// read opening bracket
 	_, err := decoder.Token()
 	if err != nil {
-		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode request as JSON: %v", err)
 		return
 	}
 
@@ -555,7 +555,7 @@ func (srv *server) storePrometheusMetricsDataHandler(w http.ResponseWriter, r *h
 		var m prestostore.PrometheusMetric
 		err = decoder.Decode(&m)
 		if err != nil {
-			writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
+			writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode request as JSON: %v", err)
 			return
 		}
 		metrics = append(metrics, &m)
@@ -564,7 +564,7 @@ func (srv *server) storePrometheusMetricsDataHandler(w http.ResponseWriter, r *h
 	// read closing bracket
 	_, err = decoder.Token()
 	if err != nil {
-		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode request as JSON: %v", err)
 		return
 	}
 
@@ -699,7 +699,7 @@ func (srv *server) renderReportQueryV2Handler(w http.ResponseWriter, r *http.Req
 	var req RenderReportQueryRequest
 	err = decoder.Decode(&req)
 	if err != nil {
-		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode response as JSON: %v", err)
+		writeErrorResponse(logger, w, r, http.StatusInternalServerError, "unable to decode request as JSON: %v", err)
 		return
 	}
 

--- a/pkg/operator/http_test.go
+++ b/pkg/operator/http_test.go
@@ -38,12 +38,12 @@ var (
 
 //for v2 endpoints full
 func apiReportV2URLFull(namespace, reportName string) string {
-	return path.Join(APIV2ReportsEndpointPrefix, namespace, reportName, "full")
+	return path.Join(APIV2ReportEndpointPrefix, namespace, reportName, "full")
 }
 
 //for v2 endpoints TableHidden
 func apiReportV2URLTable(namespace, reportName string) string {
-	return path.Join(APIV2ReportsEndpointPrefix, namespace, reportName, "table")
+	return path.Join(APIV2ReportEndpointPrefix, namespace, reportName, "table")
 }
 
 type fakePrometheusMetricsRepo struct {
@@ -306,7 +306,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 			}
 
 			// setup a test server suitable for making API calls against
-			router := newRouter(testLogger, testRand, tt.prometheusMetricsRepo, tt.reportResultsGetter, noopPrometheusImporterFunc,
+			router := newRouter(testLogger, testRand, tt.prometheusMetricsRepo, tt.reportResultsGetter, nil, noopPrometheusImporterFunc,
 				reportLister, reportDataSourceLister, reportQueryLister, prestoTableLister,
 			)
 			server := httptest.NewServer(router)
@@ -516,7 +516,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-name-not-specified": {
 			reportName:            "",
-			apiPath:               APIV2ReportsEndpointPrefix + "/ " + namespace + "//full" + testFormat,
+			apiPath:               APIV2ReportEndpointPrefix + "/ " + namespace + "//full" + testFormat,
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: name",
 			reportResultsGetter:   &fakeReportResultsGetter{},
@@ -612,7 +612,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 			}
 
 			// setup a test server suitable for making API calls against
-			router := newRouter(testLogger, testRand, tt.prometheusMetricsRepo, tt.reportResultsGetter, noopPrometheusImporterFunc,
+			router := newRouter(testLogger, testRand, tt.prometheusMetricsRepo, tt.reportResultsGetter, nil, noopPrometheusImporterFunc,
 				reportLister, reportDataSourceLister, reportQueryLister, prestoTableLister,
 			)
 			server := httptest.NewServer(router)
@@ -806,7 +806,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-name-not-specified": {
 			reportName:            "",
-			apiPath:               APIV2ReportsEndpointPrefix + "/ " + namespace + "//table" + testFormat,
+			apiPath:               APIV2ReportEndpointPrefix + "/ " + namespace + "//table" + testFormat,
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: name",
 			reportResultsGetter:   &fakeReportResultsGetter{},
@@ -902,7 +902,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 			}
 
 			// setup a test server suitable for making API calls against
-			router := newRouter(testLogger, testRand, tt.prometheusMetricsRepo, tt.reportResultsGetter, noopPrometheusImporterFunc,
+			router := newRouter(testLogger, testRand, tt.prometheusMetricsRepo, tt.reportResultsGetter, nil, noopPrometheusImporterFunc,
 				reportLister, reportDataSourceLister, reportQueryLister, prestoTableLister,
 			)
 			server := httptest.NewServer(router)

--- a/pkg/operator/http_test.go
+++ b/pkg/operator/http_test.go
@@ -321,7 +321,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 				"namespace": []string{namespace},
 			}
 
-			endpoint := server.URL + APIV1ReportsGetEndpoint
+			endpoint := server.URL + APIV1ReportGetEndpoint
 
 			// construct the url object
 			endpointURL, err := url.Parse(endpoint)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -541,7 +541,7 @@ func (op *Reporting) Run(ctx context.Context) error {
 
 	op.logger.Infof("starting HTTP server")
 	apiRouter := newRouter(
-		op.logger, op.rand, op.prometheusMetricsRepo, op.reportResultsRepo, op.importPrometheusForTimeRange,
+		op.logger, op.rand, op.prometheusMetricsRepo, op.reportResultsRepo, op.dependencyResolver, op.importPrometheusForTimeRange,
 		op.reportLister, op.reportDataSourceLister, op.reportQueryLister, op.prestoTableLister,
 	)
 	apiRouter.HandleFunc("/ready", op.readinessHandler)


### PR DESCRIPTION
```
export REPORT_API_URL=127.0.0.1:8080
$ curl $REPORT_API_URL/api/v2/reportqueries/metering-chancez3/namespace-memory-request/render --data '{"inputs": [], "start": "2019-09-01T00:00:00-00:00", "end": "2019-09-30T00:00:00-00:00"}' -XPOST -H "Content-Type: application/json"

SELECT
  timestamp '2019-09-01 00:00:00.000' AS period_start,
  timestamp '2019-09-30 00:00:00.000' AS period_end,
  namespace,
  sum(pod_request_memory_byte_seconds) as pod_request_memory_byte_seconds
FROM hive.metering.datasource_metering_chancez3_pod_memory_request_raw
WHERE "timestamp" >= timestamp '2019-09-01 00:00:00.000'
AND "timestamp" < timestamp '2019-09-30 00:00:00.000'
AND dt >= '2019-09-01'
AND dt <= '2019-09-30'
GROUP BY namespace
```