### PR TITLE
Return correct resource_id for Azure

### DIFF
--- a/charts/openshift-metering/templates/openshift-reporting/report-queries/node-cpu.yaml
+++ b/charts/openshift-metering/templates/openshift-reporting/report-queries/node-cpu.yaml
@@ -37,7 +37,13 @@ spec:
     SELECT labels['node'] as node,
         labels,
         amount as node_capacity_cpu_cores,
-        split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as resource_id,
+        CASE
+          WHEN split_part(element_at(labels, 'provider_id'), ':///', 1) = 'aws'
+            THEN split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2)
+          WHEN split_part(element_at(labels, 'provider_id'), ':///', 1) = 'azure'
+            THEN split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 8)
+          ELSE split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2)
+        END as resource_id,
         timeprecision,
         amount * timeprecision as node_capacity_cpu_core_seconds,
         "timestamp",
@@ -126,7 +132,13 @@ spec:
     SELECT labels['node'] as node,
         labels,
         amount as node_allocatable_cpu_cores,
-        split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as resource_id,
+        CASE
+          WHEN split_part(element_at(labels, 'provider_id'), ':///', 1) = 'aws'
+            THEN split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2)
+          WHEN split_part(element_at(labels, 'provider_id'), ':///', 1) = 'azure'
+            THEN split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 8)
+          ELSE split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2)
+        END as resource_id,
         timeprecision,
         amount * timeprecision as node_allocatable_cpu_core_seconds,
         "timestamp",

--- a/charts/openshift-metering/templates/openshift-reporting/report-queries/node-memory.yaml
+++ b/charts/openshift-metering/templates/openshift-reporting/report-queries/node-memory.yaml
@@ -38,7 +38,13 @@ spec:
     SELECT labels['node'] as node,
         labels,
         amount as node_capacity_memory_bytes,
-        split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as resource_id,
+        CASE
+          WHEN split_part(element_at(labels, 'provider_id'), ':///', 1) = 'aws'
+            THEN split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2)
+          WHEN split_part(element_at(labels, 'provider_id'), ':///', 1) = 'azure'
+            THEN split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 8)
+          ELSE split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2)
+        END as resource_id,
         timeprecision,
         amount * timeprecision as node_capacity_memory_byte_seconds,
         "timestamp",
@@ -128,7 +134,13 @@ spec:
     SELECT labels['node'] as node,
         labels,
         amount as node_allocatable_memory_bytes,
-        split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2) as resource_id,
+        CASE
+          WHEN split_part(element_at(labels, 'provider_id'), ':///', 1) = 'aws'
+            THEN split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2)
+          WHEN split_part(element_at(labels, 'provider_id'), ':///', 1) = 'azure'
+            THEN split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 8)
+          ELSE split_part(split_part(element_at(labels, 'provider_id'), ':///', 2), '/', 2)
+        END as resource_id,
         timeprecision,
         amount * timeprecision as node_allocatable_memory_byte_seconds,
         "timestamp",


### PR DESCRIPTION
## Summary

The proposed change here uses a CASE statement to return the correct resource_id depending on the cloud the cluster is installed in. This adds support for Azure to the resource_id column. 