### PR TITLE
pkg/operator,cmd/deploy-metering: Move reading of MeteringConfig into main package

### DIFF
--- a/cmd/deploy-metering/main.go
+++ b/cmd/deploy-metering/main.go
@@ -86,9 +86,14 @@ func runDeployMetering(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to set the $METERING_CR_FILE or --meteringconfig flag")
 	}
 
-	err := deploy.InitObjectFromManifest(deployManifestsDir, meteringConfigCRFile, &cfg)
+	err := deploy.DecodeYAMLManifestToObject(meteringConfigCRFile, &cfg.MeteringConfig)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize metering resource objects from YAML manifests: %v", err)
+		return fmt.Errorf("Failed to read MeteringConfig: %v", err)
+	}
+
+	cfg.OperatorResources, err = deploy.ReadMeteringAnsibleOperatorManifests(deployManifestsDir, cfg.Platform)
+	if err != nil {
+		return fmt.Errorf("Failed to read metering-ansible-operator manifests: %v", err)
 	}
 
 	logger.Debugf("Metering Deploy Config: %#v", cfg)

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -65,11 +65,13 @@ type Config struct {
 	Platform               string
 	Repo                   string
 	Tag                    string
-	Resources              *MeteringResources
+	OperatorResources      *OperatorResources
+	MeteringConfig         *meteringv1.MeteringConfig
 }
 
-// MeteringResources contains all the objects that metering manages
-type MeteringResources struct {
+// OperatorResources contains all the objects that make up the
+// Metering Ansible Operator
+type OperatorResources struct {
 	CRDs               []CRD
 	Deployment         *appsv1.Deployment
 	ServiceAccount     *corev1.ServiceAccount
@@ -77,7 +79,6 @@ type MeteringResources struct {
 	Role               *rbacv1.Role
 	ClusterRoleBinding *rbacv1.ClusterRoleBinding
 	ClusterRole        *rbacv1.ClusterRole
-	MeteringConfig     *meteringv1.MeteringConfig
 }
 
 // Deployer holds all the information needed to handle the deployment

--- a/pkg/operator/deploy/helpers.go
+++ b/pkg/operator/deploy/helpers.go
@@ -133,22 +133,12 @@ func getMeteringAnsiblePath(manifestDir, platform string) (string, error) {
 	return ansibleOperatorManifestDir, nil
 }
 
-// Resource contains information about an individual resource that metering manages
-type Resource struct {
-	UseAbsolutePath  bool
-	SkipYAMLDecoding bool
-	Path             string
-	Resource         interface{}
-}
+func ReadMeteringAnsibleOperatorManifests(manifestDir, platform string) (*OperatorResources, error) {
+	var resources OperatorResources
 
-// InitObjectFromManifest is the driver function for building up a path to the metering-ansible-operator directory
-// from the base @manifestDir directory and initializing the metering resource/CRD objects from the YAML manifests.
-func InitObjectFromManifest(manifestDir, meteringConfigCRFile string, cfg *Config) error {
-	var resources MeteringResources
-
-	ansibleOperatorManifestDir, err := getMeteringAnsiblePath(manifestDir, cfg.Platform)
+	ansibleOperatorManifestDir, err := getMeteringAnsiblePath(manifestDir, platform)
 	if err != nil {
-		return fmt.Errorf("Failed to get the path to the metering-ansible-operator directory: %v", err)
+		return nil, fmt.Errorf("Failed to get the path to the metering-ansible-operator directory: %v", err)
 	}
 
 	pathToCRDMap := map[string]string{
@@ -166,56 +156,48 @@ func InitObjectFromManifest(manifestDir, meteringConfigCRFile string, cfg *Confi
 	for _, crd := range resources.CRDs {
 		err := DecodeYAMLManifestToObject(crd.Path, crd.CRD)
 		if err != nil {
-			return fmt.Errorf("Failed to decode the YAML manifest: %v", err)
+			return nil, fmt.Errorf("Failed to decode the YAML manifest: %v", err)
 		}
 	}
 
-	meteringResourceMap := map[string]Resource{
-		"meteringConfig": Resource{
-			Path:            meteringConfigCRFile,
-			UseAbsolutePath: true,
-			Resource:        &resources.MeteringConfig,
+	meteringResourceMap := map[string]struct {
+		path string
+		obj  interface{}
+	}{
+		"deployment": {
+			path: meteringDeploymentFile,
+			obj:  &resources.Deployment,
 		},
-		"deployment": Resource{
-			Path:     meteringDeploymentFile,
-			Resource: &resources.Deployment,
+		"serviceAccount": {
+			path: meteringServiceAccountFile,
+			obj:  &resources.ServiceAccount,
 		},
-		"serviceAccount": Resource{
-			Path:     meteringServiceAccountFile,
-			Resource: &resources.ServiceAccount,
+		"roleBinding": {
+			path: meteringRoleBindingFile,
+			obj:  &resources.RoleBinding,
 		},
-		"roleBinding": Resource{
-			Path:     meteringRoleBindingFile,
-			Resource: &resources.RoleBinding,
+		"role": {
+			path: meteringRoleFile,
+			obj:  &resources.Role,
 		},
-		"role": Resource{
-			Path:     meteringRoleFile,
-			Resource: &resources.Role,
+		"clusterRoleBinding": {
+			path: meteringClusterRoleBindingFile,
+			obj:  &resources.ClusterRoleBinding,
 		},
-		"clusterRoleBinding": Resource{
-			Path:     meteringClusterRoleBindingFile,
-			Resource: &resources.ClusterRoleBinding,
-		},
-		"clusterRole": Resource{
-			Path:     meteringClusterRoleFile,
-			Resource: &resources.ClusterRole,
+		"clusterRole": {
+			path: meteringClusterRoleFile,
+			obj:  &resources.ClusterRole,
 		},
 	}
 
 	for name, resource := range meteringResourceMap {
-		path := filepath.Join(ansibleOperatorManifestDir, resource.Path)
+		path := filepath.Join(ansibleOperatorManifestDir, resource.path)
 
-		if resource.UseAbsolutePath {
-			path = resource.Path
-		}
-
-		err = DecodeYAMLManifestToObject(path, resource.Resource)
+		err = DecodeYAMLManifestToObject(path, resource.obj)
 		if err != nil {
-			return fmt.Errorf("Failed to decode the YAML manifest for the %s resource: %v", name, err)
+			return nil, fmt.Errorf("Failed to decode the YAML manifest for the %s resource: %v", name, err)
 		}
 	}
 
-	cfg.Resources = &resources
-
-	return nil
+	return &resources, nil
 }

--- a/pkg/operator/deploy/install.go
+++ b/pkg/operator/deploy/install.go
@@ -6,7 +6,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func (deploy *Deployer) installNamespace() error {
@@ -60,15 +60,15 @@ func (deploy *Deployer) installNamespace() error {
 }
 
 func (deploy *Deployer) installMeteringConfig() error {
-	mc, err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Get(deploy.config.Resources.MeteringConfig.Name, metav1.GetOptions{})
+	mc, err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Get(deploy.config.MeteringConfig.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Create(deploy.config.Resources.MeteringConfig)
+		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Create(deploy.config.MeteringConfig)
 		if err != nil {
 			return fmt.Errorf("Failed to create the MeteringConfig resource: %v", err)
 		}
 		deploy.logger.Infof("Created the MeteringConfig resource")
 	} else if err == nil {
-		mc.Spec = deploy.config.Resources.MeteringConfig.Spec
+		mc.Spec = deploy.config.MeteringConfig.Spec
 
 		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Update(mc)
 		if err != nil {
@@ -117,7 +117,7 @@ func (deploy *Deployer) installMeteringResources() error {
 }
 
 func (deploy *Deployer) installMeteringDeployment() error {
-	res := deploy.config.Resources.Deployment
+	res := deploy.config.OperatorResources.Deployment
 
 	// check if the metering operator image needs to be updated
 	// TODO: implement support for METERING_OPERATOR_ALL_NAMESPACES and METERING_OPERATOR_TARGET_NAMESPACES
@@ -154,9 +154,9 @@ func (deploy *Deployer) installMeteringDeployment() error {
 }
 
 func (deploy *Deployer) installMeteringServiceAccount() error {
-	_, err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Get(deploy.config.Resources.ServiceAccount.Name, metav1.GetOptions{})
+	_, err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Get(deploy.config.OperatorResources.ServiceAccount.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Create(deploy.config.Resources.ServiceAccount)
+		_, err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Create(deploy.config.OperatorResources.ServiceAccount)
 		if err != nil {
 			return fmt.Errorf("Failed to create the metering serviceaccount: %v", err)
 		}
@@ -171,7 +171,7 @@ func (deploy *Deployer) installMeteringServiceAccount() error {
 }
 
 func (deploy *Deployer) installMeteringRoleBinding() error {
-	res := deploy.config.Resources.RoleBinding
+	res := deploy.config.OperatorResources.RoleBinding
 
 	// TODO: implement support for METERING_OPERATOR_TARGET_NAMESPACES
 	res.Name = deploy.config.Namespace + "-" + res.Name
@@ -199,7 +199,7 @@ func (deploy *Deployer) installMeteringRoleBinding() error {
 }
 
 func (deploy *Deployer) installMeteringRole() error {
-	res := deploy.config.Resources.Role
+	res := deploy.config.OperatorResources.Role
 
 	res.Name = deploy.config.Namespace + "-" + res.Name
 	res.Namespace = deploy.config.Namespace
@@ -221,7 +221,7 @@ func (deploy *Deployer) installMeteringRole() error {
 }
 
 func (deploy *Deployer) installMeteringClusterRoleBinding() error {
-	res := deploy.config.Resources.ClusterRoleBinding
+	res := deploy.config.OperatorResources.ClusterRoleBinding
 
 	res.Name = deploy.config.Namespace + "-" + res.Name
 	res.RoleRef.Name = res.Name
@@ -247,7 +247,7 @@ func (deploy *Deployer) installMeteringClusterRoleBinding() error {
 }
 
 func (deploy *Deployer) installMeteringClusterRole() error {
-	res := deploy.config.Resources.ClusterRole
+	res := deploy.config.OperatorResources.ClusterRole
 
 	res.Name = deploy.config.Namespace + "-" + res.Name
 
@@ -268,7 +268,7 @@ func (deploy *Deployer) installMeteringClusterRole() error {
 }
 
 func (deploy *Deployer) installMeteringCRDs() error {
-	for _, crd := range deploy.config.Resources.CRDs {
+	for _, crd := range deploy.config.OperatorResources.CRDs {
 		err := deploy.installMeteringCRD(crd)
 		if err != nil {
 			return fmt.Errorf("Failed to create a CRD while looping: %v", err)

--- a/pkg/operator/deploy/uninstall.go
+++ b/pkg/operator/deploy/uninstall.go
@@ -21,7 +21,7 @@ func (deploy *Deployer) uninstallNamespace() error {
 }
 
 func (deploy *Deployer) uninstallMeteringConfig() error {
-	err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Delete(deploy.config.Resources.MeteringConfig.Name, &metav1.DeleteOptions{})
+	err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Delete(deploy.config.MeteringConfig.Name, &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		deploy.logger.Warnf("The MeteringConfig resource doesn't exist")
 	} else if err == nil {
@@ -109,7 +109,7 @@ func (deploy *Deployer) uninstallMeteringPVCs() error {
 }
 
 func (deploy *Deployer) uninstallMeteringDeployment() error {
-	err := deploy.client.AppsV1().Deployments(deploy.config.Namespace).Delete(deploy.config.Resources.Deployment.Name, &metav1.DeleteOptions{})
+	err := deploy.client.AppsV1().Deployments(deploy.config.Namespace).Delete(deploy.config.OperatorResources.Deployment.Name, &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		deploy.logger.Warnf("The metering deployment doesn't exist")
 	} else if err == nil {
@@ -122,7 +122,7 @@ func (deploy *Deployer) uninstallMeteringDeployment() error {
 }
 
 func (deploy *Deployer) uninstallMeteringServiceAccount() error {
-	err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Delete(deploy.config.Resources.ServiceAccount.Name, &metav1.DeleteOptions{})
+	err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Delete(deploy.config.OperatorResources.ServiceAccount.Name, &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		deploy.logger.Warnf("The metering service account doesn't exist")
 	} else if err == nil {
@@ -135,7 +135,7 @@ func (deploy *Deployer) uninstallMeteringServiceAccount() error {
 }
 
 func (deploy *Deployer) uninstallMeteringRoleBinding() error {
-	res := deploy.config.Resources.RoleBinding
+	res := deploy.config.OperatorResources.RoleBinding
 
 	res.Name = deploy.config.Namespace + "-" + res.Name
 	res.RoleRef.Name = res.Name
@@ -158,7 +158,7 @@ func (deploy *Deployer) uninstallMeteringRoleBinding() error {
 }
 
 func (deploy *Deployer) uninstallMeteringRole() error {
-	res := deploy.config.Resources.Role
+	res := deploy.config.OperatorResources.Role
 
 	res.Name = deploy.config.Namespace + "-" + res.Name
 	res.Namespace = deploy.config.Namespace
@@ -176,7 +176,7 @@ func (deploy *Deployer) uninstallMeteringRole() error {
 }
 
 func (deploy *Deployer) uninstallMeteringClusterRole() error {
-	res := deploy.config.Resources.ClusterRole
+	res := deploy.config.OperatorResources.ClusterRole
 
 	res.Name = deploy.config.Namespace + "-" + res.Name
 
@@ -193,7 +193,7 @@ func (deploy *Deployer) uninstallMeteringClusterRole() error {
 }
 
 func (deploy *Deployer) uninstallMeteringClusterRoleBinding() error {
-	res := deploy.config.Resources.ClusterRoleBinding
+	res := deploy.config.OperatorResources.ClusterRoleBinding
 
 	res.Name = deploy.config.Namespace + "-" + res.Name
 	res.RoleRef.Name = res.Name
@@ -215,7 +215,7 @@ func (deploy *Deployer) uninstallMeteringClusterRoleBinding() error {
 }
 
 func (deploy *Deployer) uninstallMeteringCRDs() error {
-	for _, crd := range deploy.config.Resources.CRDs {
+	for _, crd := range deploy.config.OperatorResources.CRDs {
 		err := deploy.uninstallMeteringCRD(crd)
 		if err != nil {
 			return fmt.Errorf("Failed to delete a CRD while looping: %v", err)


### PR DESCRIPTION
Also read InitObjectFromManifest to ReadMeteringAnsibleOperatorManifests.
Moving the reading of MeteringConfig into main means we can re-use
ReadMeteringAnsibleOperatorManifests even if we're creating a
MeteringConfig directly, instead of reading it from a file.