### PR TITLE
charts,images: Disable post 1.14 kube Prom datasources

### DIFF
--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -209,7 +209,7 @@ openshift-reporting:
                   sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
 
       postKube_1_14:
-        enabled: true
+        enabled: false
         items:
           - name: pod-usage-cpu-cores
             spec:

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting.yml
@@ -4,7 +4,7 @@
   command: kubectl version -o json
   register: kube_version
 
-- name: Set default ReportDataSources to use based on Kubernetes version
+- name: Get Kubernetes minor version
   block:
     - name: Log Kubernetes version
       debug:
@@ -12,9 +12,6 @@
           Kubernetes Minor Version: {{ kube_minor_version }}
           Kubernetes version at least 1.14: {{ kube_version_at_least_1_14 }}
 
-    - name: Set default ReportDataSources to use based on Kubernetes version
-      set_fact:
-        meteringconfig_reporting_enable_post_kube_1_14_datasources: "{{ kube_version_at_least_1_14 }}"
   vars:
     kube_minor_version: "{{ (kube_version.stdout | from_json | json_query('serverVersion.minor')).rstrip('+') }}"
     kube_version_at_least_1_14: "{{ ((kube_minor_version | int) >= 14) | bool }}"


### PR DESCRIPTION
It doesn't look like kube 1.16 in OCP 4.3 has the new consistent labels
on container metrics which is breaking our metrics imports for pod usage
metrics.