### PR TITLE
cmd,pkg/deploy: Remove the nested logging and fix linting errors.

### DIFF
--- a/cmd/deploy-metering/main.go
+++ b/cmd/deploy-metering/main.go
@@ -88,17 +88,17 @@ func runDeployMetering(cmd *cobra.Command, args []string) error {
 	logger := setupLogger(logLevel)
 
 	if meteringConfigCRFile == "" {
-		return fmt.Errorf("Failed to set the $METERING_CR_FILE or --meteringconfig flag")
+		return fmt.Errorf("failed to set the $METERING_CR_FILE or --meteringconfig flag")
 	}
 
 	err := deploy.DecodeYAMLManifestToObject(meteringConfigCRFile, &cfg.MeteringConfig)
 	if err != nil {
-		return fmt.Errorf("Failed to read MeteringConfig: %v", err)
+		return fmt.Errorf("failed to read MeteringConfig: %v", err)
 	}
 
 	cfg.OperatorResources, err = deploy.ReadMeteringAnsibleOperatorManifests(deployManifestsDir, cfg.Platform)
 	if err != nil {
-		return fmt.Errorf("Failed to read metering-ansible-operator manifests: %v", err)
+		return fmt.Errorf("failed to read metering-ansible-operator manifests: %v", err)
 	}
 
 	logger.Debugf("Metering Deploy Config: %#v", cfg)
@@ -110,39 +110,39 @@ func runDeployMetering(cmd *cobra.Command, args []string) error {
 
 	restconfig, err := kubeconfig.ClientConfig()
 	if err != nil {
-		return fmt.Errorf("Failed to initialize the kubernetes client config: %v", err)
+		return fmt.Errorf("failed to initialize the kubernetes client config: %v", err)
 	}
 
 	client, err := kubernetes.NewForConfig(restconfig)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize the kubernetes clientset: %v", err)
+		return fmt.Errorf("failed to initialize the kubernetes clientset: %v", err)
 	}
 
 	apiextClient, err := apiextclientv1beta1.NewForConfig(restconfig)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize the apiextensions clientset: %v", err)
+		return fmt.Errorf("failed to initialize the apiextensions clientset: %v", err)
 	}
 
 	meteringClient, err := metering.NewForConfig(restconfig)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize the metering clientset: %v", err)
+		return fmt.Errorf("failed to initialize the metering clientset: %v", err)
 	}
 
 	deployObj, err := deploy.NewDeployer(cfg, logger, client, apiextClient, meteringClient)
 	if err != nil {
-		return fmt.Errorf("Failed to deploy metering: %v", err)
+		return fmt.Errorf("failed to deploy metering: %v", err)
 	}
 
 	if deployType == "install" {
 		err := deployObj.Install()
 		if err != nil {
-			return fmt.Errorf("Failed to install metering: %v", err)
+			return fmt.Errorf("failed to install metering: %v", err)
 		}
 		logger.Infof("Finished installing metering")
 	} else if deployType == "uninstall" {
 		err := deployObj.Uninstall()
 		if err != nil {
-			return fmt.Errorf("Failed to uninstall metering: %v", err)
+			return fmt.Errorf("failed to uninstall metering: %v", err)
 		}
 		logger.Infof("Finished uninstall metering")
 	}
@@ -228,12 +228,12 @@ func mapEnvVarToFlag(vars map[string]string, flagset *pflag.FlagSet) error {
 	for env, flag := range vars {
 		flagObj := flagset.Lookup(flag)
 		if flagObj == nil {
-			return fmt.Errorf("The %s flag doesn't exist", flag)
+			return fmt.Errorf("the %s flag doesn't exist", flag)
 		}
 
 		if val := os.Getenv(env); val != "" {
 			if err := flagObj.Value.Set(val); err != nil {
-				return fmt.Errorf("Failed to set the %s flag: %v", flag, err)
+				return fmt.Errorf("failed to set the %s flag: %v", flag, err)
 			}
 		}
 

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -122,7 +122,7 @@ func NewDeployer(
 	}
 
 	if deploy.config.Namespace == "" {
-		return deploy, fmt.Errorf("Failed to set $METERING_NAMESPACE or --namespace flag")
+		return deploy, fmt.Errorf("failed to set $METERING_NAMESPACE or --namespace flag")
 	}
 
 	return deploy, nil
@@ -133,24 +133,24 @@ func NewDeployer(
 func (deploy *Deployer) Install() error {
 	err := deploy.installNamespace()
 	if err != nil {
-		return fmt.Errorf("Failed to create the %s namespace: %v", deploy.config.Namespace, err)
+		return fmt.Errorf("failed to create the %s namespace: %v", deploy.config.Namespace, err)
 	}
 
 	err = deploy.installMeteringCRDs()
 	if err != nil {
-		return fmt.Errorf("Failed to create the Metering CRDs: %v", err)
+		return fmt.Errorf("failed to create the Metering CRDs: %v", err)
 	}
 
 	if !deploy.config.SkipMeteringDeployment {
 		err = deploy.installMeteringResources()
 		if err != nil {
-			return fmt.Errorf("Failed to create the metering resources: %v", err)
+			return fmt.Errorf("failed to create the metering resources: %v", err)
 		}
 	}
 
 	err = deploy.installMeteringConfig()
 	if err != nil {
-		return fmt.Errorf("Failed to create the MeteringConfig resource: %v", err)
+		return fmt.Errorf("failed to create the MeteringConfig resource: %v", err)
 	}
 
 	return nil
@@ -162,18 +162,18 @@ func (deploy *Deployer) Install() error {
 func (deploy *Deployer) Uninstall() error {
 	err := deploy.uninstallMeteringConfig()
 	if err != nil {
-		return fmt.Errorf("Failed to delete the MeteringConfig resource: %v", err)
+		return fmt.Errorf("failed to delete the MeteringConfig resource: %v", err)
 	}
 
 	err = deploy.uninstallMeteringResources()
 	if err != nil {
-		return fmt.Errorf("Failed to delete the metering resources: %v", err)
+		return fmt.Errorf("failed to delete the metering resources: %v", err)
 	}
 
 	if deploy.config.DeleteCRDs {
 		err = deploy.uninstallMeteringCRDs()
 		if err != nil {
-			return fmt.Errorf("Failed to delete the Metering CRDs: %v", err)
+			return fmt.Errorf("failed to delete the Metering CRDs: %v", err)
 		}
 	} else {
 		deploy.logger.Infof("Skipped deleting the metering CRDs")
@@ -182,7 +182,7 @@ func (deploy *Deployer) Uninstall() error {
 	if deploy.config.DeleteNamespace {
 		err = deploy.uninstallNamespace()
 		if err != nil {
-			return fmt.Errorf("Failed to delete the %s namespace: %v", deploy.config.Namespace, err)
+			return fmt.Errorf("failed to delete the %s namespace: %v", deploy.config.Namespace, err)
 		}
 	} else {
 		deploy.logger.Infof("Skipped deleting the %s namespace", deploy.config.Namespace)

--- a/pkg/operator/deploy/helpers.go
+++ b/pkg/operator/deploy/helpers.go
@@ -23,7 +23,7 @@ func getBoolEnv(env string, defaultVal bool) (bool, error) {
 
 	val, err := strconv.ParseBool(key)
 	if err != nil {
-		return false, fmt.Errorf("Failed to convert the %s env variable into a boolean: %v", env, err)
+		return false, fmt.Errorf("failed to convert the %s env variable into a boolean: %v", env, err)
 	}
 
 	return val, nil
@@ -35,7 +35,7 @@ func getBoolEnv(env string, defaultVal bool) (bool, error) {
 func DecodeYAMLManifestToObject(path string, resource interface{}) error {
 	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("Failed to open %s, got: %v", path, err)
+		return fmt.Errorf("failed to open %s, got: %v", path, err)
 	}
 
 	err = yaml.NewYAMLOrJSONDecoder(file, 100).Decode(&resource)
@@ -93,20 +93,20 @@ func InitMeteringCRDSlice(manifestDir string, pathToCRDMap map[string]string) []
 
 func getMeteringAnsiblePath(manifestDir, platform string) (string, error) {
 	if manifestDir == "" {
-		return "", fmt.Errorf("Failed to set the $DEPLOY_MANIFESTS_DIR or --deploy-manifests-dir flag to a non-empty value")
+		return "", fmt.Errorf("failed to set the $DEPLOY_MANIFESTS_DIR or --deploy-manifests-dir flag to a non-empty value")
 	}
 
 	deployDir, err := filepath.Abs(manifestDir)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get the absolute path of the manifest/deploy directory %s: %v", manifestDir, err)
+		return "", fmt.Errorf("failed to get the absolute path of the manifest/deploy directory %s: %v", manifestDir, err)
 	}
 
 	dirStat, err := os.Stat(manifestDir)
 	if os.IsNotExist(err) {
-		return "", fmt.Errorf("Failed to get the stat the manifest/deploy directory %s: %v", manifestDir, err)
+		return "", fmt.Errorf("failed to get the stat the manifest/deploy directory %s: %v", manifestDir, err)
 	}
 	if !dirStat.IsDir() {
-		return "", fmt.Errorf("Specified deploy directory '%s' is not a directory", manifestDir)
+		return "", fmt.Errorf("specified deploy directory '%s' is not a directory", manifestDir)
 	}
 
 	var ansibleOperatorManifestDir string
@@ -119,15 +119,15 @@ func getMeteringAnsiblePath(manifestDir, platform string) (string, error) {
 	case "ocp-testing":
 		ansibleOperatorManifestDir = filepath.Join(deployDir, ocpTestingManifestDirname, manifestAnsibleOperator)
 	default:
-		return "", fmt.Errorf("Failed to set $DEPLOY_PLATFORM or --platform flag to a valid value. Supported platforms: [upstream, openshift, ocp-testing]")
+		return "", fmt.Errorf("failed to set $DEPLOY_PLATFORM or --platform flag to a valid value. Supported platforms: [upstream, openshift, ocp-testing]")
 	}
 
 	dirStat, err = os.Stat(ansibleOperatorManifestDir)
 	if os.IsNotExist(err) {
-		return "", fmt.Errorf("Failed to stat the %s deploy platform directory '%s': %v", platform, ansibleOperatorManifestDir, err)
+		return "", fmt.Errorf("failed to stat the %s deploy platform directory '%s': %v", platform, ansibleOperatorManifestDir, err)
 	}
 	if !dirStat.IsDir() {
-		return "", fmt.Errorf("Specified %s deploy platform directory '%s' is not a directory", platform, ansibleOperatorManifestDir)
+		return "", fmt.Errorf("specified %s deploy platform directory '%s' is not a directory", platform, ansibleOperatorManifestDir)
 	}
 
 	return ansibleOperatorManifestDir, nil
@@ -138,7 +138,7 @@ func ReadMeteringAnsibleOperatorManifests(manifestDir, platform string) (*Operat
 
 	ansibleOperatorManifestDir, err := getMeteringAnsiblePath(manifestDir, platform)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get the path to the metering-ansible-operator directory: %v", err)
+		return nil, fmt.Errorf("failed to get the path to the metering-ansible-operator directory: %v", err)
 	}
 
 	pathToCRDMap := map[string]string{
@@ -156,7 +156,7 @@ func ReadMeteringAnsibleOperatorManifests(manifestDir, platform string) (*Operat
 	for _, crd := range resources.CRDs {
 		err := DecodeYAMLManifestToObject(crd.Path, crd.CRD)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to decode the YAML manifest: %v", err)
+			return nil, fmt.Errorf("failed to decode the YAML manifest: %v", err)
 		}
 	}
 
@@ -195,7 +195,7 @@ func ReadMeteringAnsibleOperatorManifests(manifestDir, platform string) (*Operat
 
 		err = DecodeYAMLManifestToObject(path, resource.obj)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to decode the YAML manifest for the %s resource: %v", name, err)
+			return nil, fmt.Errorf("failed to decode the YAML manifest for the %s resource: %v", name, err)
 		}
 	}
 

--- a/pkg/operator/deploy/install.go
+++ b/pkg/operator/deploy/install.go
@@ -29,7 +29,7 @@ func (deploy *Deployer) installNamespace() error {
 
 		_, err := deploy.client.CoreV1().Namespaces().Create(namespaceObj)
 		if err != nil {
-			return fmt.Errorf("Failed to create %s namespace: %v", deploy.config.Namespace, err)
+			return err
 		}
 		deploy.logger.Infof("Created the %s namespace", deploy.config.Namespace)
 	} else if err == nil {
@@ -47,7 +47,7 @@ func (deploy *Deployer) installNamespace() error {
 
 			_, err := deploy.client.CoreV1().Namespaces().Update(namespace)
 			if err != nil {
-				return fmt.Errorf("Failed to add the 'openshift.io/cluster-monitoring' label to the %s namespace: %v", deploy.config.Namespace, err)
+				return fmt.Errorf("failed to add the 'openshift.io/cluster-monitoring' label to the %s namespace: %v", deploy.config.Namespace, err)
 			}
 		} else {
 			deploy.logger.Infof("The %s namespace already exists", deploy.config.Namespace)
@@ -64,7 +64,7 @@ func (deploy *Deployer) installMeteringConfig() error {
 	if apierrors.IsNotFound(err) {
 		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Create(deploy.config.MeteringConfig)
 		if err != nil {
-			return fmt.Errorf("Failed to create the MeteringConfig resource: %v", err)
+			return err
 		}
 		deploy.logger.Infof("Created the MeteringConfig resource")
 	} else if err == nil {
@@ -72,7 +72,7 @@ func (deploy *Deployer) installMeteringConfig() error {
 
 		_, err = deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Update(mc)
 		if err != nil {
-			return fmt.Errorf("Failed to update the MeteringConfig: %v", err)
+			return fmt.Errorf("failed to update the MeteringConfig: %v", err)
 		}
 		deploy.logger.Infof("The MeteringConfig resource has been updated")
 	} else {
@@ -85,32 +85,32 @@ func (deploy *Deployer) installMeteringConfig() error {
 func (deploy *Deployer) installMeteringResources() error {
 	err := deploy.installMeteringDeployment()
 	if err != nil {
-		return fmt.Errorf("Failed to create the metering deployment: %v", err)
+		return fmt.Errorf("failed to create the metering deployment: %v", err)
 	}
 
 	err = deploy.installMeteringServiceAccount()
 	if err != nil {
-		return fmt.Errorf("Failed to create the metering service account: %v", err)
+		return fmt.Errorf("failed to create the metering service account: %v", err)
 	}
 
 	err = deploy.installMeteringRole()
 	if err != nil {
-		return fmt.Errorf("Failed to create the metering role: %v", err)
+		return fmt.Errorf("failed to create the metering role: %v", err)
 	}
 
 	err = deploy.installMeteringRoleBinding()
 	if err != nil {
-		return fmt.Errorf("Failed to create the metering role binding: %v", err)
+		return fmt.Errorf("failed to create the metering role binding: %v", err)
 	}
 
 	err = deploy.installMeteringClusterRole()
 	if err != nil {
-		return fmt.Errorf("Failed to create the metering cluster role: %v", err)
+		return fmt.Errorf("failed to create the metering cluster role: %v", err)
 	}
 
 	err = deploy.installMeteringClusterRoleBinding()
 	if err != nil {
-		return fmt.Errorf("Failed to create the metering cluster role binding: %v", err)
+		return fmt.Errorf("failed to create the metering cluster role binding: %v", err)
 	}
 
 	return nil
@@ -135,7 +135,7 @@ func (deploy *Deployer) installMeteringDeployment() error {
 	if apierrors.IsNotFound(err) {
 		_, err := deploy.client.AppsV1().Deployments(deploy.config.Namespace).Create(res)
 		if err != nil {
-			return fmt.Errorf("Failed to create the metering deployment: %v", err)
+			return err
 		}
 		deploy.logger.Infof("Created the metering deployment")
 	} else if err == nil {
@@ -143,7 +143,7 @@ func (deploy *Deployer) installMeteringDeployment() error {
 
 		_, err = deploy.client.AppsV1().Deployments(deploy.config.Namespace).Update(deployment)
 		if err != nil {
-			return fmt.Errorf("Failed to update the metering deployment: %v", err)
+			return fmt.Errorf("failed to update the metering deployment: %v", err)
 		}
 		deploy.logger.Infof("The metering deployment resource has been updated")
 	} else {
@@ -158,7 +158,7 @@ func (deploy *Deployer) installMeteringServiceAccount() error {
 	if apierrors.IsNotFound(err) {
 		_, err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Create(deploy.config.OperatorResources.ServiceAccount)
 		if err != nil {
-			return fmt.Errorf("Failed to create the metering serviceaccount: %v", err)
+			return err
 		}
 		deploy.logger.Infof("Created the metering serviceaccount")
 	} else if err == nil {
@@ -186,7 +186,7 @@ func (deploy *Deployer) installMeteringRoleBinding() error {
 	if apierrors.IsNotFound(err) {
 		_, err := deploy.client.RbacV1().RoleBindings(deploy.config.Namespace).Create(res)
 		if err != nil {
-			return fmt.Errorf("Failed to create the metering role binding: %v", err)
+			return err
 		}
 		deploy.logger.Infof("Created the metering role binding")
 	} else if err == nil {
@@ -208,7 +208,7 @@ func (deploy *Deployer) installMeteringRole() error {
 	if apierrors.IsNotFound(err) {
 		_, err := deploy.client.RbacV1().Roles(deploy.config.Namespace).Create(res)
 		if err != nil {
-			return fmt.Errorf("Failed to create the metering role: %v", err)
+			return err
 		}
 		deploy.logger.Infof("Created the metering role")
 	} else if err == nil {
@@ -234,7 +234,7 @@ func (deploy *Deployer) installMeteringClusterRoleBinding() error {
 	if apierrors.IsNotFound(err) {
 		_, err := deploy.client.RbacV1().ClusterRoleBindings().Create(res)
 		if err != nil {
-			return fmt.Errorf("Failed to create the metering cluster role, got: %v", err)
+			return err
 		}
 		deploy.logger.Infof("Created the metering cluster role binding")
 	} else if err == nil {
@@ -255,7 +255,7 @@ func (deploy *Deployer) installMeteringClusterRole() error {
 	if apierrors.IsNotFound(err) {
 		_, err := deploy.client.RbacV1().ClusterRoles().Create(res)
 		if err != nil {
-			return fmt.Errorf("Failed to create the metering cluster role: %v", err)
+			return err
 		}
 		deploy.logger.Infof("Created the metering cluster role")
 	} else if err == nil {
@@ -271,7 +271,7 @@ func (deploy *Deployer) installMeteringCRDs() error {
 	for _, crd := range deploy.config.OperatorResources.CRDs {
 		err := deploy.installMeteringCRD(crd)
 		if err != nil {
-			return fmt.Errorf("Failed to create a CRD while looping: %v", err)
+			return fmt.Errorf("failed to create a CRD while looping: %v", err)
 		}
 	}
 
@@ -283,7 +283,7 @@ func (deploy *Deployer) installMeteringCRD(resource CRD) error {
 	if apierrors.IsNotFound(err) {
 		_, err := deploy.apiExtClient.CustomResourceDefinitions().Create(resource.CRD)
 		if err != nil {
-			return fmt.Errorf("Failed to create the %s CRD: %v", resource.CRD.Name, err)
+			return err
 		}
 		deploy.logger.Infof("Created the %s CRD", resource.Name)
 	} else if err == nil {
@@ -291,7 +291,7 @@ func (deploy *Deployer) installMeteringCRD(resource CRD) error {
 
 		_, err := deploy.apiExtClient.CustomResourceDefinitions().Update(crd)
 		if err != nil {
-			return fmt.Errorf("Failed to update the %s CRD: %v", resource.CRD.Name, err)
+			return fmt.Errorf("failed to update the %s CRD: %v", resource.CRD.Name, err)
 		}
 		deploy.logger.Infof("Updated the %s CRD", resource.CRD.Name)
 	} else {

--- a/pkg/operator/deploy/uninstall.go
+++ b/pkg/operator/deploy/uninstall.go
@@ -14,7 +14,7 @@ func (deploy *Deployer) uninstallNamespace() error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the %s namespace", deploy.config.Namespace)
 	} else {
-		return fmt.Errorf("Failed to delete the %s namespace: %v", deploy.config.Namespace, err)
+		return err
 	}
 
 	return nil
@@ -27,7 +27,7 @@ func (deploy *Deployer) uninstallMeteringConfig() error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the MeteringConfig resource")
 	} else {
-		return fmt.Errorf("Failed to delete the MeteringConfig resource: %v", err)
+		return err
 	}
 
 	return nil
@@ -36,33 +36,33 @@ func (deploy *Deployer) uninstallMeteringConfig() error {
 func (deploy *Deployer) uninstallMeteringResources() error {
 	err := deploy.uninstallMeteringDeployment()
 	if err != nil {
-		return fmt.Errorf("Failed to delete the metering service account: %v", err)
+		return fmt.Errorf("failed to delete the metering service account: %v", err)
 	}
 
 	err = deploy.uninstallMeteringServiceAccount()
 	if err != nil {
-		return fmt.Errorf("Failed to delete the metering service account: %v", err)
+		return fmt.Errorf("failed to delete the metering service account: %v", err)
 	}
 
 	err = deploy.uninstallMeteringRole()
 	if err != nil {
-		return fmt.Errorf("Failed to delete the metering role: %v", err)
+		return fmt.Errorf("failed to delete the metering role: %v", err)
 	}
 
 	err = deploy.uninstallMeteringRoleBinding()
 	if err != nil {
-		return fmt.Errorf("Failed to delete the metering role binding: %v", err)
+		return fmt.Errorf("failed to delete the metering role binding: %v", err)
 	}
 
 	if deploy.config.DeleteCRB {
 		err = deploy.uninstallMeteringClusterRole()
 		if err != nil {
-			return fmt.Errorf("Failed to delete the metering cluster role: %v", err)
+			return fmt.Errorf("failed to delete the metering cluster role: %v", err)
 		}
 
 		err = deploy.uninstallMeteringClusterRoleBinding()
 		if err != nil {
-			return fmt.Errorf("Failed to delete the metering cluster role binding: %v", err)
+			return fmt.Errorf("failed to delete the metering cluster role binding: %v", err)
 		}
 	} else {
 		deploy.logger.Infof("Skipped deleting the metering cluster role resources")
@@ -71,7 +71,7 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 	if deploy.config.DeletePVCs {
 		err = deploy.uninstallMeteringPVCs()
 		if err != nil {
-			return fmt.Errorf("Failed to delete the metering PVCs: %v", err)
+			return fmt.Errorf("failed to delete the metering PVCs: %v", err)
 		}
 	} else {
 		deploy.logger.Infof("Skipped deleting the metering PVCs")
@@ -88,7 +88,7 @@ func (deploy *Deployer) uninstallMeteringPVCs() error {
 		LabelSelector: "app in (hdfs,hive)",
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to list all the metering PVCs in the %s namespace: %v", deploy.config.Namespace, err)
+		return fmt.Errorf("failed to list all the metering PVCs in the %s namespace: %v", deploy.config.Namespace, err)
 	}
 
 	if len(pvcs.Items) == 0 {
@@ -99,7 +99,7 @@ func (deploy *Deployer) uninstallMeteringPVCs() error {
 	for _, pvc := range pvcs.Items {
 		err = deploy.client.CoreV1().PersistentVolumeClaims(deploy.config.Namespace).Delete(pvc.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			return fmt.Errorf("Failed to delete the PVC %s: %v", pvc.Name, err)
+			return fmt.Errorf("failed to delete the %s PVC: %v", pvc.Name, err)
 		}
 	}
 
@@ -115,7 +115,7 @@ func (deploy *Deployer) uninstallMeteringDeployment() error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the metering deployment")
 	} else {
-		return fmt.Errorf("Failed to delete the metering deployment: %v", err)
+		return err
 	}
 
 	return nil
@@ -128,7 +128,7 @@ func (deploy *Deployer) uninstallMeteringServiceAccount() error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the metering serviceaccount")
 	} else {
-		return fmt.Errorf("Failed to delete the metering serviceaccount: %v", err)
+		return err
 	}
 
 	return nil
@@ -151,7 +151,7 @@ func (deploy *Deployer) uninstallMeteringRoleBinding() error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the metering role binding")
 	} else {
-		return fmt.Errorf("Failed to delete the metering role binding: %v", err)
+		return err
 	}
 
 	return nil
@@ -169,7 +169,7 @@ func (deploy *Deployer) uninstallMeteringRole() error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the metering role")
 	} else {
-		return fmt.Errorf("Failed to delete the metering role: %v", err)
+		return err
 	}
 
 	return nil
@@ -186,7 +186,7 @@ func (deploy *Deployer) uninstallMeteringClusterRole() error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the metering cluster role")
 	} else {
-		return fmt.Errorf("Failed to delete the metering cluster role: %v", err)
+		return err
 	}
 
 	return nil
@@ -208,7 +208,7 @@ func (deploy *Deployer) uninstallMeteringClusterRoleBinding() error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the metering cluster role binding")
 	} else {
-		return fmt.Errorf("Failed to delete the metering cluster role binding: %v", err)
+		return err
 	}
 
 	return nil
@@ -218,7 +218,7 @@ func (deploy *Deployer) uninstallMeteringCRDs() error {
 	for _, crd := range deploy.config.OperatorResources.CRDs {
 		err := deploy.uninstallMeteringCRD(crd)
 		if err != nil {
-			return fmt.Errorf("Failed to delete a CRD while looping: %v", err)
+			return fmt.Errorf("failed to delete a CRD while looping: %v", err)
 		}
 	}
 
@@ -232,7 +232,7 @@ func (deploy *Deployer) uninstallMeteringCRD(resource CRD) error {
 	} else if err == nil {
 		deploy.logger.Infof("Deleted the %s CRD", resource.Name)
 	} else {
-		return fmt.Errorf("Failed to remove the %s CRD: %v", resource.Name, err)
+		return fmt.Errorf("failed to remove the %s CRD: %v", resource.Name, err)
 	}
 
 	return nil


### PR DESCRIPTION
With a recent PR failing e2e [1], the following error message was returned: 'Failed to deploy metering: Failed to uninstall metering: Failed to delete the MeteringConfig resource: Failed to delete the MeteringConfig resource:' which is difficult to read/follow the stack/command trace.

[1] https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/operator-framework_operator-metering/997/pull-ci-operator-framework-operator-metering-feature-metering-e2e-aws/62