### PR TITLE
images: Update the HDFS pod security to run as root user.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -355,6 +355,8 @@ _ocp_disabled_overrides:
       hdfs:
         securityContext:
           fsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
 
 _ocp_enabled_overrides:
   reporting-operator:


### PR DESCRIPTION
When installing the upstream metering package, the `hdfs-datanode-*` pod is unable to report a ready status. 

Updating the `spec.hadoop.spec.hdfs.securityContext` field in the `_ocp_disabled_overrides` dictionary needs to be updated in order for the pod to be run as a root user.