### PR TITLE
test,hack: Refactor the e2e package to use the deploy metering package.

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,20 +1,32 @@
 #!/bin/bash
-set -e
 
 : "${KUBECONFIG:?}"
 
-ROOT_DIR=$(dirname "${BASH_SOURCE}")/..
+ROOT_DIR=$(dirname "${BASH_SOURCE[0]}")/..
 source "${ROOT_DIR}/hack/common.sh"
 source "${ROOT_DIR}/hack/lib/tests.sh"
 
+function remove_namespaces() {
+    echo "Removing namespaces with the 'name=metering-testing-ns' label"
+    kubectl delete ns -l "name=metering-testing-ns" || true
+}
+
+trap remove_namespaces SIGINT
+
 export METERING_NAMESPACE="${METERING_E2E_NAMESPACE:=${METERING_NAMESPACE}-e2e}"
+export METERING_SHORT_TESTS=${METERING_SHORT_TESTS:=false}
+export METERING_DEPLOY_MANIFESTS_PATH=${METERING_DEPLOY_MANIFESTS_PATH:=${ROOT_DIR}/manifests/deploy}
+export METERING_CLEANUP_SCRIPT_PATH=${METERING_CLEANUP_SCRIPT_PATH:=${ROOT_DIR}/hack/run-test-cleanup.sh}
+export TEST_OUTPUT_PATH=${TEST_OUTPUT_PATH:="$(mktemp -d)/${METERING_E2E_NAMESPACE}"}
+export TEST_LOG_LEVEL=${TEST_LOG_LEVEL:="debug"}
 
-export DEPLOY_SCRIPT="${DEPLOY_SCRIPT:-deploy-e2e.sh}"
-export TEST_SCRIPT="$ROOT_DIR/hack/run-e2e-tests.sh"
+TEST_OUTPUT_DIR="${TEST_OUTPUT_PATH}/tests"
+TEST_LOG_FILE="${TEST_LOG_FILE:-e2e-tests.log}"
+TEST_LOG_FILE_PATH="${TEST_LOG_FILE_PATH:-$TEST_OUTPUT_DIR/$TEST_LOG_FILE}"
+TEST_JUNIT_REPORT_FILE="${TEST_JUNIT_REPORT_FILE:-junit-e2e-tests.xml}"
+TEST_JUNIT_REPORT_FILE_PATH="${TEST_JUNIT_REPORT_FILE_PATH:-$TEST_OUTPUT_DIR/$TEST_JUNIT_REPORT_FILE}"
 
-export TEST_LOG_FILE="${TEST_LOG_FILE:-e2e-tests.log}"
-export DEPLOY_LOG_FILE="${DEPLOY_LOG_FILE:-e2e-deploy.log}"
-export TEST_TAP_FILE="${TEST_TAP_FILE:-e2e-tests.tap}"
+mkdir -p "$TEST_OUTPUT_DIR"
 
 echo "\$KUBECONFIG=$KUBECONFIG"
 echo "\$METERING_NAMESPACE=$METERING_NAMESPACE"
@@ -22,31 +34,28 @@ echo "\$METERING_OPERATOR_IMAGE_REPO=$METERING_OPERATOR_IMAGE_REPO"
 echo "\$REPORTING_OPERATOR_IMAGE_REPO=$REPORTING_OPERATOR_IMAGE_REPO"
 echo "\$METERING_OPERATOR_IMAGE_TAG=$METERING_OPERATOR_IMAGE_TAG"
 echo "\$REPORTING_OPERATOR_IMAGE_TAG=$REPORTING_OPERATOR_IMAGE_TAG"
+echo "\$TEST_OUTPUT_PATH=$TEST_OUTPUT_PATH"
 
-export DISABLE_PROMETHEUS_METRICS_IMPORTER=false
-if [ "$DEPLOY_REPORTING_OPERATOR_LOCAL" == "true" ]; then
-    export REPORTING_OPERATOR_PROMETHEUS_DATASOURCE_MAX_IMPORT_BACKFILL_DURATION='15m'
-    export REPORTING_OPERATOR_PROMETHEUS_METRICS_IMPORTER_INTERVAL="30s"
-    export REPORTING_OPERATOR_PROMETHEUS_METRICS_IMPORTER_CHUNK_SIZE="5m"
-    export REPORTING_OPERATOR_PROMETHEUS_METRICS_IMPORTER_INTERVAL="5m"
-    export REPORTING_OPERATOR_PROMETHEUS_METRICS_IMPORTER_STEP_SIZE="60s"
+set +e
+set +o pipefail
+set -x
+echo "Running E2E Tests"
 
-    export REPORTING_OPERATOR_API_LISTEN="127.0.0.1:8100"
-    export REPORTING_OPERATOR_METRICS_LISTEN="127.0.0.1:8101"
-    export REPORTING_OPERATOR_PPROF_LISTEN="127.0.0.1:8102"
+go test \
+    -test.short="${METERING_SHORT_TESTS}" \
+    -test.v \
+    -parallel 10 \
+    -timeout 30m \
+    "./test/e2e" \
+    -kubeconfig="${KUBECONFIG}" \
+    -namespace-prefix="${METERING_NAMESPACE}" \
+    -deploy-manifests-dir="${METERING_DEPLOY_MANIFESTS_PATH}" \
+    -cleanup-script-path="${METERING_CLEANUP_SCRIPT_PATH}" \
+    -test-output-path="${TEST_OUTPUT_PATH}" \
+    -log-level="${TEST_LOG_LEVEL}" \
+    |& tee "$TEST_LOG_FILE_PATH"
 
-    export METERING_PRESTO_PORT_FORWARD_PORT="8103"
-    export METERING_HIVE_PORT_FORWARD_PORT="8104"
-    export METERING_PROMETHEUS_PORT_FORWARD_PORT="8105"
-
-    export METERING_HTTPS_API="false"
-    export METERING_REPORTING_API_URL="http://$REPORTING_OPERATOR_API_LISTEN"
-    export METERING_USE_KUBE_PROXY_FOR_REPORTING_API="false"
-    export METERING_USE_ROUTE_FOR_REPORTING_API="false"
+# if go-junit-report is installed, create a junit report also
+if command -v go-junit-report >/dev/null 2>&1; then
+    go-junit-report < "$TEST_LOG_FILE_PATH" > "${TEST_JUNIT_REPORT_FILE_PATH}"
 fi
-
-if [ "$DEPLOY_METERING_OPERATOR_LOCAL" == "true" ]; then
-    export METERING_OPERATOR_CONTAINER_NAME="metering-operator-e2e"
-fi
-
-"$ROOT_DIR/hack/e2e-test-runner.sh"

--- a/hack/run-test-cleanup.sh
+++ b/hack/run-test-cleanup.sh
@@ -1,0 +1,108 @@
+#! /bin/bash
+
+echo "Performing cleanup"
+echo "Storing pod descriptions and logs at $LOG_DIR"
+echo "Capturing pod descriptions"
+
+PODS="$(kubectl get pods --no-headers --namespace "$METERING_TEST_NAMESPACE" -o name | cut -d/ -f2)"
+while read -r pod; do
+    if [[ -n "$pod" ]]; then
+        echo "Capturing pod $pod description"
+        if ! kubectl describe pod --namespace "$METERING_TEST_NAMESPACE" "$pod" > "$LOG_DIR/${pod}-description.txt"; then
+            echo "Error capturing pod $pod description"
+        fi
+    fi
+done <<< "$PODS"
+
+echo "Capturing pod logs"
+while read -r pod; do
+    if [[ -z "$pod" ]]; then
+        continue
+    fi
+    # There can be multiple containers within a pod. We need to iterate
+    # over each of those
+    containers=$(kubectl get pods -o jsonpath="{.spec.containers[*].name}" --namespace "$METERING_TEST_NAMESPACE" "$pod")
+    for container in $containers; do
+        echo "Capturing pod $pod container $container logs"
+        if ! kubectl logs --namespace "$METERING_TEST_NAMESPACE" -c "$container" "$pod" > "$LOG_DIR/${pod}-${container}.log"; then
+            echo "Error capturing pod $pod container $container logs"
+        fi
+    done
+done <<< "$PODS"
+
+echo "Capturing MeteringConfigs"
+METERINGCONFIGS="$(kubectl get meteringconfigs --no-headers --namespace "$METERING_TEST_NAMESPACE" -o name | cut -d/ -f2)"
+while read -r meteringconfig; do
+    if [[ -n "$meteringconfig" ]]; then
+        echo "Capturing MeteringConfig $meteringconfig as json"
+        if ! kubectl get meteringconfig "$meteringconfig" --namespace "$METERING_TEST_NAMESPACE" -o json > "$METERINGCONFIGS_DIR/${meteringconfig}.json"; then
+            echo "Error getting $meteringconfig as json"
+        fi
+    fi
+done <<< "$METERINGCONFIGS"
+
+echo "Capturing Metering StorageLocations"
+STORAGELOCATIONS="$(kubectl get storagelocations --no-headers --namespace "$METERING_TEST_NAMESPACE" -o name | cut -d/ -f2)"
+while read -r storagelocation; do
+    if [[ -n "$storagelocation" ]]; then
+        echo "Capturing StorageLocation $storagelocation as json"
+        if ! kubectl get storagelocation "$storagelocation" --namespace "$METERING_TEST_NAMESPACE" -o json > "$STORAGELOCATIONS_DIR/${storagelocation}.json"; then
+            echo "Error getting $storagelocation as json"
+        fi
+    fi
+done <<< "$STORAGELOCATIONS"
+
+echo "Capturing Metering PrestoTables"
+PRESTOTABLES="$(kubectl get prestotables --no-headers --namespace "$METERING_TEST_NAMESPACE" -o name | cut -d/ -f2)"
+while read -r prestotable; do
+    if [[ -n "$prestotable" ]]; then
+        echo "Capturing PrestoTable $prestotable as json"
+        if ! kubectl get prestotable "$prestotable" --namespace "$METERING_TEST_NAMESPACE" -o json > "$PRESTOTABLES_DIR/${prestotable}.json"; then
+            echo "Error getting $prestotable as json"
+        fi
+    fi
+done <<< "$PRESTOTABLES"
+
+echo "Capturing Metering HiveTables"
+HIVETABLES="$(kubectl get hivetables --no-headers --namespace "$METERING_TEST_NAMESPACE" -o name | cut -d/ -f2)"
+while read -r hivetable; do
+    if [[ -n "$hivetable" ]]; then
+        echo "Capturing HiveTable $hivetable as json"
+        if ! kubectl get hivetable "$hivetable" --namespace "$METERING_TEST_NAMESPACE" -o json > "$HIVETABLES_DIR/${hivetable}.json"; then
+            echo "Error getting $hivetable as json"
+        fi
+    fi
+done <<< "$HIVETABLES"
+
+echo "Capturing Metering ReportDataSources"
+DATASOURCES="$(kubectl get reportdatasources --no-headers --namespace "$METERING_TEST_NAMESPACE" -o name | cut -d/ -f2)"
+while read -r datasource; do
+    if [[ -n "$datasource" ]]; then
+        echo "Capturing ReportDataSource $datasource as json"
+        if ! kubectl get reportdatasource "$datasource" --namespace "$METERING_TEST_NAMESPACE" -o json > "$DATASOURCES_DIR/${datasource}.json"; then
+            echo "Error getting $datasource as json"
+        fi
+    fi
+done <<< "$DATASOURCES"
+
+echo "Capturing Metering ReportQueries"
+RGQS="$(kubectl get reportqueries --no-headers --namespace "$METERING_TEST_NAMESPACE" -o name | cut -d/ -f2)"
+while read -r rgq; do
+    if [[ -n "$rgq" ]]; then
+        echo "Capturing ReportQuery $rgq as json"
+        if ! kubectl get reportquery "$rgq" --namespace "$METERING_TEST_NAMESPACE" -o json > "$REPORTQUERIES_DIR/${rgq}.json"; then
+            echo "Error getting $rgq as json"
+        fi
+    fi
+done <<< "$RGQS"
+
+echo "Capturing Metering Reports"
+REPORTS="$(kubectl get reports --no-headers --namespace "$METERING_TEST_NAMESPACE" -o name | cut -d/ -f2)"
+while read -r report; do
+    if [[ -n "$report" ]]; then
+        echo "Capturing Report $report as json"
+        if ! kubectl get report "$report" --namespace "$METERING_TEST_NAMESPACE" -o json > "$REPORTS_DIR/${report}.json"; then
+            echo "Error getting $report as json"
+        fi
+    fi
+done <<< "$REPORTS"

--- a/test/deployframework/context.go
+++ b/test/deployframework/context.go
@@ -1,0 +1,297 @@
+package deployframework
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
+	meteringv1 "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1"
+	"github.com/operator-framework/operator-metering/pkg/operator/deploy"
+	"github.com/operator-framework/operator-metering/test/reportingframework"
+)
+
+// DeployerCtx contains all the information needed to manage the
+// full lifecycle of a single metering deployment
+type DeployerCtx struct {
+	TargetPods         int
+	Namespace          string
+	KubeConfigPath     string
+	TestCaseOutputPath string
+	Deployer           *deploy.Deployer
+	Logger             logrus.FieldLogger
+	Client             kubernetes.Interface
+	APIExtClient       apiextclientv1beta1.CustomResourceDefinitionsGetter
+	MeteringClient     meteringv1.MeteringV1Interface
+}
+
+// NewDeployerCtx constructs and returns a new DeployerCtx object
+func (df *DeployFramework) NewDeployerCtx(
+	repo,
+	tag,
+	namespace,
+	outputPath string,
+	targetPods int,
+	spec metering.MeteringConfigSpec,
+) (*DeployerCtx, error) {
+	operatorResources, err := deploy.ReadMeteringAnsibleOperatorManifests(df.ManifestsDir, defaultPlatform)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize objects from manifests: %v", err)
+	}
+
+	cfg := deploy.Config{
+		Namespace:       namespace,
+		Repo:            repo,
+		Tag:             tag,
+		Platform:        defaultPlatform,
+		DeleteNamespace: defaultDeleteNamespace,
+		ExtraNamespaceLabels: map[string]string{
+			"name": testNamespaceLabel,
+		},
+		OperatorResources: operatorResources,
+		MeteringConfig: &metering.MeteringConfig{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      meteringconfigMetadataName,
+				Namespace: namespace,
+			},
+			Spec: spec,
+		},
+	}
+
+	df.Logger.Debugf("Deployer config: %+v", cfg)
+
+	deployer, err := deploy.NewDeployer(cfg, df.Logger, df.Client, df.APIExtClient, df.MeteringClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a new deployer instance: %v", err)
+	}
+
+	deployerCtx := &DeployerCtx{
+		Namespace:          namespace,
+		TargetPods:         targetPods,
+		TestCaseOutputPath: outputPath,
+		Deployer:           deployer,
+		KubeConfigPath:     df.KubeConfigPath,
+		Logger:             df.Logger,
+		Client:             df.Client,
+		APIExtClient:       df.APIExtClient,
+		MeteringClient:     df.MeteringClient,
+	}
+
+	return deployerCtx, nil
+}
+
+// Setup handles the process of deploying metering, and waiting for all necessary resources
+// to become ready in order to proceed with running the reporting tests.
+func (ctx *DeployerCtx) Setup() (*reportingframework.ReportingFramework, error) {
+	err := ctx.Deployer.Install()
+	if err != nil {
+		return nil, fmt.Errorf("failed to install metering: %v", err)
+	}
+
+	err = ctx.WaitForMeteringPods()
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for metering pods to become ready: %v", err)
+	}
+
+	routeBearerToken, err := ctx.GetRouteBearerToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the route bearer token: %v", err)
+	}
+
+	reportResultsPath := filepath.Join(ctx.TestCaseOutputPath, reportResultsDir)
+	err = os.Mkdir(reportResultsPath, 0777)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the report results directory %s: %v", reportResultsPath, err)
+	}
+
+	ctx.Logger.Infof("Report results directory: %s", reportResultsPath)
+
+	// TODO create functions that determine the reportingframework fields
+	// we can hardcode these values for now as we only have one
+	// meteringconfig configuration that gets installed and we dont
+	// support passing a METERING_CR_FILE yaml file for local testing
+	useHTTPSAPI := true
+	useRouteForReportingAPI := true
+	useKubeProxyForReportingAPI := false
+	reportingAPIURL := ""
+
+	rf, err := reportingframework.New(
+		ctx.Namespace,
+		ctx.KubeConfigPath,
+		useHTTPSAPI,
+		useKubeProxyForReportingAPI,
+		useRouteForReportingAPI,
+		routeBearerToken,
+		reportingAPIURL,
+		reportResultsPath,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct a reportingframework: %v", err)
+	}
+
+	return rf, nil
+}
+
+// Teardown is a method that creates the resource and container logging
+// directories, then populates those directories by executing the
+// @cleanupScript bash script, while streaming the script output
+// to stdout. Once the cleanup script has finished execution, we can
+// uninstall the metering stack and return an error if there is any.
+func (ctx *DeployerCtx) Teardown(cleanupScript string) error {
+	logger := ctx.Logger.WithFields(logrus.Fields{"component": "cleanup"})
+
+	var errArr []string
+	envVarArr, err := createResourceDirs(ctx.Namespace, ctx.TestCaseOutputPath)
+	if err != nil {
+		errArr = append(errArr, fmt.Sprintf("failed to create the resource output directories: %v", err))
+	}
+
+	cleanupCmd := exec.Command(cleanupScript)
+	cleanupStdout, err := cleanupCmd.StdoutPipe()
+	if err != nil {
+		errArr = append(errArr, fmt.Sprintf("failed to create a pipe from command output to stdout: %v", err))
+	}
+
+	scanner := bufio.NewScanner(cleanupStdout)
+	go func() {
+		for scanner.Scan() {
+			line := scanner.Text()
+			logger.Infof(line)
+		}
+		if err := scanner.Err(); err != nil {
+			errArr = append(errArr, fmt.Sprintf("error reading output from command: %v", err))
+		}
+		return
+	}()
+
+	cleanupCmd.Env = append(os.Environ(), envVarArr...)
+	err = cleanupCmd.Run()
+	if err != nil {
+		errArr = append(errArr, fmt.Sprintf("error running the cleanup script: %v", err))
+	}
+
+	err = ctx.Deployer.Uninstall()
+	if err != nil {
+		errArr = append(errArr, fmt.Sprintf("failed to uninstall metering: %v", err))
+	}
+
+	if len(errArr) != 0 {
+		return fmt.Errorf(strings.Join(errArr, "\n"))
+	}
+
+	return nil
+}
+
+type podStat struct {
+	PodName string
+	Ready   int
+	Total   int
+}
+
+// WaitForMeteringPods periodically polls the list of pods in the ctx.Namespace
+// and ensures the metering pods created are considered ready. In order to exit
+// the polling loop, the number of pods listed must match the expected number
+// of ctx.TargetPods, and all pod containers listed must report a ready status.
+func (ctx *DeployerCtx) WaitForMeteringPods() error {
+	var readyPods []string
+	var unreadyPods []podStat
+
+	start := time.Now()
+
+	ctx.Logger.Infof("Waiting for all metering pods to be ready")
+	err := wait.Poll(10*time.Second, 20*time.Minute, func() (done bool, err error) {
+		unreadyPods = nil
+		readyPods = nil
+
+		pods, err := ctx.Client.CoreV1().Pods(ctx.Namespace).List(meta.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(pods.Items) == 0 {
+			return false, fmt.Errorf("the number of pods in the %s namespace should exceed zero", ctx.Namespace)
+		}
+
+		for _, pod := range pods.Items {
+			podIsReady, readyContainers := checkPodStatus(pod)
+			if podIsReady {
+				readyPods = append(readyPods, pod.Name)
+				continue
+			}
+
+			unreadyPods = append(unreadyPods, podStat{
+				PodName: pod.Name,
+				Ready:   readyContainers,
+				Total:   len(pod.Status.ContainerStatuses),
+			})
+		}
+
+		logPollingSummary(ctx.Logger, ctx.TargetPods, readyPods, unreadyPods)
+
+		return len(pods.Items) == ctx.TargetPods && len(unreadyPods) == 0, nil
+	})
+	if err != nil {
+		return fmt.Errorf("the metering pods failed to report a ready status before the timeout period occurred: %v", err)
+	}
+
+	ctx.Logger.Infof("Installing metering took %v", time.Since(start))
+
+	return nil
+}
+
+// GetRouteBearerToken queries the ctx.Namespace for the reporting-operator service account and attempts
+// to find the secret that contains the reporting-operator token. If that secret exists, return the
+// string representation of the token (key) byte slice (value), or return an error.
+func (ctx *DeployerCtx) GetRouteBearerToken() (string, error) {
+	var sa *v1.ServiceAccount
+	var err error
+
+	ctx.Logger.Infof("Waiting for the reporting-operator service account to be created")
+	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		sa, err = ctx.Client.CoreV1().ServiceAccounts(ctx.Namespace).Get(reportingOperatorServiceAccountName, meta.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		ctx.Logger.Infof("The %s service account has been created", reportingOperatorServiceAccountName)
+		return true, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get the %s service account before timeout has occurred: %v", reportingOperatorServiceAccountName, err)
+	}
+
+	if len(sa.Secrets) == 0 {
+		return "", fmt.Errorf("failed to return a list of secrets in the reporting-operator service account")
+	}
+
+	var secretName string
+
+	for _, secret := range sa.Secrets {
+		if strings.Contains(secret.Name, "token") {
+			secretName = secret.Name
+			break
+		}
+	}
+
+	if secretName == "" {
+		return "", fmt.Errorf("failed to get the secret token for the reporting-operator serviceaccount")
+	}
+
+	secret, err := ctx.Client.CoreV1().Secrets(ctx.Namespace).Get(secretName, meta.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get the secret containing the reporting-operator service account token: %v", err)
+	}
+
+	return string(secret.Data["token"]), nil
+}

--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -1,0 +1,87 @@
+package deployframework
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	meteringv1 "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1"
+)
+
+const (
+	reportResultsDir                    = "report_results"
+	logDir                              = "logs"
+	meteringconfigDir                   = "meteringconfigs"
+	reportsDir                          = "reports"
+	datasourcesDir                      = "reportdatasources"
+	reportqueriesDir                    = "reportqueries"
+	hivetablesDir                       = "hivetables"
+	prestotablesDir                     = "prestotables"
+	storagelocationsDir                 = "storagelocations"
+	testNamespaceLabel                  = "metering-testing-ns"
+	meteringconfigMetadataName          = "operator-metering"
+	reportingOperatorServiceAccountName = "reporting-operator"
+	defaultPlatform                     = "openshift"
+	defaultDeleteNamespace              = true
+)
+
+// DeployFramework contains all the information necessary to deploy
+// different metering instances and run tests against them
+type DeployFramework struct {
+	NamespacePrefix   string
+	ManifestsDir      string
+	LoggingPath       string
+	CleanupScriptPath string
+	KubeConfigPath    string
+	Logger            logrus.FieldLogger
+	Client            kubernetes.Interface
+	APIExtClient      apiextclientv1beta1.CustomResourceDefinitionsGetter
+	MeteringClient    meteringv1.MeteringV1Interface
+}
+
+// New is the constructor function that creates and returns a new DeployFramework object
+func New(
+	logger logrus.FieldLogger,
+	nsPrefix,
+	manifestDir,
+	kubeconfig,
+	cleanupScriptPath,
+	loggingPath string,
+) (*DeployFramework, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build a kube config from %s: %v", kubeconfig, err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize the k8s clientset: %v", err)
+	}
+
+	apiextClient, err := apiextclientv1beta1.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize the apiextensions clientset: %v", err)
+	}
+
+	meteringClient, err := meteringv1.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize the metering clientset: %v", err)
+	}
+
+	deployFramework := &DeployFramework{
+		NamespacePrefix:   nsPrefix,
+		ManifestsDir:      manifestDir,
+		CleanupScriptPath: cleanupScriptPath,
+		KubeConfigPath:    kubeconfig,
+		LoggingPath:       loggingPath,
+		Logger:            logger,
+		Client:            client,
+		APIExtClient:      apiextClient,
+		MeteringClient:    meteringClient,
+	}
+
+	return deployFramework, nil
+}

--- a/test/deployframework/helpers.go
+++ b/test/deployframework/helpers.go
@@ -1,0 +1,69 @@
+package deployframework
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+func checkPodStatus(pod v1.Pod) (bool, int) {
+	if pod.Status.Phase != v1.PodRunning {
+		return false, 0
+	}
+
+	var unreadyContainers int
+
+	for _, status := range pod.Status.ContainerStatuses {
+		if !status.Ready {
+			unreadyContainers++
+		}
+	}
+
+	return unreadyContainers == 0, len(pod.Status.ContainerStatuses) - unreadyContainers
+}
+
+func createResourceDirs(namespace, path string) ([]string, error) {
+	envVarArr := []string{
+		"METERING_TEST_NAMESPACE=" + namespace,
+	}
+
+	testDirsMap := map[string]string{
+		logDir:              "LOG_DIR",
+		reportsDir:          "REPORTS_DIR",
+		meteringconfigDir:   "METERINGCONFIGS_DIR",
+		datasourcesDir:      "DATASOURCES_DIR",
+		reportqueriesDir:    "REPORTQUERIES_DIR",
+		hivetablesDir:       "HIVETABLES_DIR",
+		prestotablesDir:     "PRESTOTABLES_DIR",
+		storagelocationsDir: "STORAGELOCATIONS_DIR",
+	}
+
+	for dirname, env := range testDirsMap {
+		dirPath := filepath.Join(path, dirname)
+
+		err := os.MkdirAll(dirPath, 0777)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the directory %s: %v", dirPath, err)
+		}
+
+		envVarArr = append(envVarArr, env+"="+dirPath)
+	}
+
+	return envVarArr, nil
+}
+
+func logPollingSummary(logger logrus.FieldLogger, targetPods int, readyPods []string, unreadyPods []podStat) {
+	logger.Infof("Poll Summary")
+	logger.Infof("Current ratio of ready to target pods: %d/%d", len(readyPods), targetPods)
+
+	for _, unreadyPod := range unreadyPods {
+		if unreadyPod.Total == 0 {
+			logger.Infof("Pod %s is pending", unreadyPod.PodName)
+			continue
+		}
+		logger.Infof("Pod %s has %d/%d ready containers", unreadyPod.PodName, unreadyPod.Ready, unreadyPod.Total)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -3,57 +3,248 @@ package e2e
 import (
 	"flag"
 	"fmt"
-	"log"
+	"math/rand"
 	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
+	"github.com/operator-framework/operator-metering/test/deployframework"
 	"github.com/operator-framework/operator-metering/test/reportingframework"
+	"github.com/operator-framework/operator-metering/test/testhelpers"
 )
 
 var (
-	testReportingFramework *reportingframework.ReportingFramework
+	df *deployframework.DeployFramework
 
-	reportTestOutputDirectory string
-	runAWSBillingTests        bool
+	runAWSBillingTests         bool
+	meteringOperatorImageRepo  string
+	meteringOperatorImageTag   string
+	reportingOperatorImageRepo string
+	reportingOperatorImageTag  string
+
+	defaultTargetPods = 7
 )
 
 func init() {
-	reportTestOutputDirectory = os.Getenv("TEST_RESULT_REPORT_OUTPUT_DIRECTORY")
-	if reportTestOutputDirectory == "" {
-		log.Fatalf("$TEST_RESULT_REPORT_OUTPUT_DIRECTORY must be set")
-	}
-
-	err := os.MkdirAll(reportTestOutputDirectory, 0777)
-	if err != nil {
-		log.Fatalf("error making directory %s, err: %s", reportTestOutputDirectory, err)
-	}
-
 	runAWSBillingTests = os.Getenv("ENABLE_AWS_BILLING_TESTS") == "true"
+	meteringOperatorImageRepo = os.Getenv("METERING_OPERATOR_IMAGE_REPO")
+	meteringOperatorImageTag = os.Getenv("METERING_OPERATOR_IMAGE_TAG")
+	reportingOperatorImageRepo = os.Getenv("REPORTING_OPERATOR_IMAGE_REPO")
+	reportingOperatorImageTag = os.Getenv("REPORTING_OPERATOR_IMAGE_TAG")
 }
 
 func TestMain(m *testing.M) {
-	kubeconfig := flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
-	ns := flag.String("namespace", "metering-ci", "test namespace")
-	httpsAPI := flag.Bool("https-api", false, "If true, use https to talk to Metering API")
-	useKubeProxyForReportingAPI := flag.Bool("use-kube-proxy-for-reporting-api", false, "If true, uses kubernetes API proxy to access reportingAPI")
-	useRouteForReportingAPI := flag.Bool("use-route-for-reporting-api", true, "If true, uses a route to access reportingAPI")
-	reportingAPIURL := flag.String("reporting-api-url", "", "reporting-operator URL if useKubeProxyForReportingAPI is false")
-	routeBearerToken := flag.String("route-bearer-token", "", "The bearer token to the reporting-operator serviceaccount if use-route-for-reporting-api is set to true")
+	kubeConfigFlag := flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
+	nsPrefixFlag := flag.String("namespace-prefix", "", "The namespace prefix to install the metering resources.")
+	manifestDirFlag := flag.String("deploy-manifests-dir", "../../manifests/deploy", "The absolute/relative path to the metering manifest directory.")
+	cleanupScriptPathFlag := flag.String("cleanup-script-path", "../../hack/run-test-cleanup.sh", "The absolute/relative path to the testing cleanup hack script.")
+	testOutputPathFlag := flag.String("test-output-path", "", "The absolute/relative path that you want to store test logs within.")
+	logLevelFlag := flag.String("log-level", logrus.DebugLevel.String(), "The log level")
 	flag.Parse()
 
+	logger := testhelpers.SetupLogger(*logLevelFlag)
+
 	var err error
-	if testReportingFramework, err = reportingframework.New(*ns, *kubeconfig, *httpsAPI, *useKubeProxyForReportingAPI, *useRouteForReportingAPI, *routeBearerToken, *reportingAPIURL, reportTestOutputDirectory); err != nil {
-		logrus.Fatalf("failed to setup framework: %v\n", err)
+	if df, err = deployframework.New(
+		logger,
+		*nsPrefixFlag,
+		*manifestDirFlag,
+		*kubeConfigFlag,
+		*cleanupScriptPathFlag,
+		*testOutputPathFlag,
+	); err != nil {
+		logger.Fatalf("Failed to create a new deploy framework: %v", err)
 	}
 
 	os.Exit(m.Run())
 }
 
-func TestReportingProducesData(t *testing.T) {
+func TestInstallMeteringAndReportingProducesData(t *testing.T) {
+	testInstallConfigs := []struct {
+		TargetPods                int
+		Name                      string
+		MeteringOperatorImageRepo string
+		MeteringOperatorImageTag  string
+		MeteringConfigSpec        metering.MeteringConfigSpec
+	}{
+		{
+			Name:                      "HDFSInstall",
+			TargetPods:                defaultTargetPods,
+			MeteringOperatorImageRepo: meteringOperatorImageRepo,
+			MeteringOperatorImageTag:  meteringOperatorImageTag,
+			MeteringConfigSpec: metering.MeteringConfigSpec{
+				LogHelmTemplate: testhelpers.PtrToBool(true),
+				UnsupportedFeatures: &metering.UnsupportedFeaturesConfig{
+					EnableHDFS: testhelpers.PtrToBool(true),
+				},
+				Storage: &metering.StorageConfig{
+					Type: "hive",
+					Hive: &metering.HiveStorageConfig{
+						Type: "hdfs",
+						Hdfs: &metering.HiveHDFSConfig{
+							Namenode: "hdfs-namenode-0.hdfs-namenode:9820",
+						},
+					},
+				},
+				ReportingOperator: &metering.ReportingOperator{
+					Spec: &metering.ReportingOperatorSpec{
+						Resources: &v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1"),
+								v1.ResourceMemory: resource.MustParse("250Mi"),
+							},
+						},
+						Image: &metering.ImageConfig{
+							Repository: reportingOperatorImageRepo,
+							Tag:        reportingOperatorImageTag,
+						},
+						Config: &metering.ReportingOperatorConfig{
+							LogLevel: "debug",
+							Prometheus: &metering.ReportingOperatorPrometheusConfig{
+								MetricsImporter: &metering.ReportingOperatorPrometheusMetricsImporterConfig{
+									Config: &metering.ReportingOperatorPrometheusMetricsImporterConfigSpec{
+										ChunkSize:                 &meta.Duration{Duration: 5 * time.Minute},
+										PollInterval:              &meta.Duration{Duration: 30 * time.Second},
+										StepSize:                  &meta.Duration{Duration: 1 * time.Minute},
+										MaxImportBackfillDuration: &meta.Duration{Duration: 15 * time.Minute},
+										MaxQueryRangeDuration:     &meta.Duration{Duration: 5 * time.Minute},
+									},
+								},
+							},
+						},
+					},
+				},
+				Presto: &metering.Presto{
+					Spec: &metering.PrestoSpec{
+						Coordinator: &metering.PrestoCoordinatorSpec{
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+				Hive: &metering.Hive{
+					Spec: &metering.HiveSpec{
+						Metastore: &metering.HiveMetastoreSpec{
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("650Mi"),
+								},
+							},
+							Storage: &metering.HiveMetastoreStorageConfig{
+								Size: "5Gi",
+							},
+						},
+						Server: &metering.HiveServerSpec{
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("500m"),
+									v1.ResourceMemory: resource.MustParse("650Mi"),
+								},
+							},
+						},
+					},
+				},
+				Hadoop: &metering.Hadoop{
+					Spec: &metering.HadoopSpec{
+						HDFS: &metering.HadoopHDFS{
+							Enabled: testhelpers.PtrToBool(true),
+							Datanode: &metering.HadoopHDFSDatanodeSpec{
+								Resources: &v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+								},
+								Storage: &metering.HadoopHDFSStorageConfig{
+									Size: "5Gi",
+								},
+							},
+							Namenode: &metering.HadoopHDFSNamenodeSpec{
+								Resources: &v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+								},
+								Storage: &metering.HadoopHDFSStorageConfig{
+									Size: "5Gi",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testInstallConfigs {
+		t := t
+		testCase := testCase
+
+		t.Run(testCase.Name, func(t *testing.T) {
+			testInstall(t, testCase.MeteringOperatorImageRepo, testCase.MeteringOperatorImageTag, testCase.Name, testCase.TargetPods, testCase.MeteringConfigSpec)
+		})
+	}
+}
+
+func testInstall(
+	t *testing.T,
+	repo,
+	tag,
+	testName string,
+	targetPods int,
+	spec metering.MeteringConfigSpec,
+) {
+	// create a directory used to store the @testName container and resource logs
+	testOutputDir := filepath.Join(df.LoggingPath, testName)
+	err := os.Mkdir(testOutputDir, 0777)
+	assert.NoError(t, err, "creating the test case output directory should produce no error")
+
+	// randomize the namespace to avoid existing namespaces
+	rand.Seed(time.Now().UnixNano())
+	namespace := df.NamespacePrefix + "-" + strconv.Itoa(rand.Intn(50))
+
+	deployerCtx, err := df.NewDeployerCtx(repo, tag, namespace, testOutputDir, targetPods, spec)
+	assert.NoError(t, err, "creating a new deployer context should produce no error")
+
+	rf, err := deployerCtx.Setup()
+	assert.NoError(t, err, "deploying metering should produce no error")
+
+	defer func() {
+		err := deployerCtx.Teardown(df.CleanupScriptPath)
+		assert.NoError(t, err, "capturing logs and uninstalling metering should produce no error")
+	}()
+
+	// note: in order to respect the defer closure and cleanup responsibly, we need
+	// to avoid returning errors or ending the function early as testInstall could
+	// be run in a goroutine - so check if the cfg object is nil to avoid a panic
+	if rf != nil {
+		// note: we need to run the testReportingProducesData as a group in order
+		// to avoid preemptively running the defer closure early and uninstalling
+		// the metering resources during the middle of the test execution
+		// for more information, see:
+		// https://github.com/golang/go/issues/22993
+		// https://github.com/golang/go/issues/31651
+		t.Run("testReportingProducesData", func(t *testing.T) {
+			testReportingProducesData(t, rf)
+		})
+	}
+}
+
+func testReportingProducesData(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
 	// cron schedule to run every minute
 	cronSchedule := &metering.ReportSchedule{
 		Period: metering.ReportPeriodCron,

--- a/test/testhelpers/helpers.go
+++ b/test/testhelpers/helpers.go
@@ -1,6 +1,7 @@
 package testhelpers
 
 import (
+	"github.com/sirupsen/logrus"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -130,4 +131,29 @@ func (store *ReportStore) GetReport(namespace, name string) (*metering.Report, e
 		return report, nil
 	}
 	return nil, errors.NewNotFound(metering.Resource("Report"), name)
+}
+
+func PtrToBool(val bool) *bool {
+	return &val
+}
+
+func SetupLogger(logLevelStr string) logrus.FieldLogger {
+	var err error
+
+	logrus.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: "01-02-2006 15:04:05",
+	})
+
+	logger := logrus.WithFields(logrus.Fields{
+		"app": "deploy",
+	})
+	logLevel, err := logrus.ParseLevel(logLevelStr)
+	if err != nil {
+		logger.WithError(err).Fatalf("invalid log level: %s", logLevel)
+	}
+	logger.Infof("Setting the log level to %s", logLevel.String())
+	logger.Logger.Level = logLevel
+
+	return logger
 }


### PR DESCRIPTION
### Overview:
This would refactor the e2e package (`/test/e2e/`) to be responsible for both deploying metering and running the reporting tests against that deployment. This PR adds a `deployframework` package that's in charge of ensuring all of the metering resources are installed and ready to proceed to run the reporting tests, then outputs the resource and container logs to a directory before uninstalling the metering deployment after the testing phase has completed.

It's important to note that the teardown method for the deploy framework calls a bash script, so now the default behavior for when tests complete is to store logs first, then output the test results.

### TODO:
- [x] Support overriding the metering and reporting operator images.
- [x] Log test output for go junit reports.
- [x] Pass a base directory for test output to the e2e package.
- [x] Support creating a specified dir and a temp dir when unspecified.
- [x] Update `testInstall` to respect the defer closure call.
- [x] Update the teardown method to ensure `df.Deployer.Uninstall()` is ran.

### Follow-up PRs:
- Pass clientsets to `reportingframework.New` instead of that method creating the clientsets explicitly
- Support a partial install of metering
- Support running tests on an existing namespace
- Support validating storage spec without installing metering.