### PR TITLE
bug 1763306: Fix setting default fileformat for Hive tables

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -1965,8 +1965,6 @@ spec:
                               type: string
                             username:
                               type: string
-                        defaultCompression:
-                          type: string
                         defaultFileFormat:
                           type: string
                         hadoopConfigSecretName:

--- a/charts/openshift-metering/templates/hive/hive-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-configmap.yaml
@@ -81,7 +81,7 @@ data:
         <name>hive.metastore.schema.verification</name>
         <value>{{ .Values.hive.spec.config.db.enableMetastoreSchemaVerification }}</value>
       </property>
-{{- if .Values.hive.spec.config.db.defaultFileFormat }}
+{{- if .Values.hive.spec.config.defaultFileFormat }}
       <property>
         <name>hive.default.fileformat</name>
         <value>{{ .Values.hive.spec.config.defaultFileFormat }}</value>

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -641,7 +641,6 @@ hive:
       metastoreClientSocketTimeout: null
       metastoreWarehouseDir: null
 
-      defaultCompression: zlib
       defaultFileFormat: orc
 
       hadoopConfigSecretName: hadoop-config

--- a/manifests/deploy/ocp-testing/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/ocp-testing/metering-ansible-operator/meteringconfig.crd.yaml
@@ -1964,8 +1964,6 @@ spec:
                               type: string
                             username:
                               type: string
-                        defaultCompression:
-                          type: string
                         defaultFileFormat:
                           type: string
                         hadoopConfigSecretName:

--- a/manifests/deploy/ocp-testing/olm/bundle/4.3/meteringconfig.crd.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.3/meteringconfig.crd.yaml
@@ -1964,8 +1964,6 @@ spec:
                               type: string
                             username:
                               type: string
-                        defaultCompression:
-                          type: string
                         defaultFileFormat:
                           type: string
                         hadoopConfigSecretName:

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -1964,8 +1964,6 @@ spec:
                               type: string
                             username:
                               type: string
-                        defaultCompression:
-                          type: string
                         defaultFileFormat:
                           type: string
                         hadoopConfigSecretName:

--- a/manifests/deploy/openshift/olm/bundle/4.3/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.3/meteringconfig.crd.yaml
@@ -1964,8 +1964,6 @@ spec:
                               type: string
                             username:
                               type: string
-                        defaultCompression:
-                          type: string
                         defaultFileFormat:
                           type: string
                         hadoopConfigSecretName:

--- a/manifests/deploy/openshift/telemeter/list.yaml
+++ b/manifests/deploy/openshift/telemeter/list.yaml
@@ -648,8 +648,6 @@ objects:
                               username:
                                 type: string
                             type: object
-                          defaultCompression:
-                            type: string
                           defaultFileFormat:
                             type: string
                           gcs:

--- a/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
@@ -1964,8 +1964,6 @@ spec:
                               type: string
                             username:
                               type: string
-                        defaultCompression:
-                          type: string
                         defaultFileFormat:
                           type: string
                         hadoopConfigSecretName:

--- a/manifests/deploy/upstream/olm/bundle/4.3/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.3/meteringconfig.crd.yaml
@@ -1964,8 +1964,6 @@ spec:
                               type: string
                             username:
                               type: string
-                        defaultCompression:
-                          type: string
                         defaultFileFormat:
                           type: string
                         hadoopConfigSecretName:


### PR DESCRIPTION
This setting only affects new tables, so doing this shouldn't have any major
backwards compatible issues, as we shouldn't be assuming anything about the
table formats anyways, since it could be changed.

/hold
We will likely want to file a bug and backport to 4.2.1 so that new installs are more likely to get ORC for all new tables.