### PR TITLE
test/reportingframework: Stat the report output directory.

### DIFF
--- a/test/reportingframework/framework.go
+++ b/test/reportingframework/framework.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -95,6 +96,14 @@ func New(
 	meteringClient, err := metering.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("creating monitoring client failed: err %v", err)
+	}
+
+	stat, err := os.Stat(reportOutputDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat the path to the report results directory %s: %v", reportOutputDir, err)
+	}
+	if !stat.IsDir() {
+		return nil, fmt.Errorf("the %s path to the report results directory is not a directory", reportOutputDir)
 	}
 
 	rf := &ReportingFramework{


### PR DESCRIPTION
This would add a validation check that the path to the intended report output directory that's passed to the reportingframework constructor is a real directory. 

This is nice to have as metering needs to be deployed before running any tests, so waiting for that stack to become ready, and failing the reporting tests due to an empty/invalid `reportOutputDir` is a waste of time/resources.