### PR TITLE
test/deployframework: Ensure the overrided reporting-operator image isn't empty.

### DIFF
--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -31,15 +31,17 @@ const (
 // DeployFramework contains all the information necessary to deploy
 // different metering instances and run tests against them
 type DeployFramework struct {
-	NamespacePrefix   string
-	ManifestsDir      string
-	LoggingPath       string
-	CleanupScriptPath string
-	KubeConfigPath    string
-	Logger            logrus.FieldLogger
-	Client            kubernetes.Interface
-	APIExtClient      apiextclientv1beta1.CustomResourceDefinitionsGetter
-	MeteringClient    meteringv1.MeteringV1Interface
+	NamespacePrefix            string
+	ManifestsDir               string
+	LoggingPath                string
+	CleanupScriptPath          string
+	KubeConfigPath             string
+	ReportingOperatorImageRepo string
+	ReportingOperatorImageTag  string
+	Logger                     logrus.FieldLogger
+	Client                     kubernetes.Interface
+	APIExtClient               apiextclientv1beta1.CustomResourceDefinitionsGetter
+	MeteringClient             meteringv1.MeteringV1Interface
 }
 
 // New is the constructor function that creates and returns a new DeployFramework object
@@ -49,7 +51,9 @@ func New(
 	manifestDir,
 	kubeconfig,
 	cleanupScriptPath,
-	loggingPath string,
+	loggingPath,
+	reportingOperatorImageRepo,
+	reportingOperatorImageTag string,
 ) (*DeployFramework, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -72,15 +76,17 @@ func New(
 	}
 
 	deployFramework := &DeployFramework{
-		NamespacePrefix:   nsPrefix,
-		ManifestsDir:      manifestDir,
-		CleanupScriptPath: cleanupScriptPath,
-		KubeConfigPath:    kubeconfig,
-		LoggingPath:       loggingPath,
-		Logger:            logger,
-		Client:            client,
-		APIExtClient:      apiextClient,
-		MeteringClient:    meteringClient,
+		NamespacePrefix:            nsPrefix,
+		ManifestsDir:               manifestDir,
+		CleanupScriptPath:          cleanupScriptPath,
+		KubeConfigPath:             kubeconfig,
+		LoggingPath:                loggingPath,
+		ReportingOperatorImageRepo: reportingOperatorImageRepo,
+		ReportingOperatorImageTag:  reportingOperatorImageTag,
+		Logger:                     logger,
+		Client:                     client,
+		APIExtClient:               apiextClient,
+		MeteringClient:             meteringClient,
 	}
 
 	return deployFramework, nil

--- a/test/deployframework/helpers.go
+++ b/test/deployframework/helpers.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 )
@@ -66,4 +68,21 @@ func logPollingSummary(logger logrus.FieldLogger, targetPods int, readyPods []st
 		}
 		logger.Infof("Pod %s has %d/%d ready containers", unreadyPod.PodName, unreadyPod.Ready, unreadyPod.Total)
 	}
+}
+
+func validateImageConfig(image metering.ImageConfig) error {
+	var errArr []string
+
+	if image.Repository == "" {
+		errArr = append(errArr, "the image repository is empty")
+	}
+	if image.Tag == "" {
+		errArr = append(errArr, "the image tag is empty")
+	}
+
+	if len(errArr) != 0 {
+		return fmt.Errorf(strings.Join(errArr, "\n"))
+	}
+
+	return nil
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -62,6 +62,8 @@ func TestMain(m *testing.M) {
 		*kubeConfigFlag,
 		*cleanupScriptPathFlag,
 		*testOutputPathFlag,
+		reportingOperatorImageRepo,
+		reportingOperatorImageTag,
 	); err != nil {
 		logger.Fatalf("Failed to create a new deploy framework: %v", err)
 	}
@@ -202,8 +204,8 @@ func TestInstallMeteringAndReportingProducesData(t *testing.T) {
 
 func testInstall(
 	t *testing.T,
-	repo,
-	tag,
+	meteringOperatorImageRepo,
+	meteringOperatorImageTag,
 	testName string,
 	targetPods int,
 	spec metering.MeteringConfigSpec,
@@ -217,7 +219,7 @@ func testInstall(
 	rand.Seed(time.Now().UnixNano())
 	namespace := df.NamespacePrefix + "-" + strconv.Itoa(rand.Intn(50))
 
-	deployerCtx, err := df.NewDeployerCtx(repo, tag, namespace, testOutputDir, targetPods, spec)
+	deployerCtx, err := df.NewDeployerCtx(meteringOperatorImageRepo, meteringOperatorImageTag, namespace, testOutputDir, targetPods, spec)
 	assert.NoError(t, err, "creating a new deployer context should produce no error")
 
 	rf, err := deployerCtx.Setup()


### PR DESCRIPTION
As we push towards refactoring the e2e/integration suites, we need to ensure that overriding the reporting-operator images works as intended. 

This PR adds a testhelper function that validates if the image repository or tag are empty, when that image is overrided.