### PR TITLE
pkg/deploy: Support passing extra namespace labels for use in testing.

### DIFF
--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -64,6 +64,7 @@ type Config struct {
 	Platform               string
 	Repo                   string
 	Tag                    string
+	ExtraNamespaceLabels   map[string]string
 	OperatorResources      *OperatorResources
 	MeteringConfig         *meteringv1.MeteringConfig
 }

--- a/pkg/operator/deploy/install.go
+++ b/pkg/operator/deploy/install.go
@@ -16,13 +16,19 @@ func (deploy *Deployer) installNamespace() error {
 			Name: deploy.config.Namespace,
 		}
 
+		labels := make(map[string]string)
+
+		for key, val := range deploy.config.ExtraNamespaceLabels {
+			labels[key] = val
+			deploy.logger.Infof("Labeling the %s namespace with '%s=%s'", deploy.config.Namespace, key, val)
+		}
+
 		if deploy.config.Platform == "openshift" {
-			namespaceObjectMeta.Labels = map[string]string{
-				"openshift.io/cluster-monitoring": "true",
-			}
+			labels["openshift.io/cluster-monitoring"] = "true"
 			deploy.logger.Infof("Labeling the %s namespace with 'openshift.io/cluster-monitoring=true'", deploy.config.Namespace)
 		}
 
+		namespaceObjectMeta.Labels = labels
 		namespaceObj := &v1.Namespace{
 			ObjectMeta: namespaceObjectMeta,
 		}


### PR DESCRIPTION
This would add the functionality to pass extra namespace labels, which can be used in the e2e/integration refactoring for easier cleanup, e.g.
```go
cfg.ExtraNamespaceLabels = map[string]string{"name": "metering-testing-ns"}
```
This is useful in the case where there's existing namespaces with the label defined above that you want to cleanup, e.g.:
```bash
kubectl delete namespace -l name=metering-testing-ns
```