### PR TITLE
charts/openshift-metering: Support annotations on service accounts

### DIFF
--- a/charts/openshift-metering/templates/hadoop/hdfs-serviceaccount.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-serviceaccount.yaml
@@ -3,4 +3,8 @@ kind: ServiceAccount
 metadata:
   name: hdfs
   labels:
-      app: hdfs
+    app: hdfs
+{{- if .Values.hadoop.spec.hdfs.namenode.annotations }}
+  annotations:
+{{ toYaml .Values.hadoop.spec.hdfs.namenode.annotations | indent 4 }}
+{{- end }}

--- a/charts/openshift-metering/templates/hive/hive-serviceaccount.yaml
+++ b/charts/openshift-metering/templates/hive/hive-serviceaccount.yaml
@@ -2,3 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hive
+  labels:
+    app: hive
+{{- if .Values.hive.spec.annotations }}
+  annotations:
+{{ toYaml .Values.hive.spec.annotations | indent 4 }}
+{{- end }}

--- a/charts/openshift-metering/templates/presto/presto-serviceaccount.yaml
+++ b/charts/openshift-metering/templates/presto/presto-serviceaccount.yaml
@@ -2,3 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: presto
+  labels:
+    app: presto
+{{- if .Values.presto.spec.annotations }}
+  annotations:
+{{ toYaml .Values.presto.spec.annotations | indent 4 }}
+{{- end }}

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-serviceaccount.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-serviceaccount.yaml
@@ -5,7 +5,10 @@ metadata:
   name: reporting-operator
   labels:
     app: reporting-operator
-{{- if and $operatorValues.spec.authProxy.enabled $operatorValues.spec.route.enabled }}
   annotations:
+{{- if and $operatorValues.spec.authProxy.enabled $operatorValues.spec.route.enabled }}
     serviceaccounts.openshift.io/oauth-redirectreference.reporting-operator: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{ $operatorValues.spec.route.name }}"}}'
+{{- end }}
+{{- if $operatorValues.spec.annotations }}
+{{ toYaml $operatorValues.spec.annotations | indent 4 }}
 {{- end }}


### PR DESCRIPTION
This re-uses spec.annotations for each component that are also set on
the pod template annotations to allow additionally setting annotations
on the pod service accounts.

Also adds app labels to each service account.

Partial fix for #947