### PR TITLE
charts/openshift-metering: Fix sum fields on pod-usage-memory-bytes

### DIFF
--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -233,7 +233,7 @@ openshift-reporting:
             spec:
               prometheusMetricsImporter:
                 query: |
-                  label_replace(sum(container_memory_usage_bytes{container_name!="POD", container_name!="",pod_name!=""}) by (pod, namespace, node), "pod", "$1", "pod_name", "(.*)")
+                  label_replace(sum(container_memory_usage_bytes{container_name!="POD", container_name!="",pod_name!=""}) by (pod_name, namespace, node), "pod", "$1", "pod_name", "(.*)")
 
 reporting-operator:
   spec:


### PR DESCRIPTION
The label_replace was moved to the outside of the sum, so the sum needs
to be on pod_name, not pod.