### PR TITLE
Add unit test ensuring metering-operator and reporting-operator image repo/tags are set correctly

### DIFF
--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -3,8 +3,8 @@ package deploy
 import (
 	"fmt"
 
-	meteringv1 "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
-	metering "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
+	meteringclient "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 
@@ -66,7 +66,7 @@ type Config struct {
 	Tag                    string
 	ExtraNamespaceLabels   map[string]string
 	OperatorResources      *OperatorResources
-	MeteringConfig         *meteringv1.MeteringConfig
+	MeteringConfig         *metering.MeteringConfig
 }
 
 // OperatorResources contains all the objects that make up the
@@ -90,7 +90,7 @@ type Deployer struct {
 	logger         log.FieldLogger
 	client         kubernetes.Interface
 	apiExtClient   apiextclientv1beta1.CustomResourceDefinitionsGetter
-	meteringClient metering.MeteringV1Interface
+	meteringClient meteringclient.MeteringV1Interface
 }
 
 // NewDeployer creates a new reference to a deploy structure, and then calls helper
@@ -102,7 +102,7 @@ func NewDeployer(
 	logger log.FieldLogger,
 	client kubernetes.Interface,
 	apiextClient apiextclientv1beta1.CustomResourceDefinitionsGetter,
-	meteringClient metering.MeteringV1Interface,
+	meteringClient meteringclient.MeteringV1Interface,
 ) (*Deployer, error) {
 	deploy := &Deployer{
 		client:         client,

--- a/test/deployframework/context.go
+++ b/test/deployframework/context.go
@@ -45,11 +45,6 @@ func (df *DeployFramework) NewDeployerCtx(
 	targetPods int,
 	spec metering.MeteringConfigSpec,
 ) (*DeployerCtx, error) {
-	operatorResources, err := deploy.ReadMeteringAnsibleOperatorManifests(df.ManifestsDir, defaultPlatform)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize objects from manifests: %v", err)
-	}
-
 	cfg := deploy.Config{
 		Namespace:       namespace,
 		Repo:            meteringOperatorImageRepo,
@@ -59,7 +54,7 @@ func (df *DeployFramework) NewDeployerCtx(
 		ExtraNamespaceLabels: map[string]string{
 			"name": testNamespaceLabel,
 		},
-		OperatorResources: operatorResources,
+		OperatorResources: df.OperatorResources,
 		MeteringConfig: &metering.MeteringConfig{
 			ObjectMeta: meta.ObjectMeta{
 				Name:      meteringconfigMetadataName,
@@ -82,7 +77,7 @@ func (df *DeployFramework) NewDeployerCtx(
 			Repository: meteringOperatorImageRepo,
 			Tag:        meteringOperatorImageTag,
 		}
-		err = validateImageConfig(*meteringOperatorImage)
+		err := validateImageConfig(*meteringOperatorImage)
 		if err != nil {
 			return nil, fmt.Errorf("the metering operator image was improperly managed: %v", err)
 		}

--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/sirupsen/logrus"
 	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	meteringv1 "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1"
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
+	meteringclient "github.com/operator-framework/operator-metering/pkg/generated/clientset/versioned/typed/metering/v1"
 	"github.com/operator-framework/operator-metering/pkg/operator/deploy"
 )
 
@@ -32,25 +34,16 @@ const (
 // DeployFramework contains all the information necessary to deploy
 // different metering instances and run tests against them
 type DeployFramework struct {
-	KubeConfigPath             string
-	ReportingOperatorImageRepo string
-	ReportingOperatorImageTag  string
-	OperatorResources          *deploy.OperatorResources
-	Logger                     logrus.FieldLogger
-	Client                     kubernetes.Interface
-	APIExtClient               apiextclientv1beta1.CustomResourceDefinitionsGetter
-	MeteringClient             meteringv1.MeteringV1Interface
+	KubeConfigPath    string
+	OperatorResources *deploy.OperatorResources
+	Logger            logrus.FieldLogger
+	Client            kubernetes.Interface
+	APIExtClient      apiextclientv1beta1.CustomResourceDefinitionsGetter
+	MeteringClient    meteringclient.MeteringV1Interface
 }
 
 // New is the constructor function that creates and returns a new DeployFramework object
-func New(
-	logger logrus.FieldLogger,
-	nsPrefix,
-	manifestsDir,
-	kubeconfig,
-	reportingOperatorImageRepo,
-	reportingOperatorImageTag string,
-) (*DeployFramework, error) {
+func New(logger logrus.FieldLogger, nsPrefix, manifestsDir, kubeconfig string) (*DeployFramework, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build a kube config from %s: %v", kubeconfig, err)
@@ -66,7 +59,7 @@ func New(
 		return nil, fmt.Errorf("failed to initialize the apiextensions clientset: %v", err)
 	}
 
-	meteringClient, err := meteringv1.NewForConfig(config)
+	meteringClient, err := meteringclient.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize the metering clientset: %v", err)
 	}
@@ -77,15 +70,75 @@ func New(
 	}
 
 	deployFramework := &DeployFramework{
-		OperatorResources:          operatorResources,
-		KubeConfigPath:             kubeconfig,
-		ReportingOperatorImageRepo: reportingOperatorImageRepo,
-		ReportingOperatorImageTag:  reportingOperatorImageTag,
-		Logger:         logger,
-		Client:         client,
-		APIExtClient:   apiextClient,
-		MeteringClient: meteringClient,
+		OperatorResources: operatorResources,
+		KubeConfigPath:    kubeconfig,
+		Logger:            logger,
+		Client:            client,
+		APIExtClient:      apiextClient,
+		MeteringClient:    meteringClient,
 	}
 
 	return deployFramework, nil
+}
+
+func (df *DeployFramework) NewDeployerConfig(
+	namespace,
+	meteringOperatorImageRepo,
+	meteringOperatorImageTag,
+	reportingOperatorImageRepo,
+	reportingOperatorImageTag string,
+	spec metering.MeteringConfigSpec,
+) (*deploy.Config, error) {
+	meteringConfig := &metering.MeteringConfig{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      meteringconfigMetadataName,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+
+	// validate the reporting-operator image is non-empty when overrided
+	if reportingOperatorImageRepo != "" || reportingOperatorImageTag != "" {
+		reportingOperatorImageConfig := &metering.ImageConfig{
+			Repository: reportingOperatorImageRepo,
+			Tag:        reportingOperatorImageTag,
+		}
+		err := validateImageConfig(*reportingOperatorImageConfig)
+		if err != nil {
+			return nil, fmt.Errorf("invalid reporting-operator image config: %v", err)
+		}
+		// Ensure the repo/tag values are set on the MeteringConfig
+		if meteringConfig.Spec.ReportingOperator == nil {
+			meteringConfig.Spec.ReportingOperator = &metering.ReportingOperator{}
+		}
+		if meteringConfig.Spec.ReportingOperator.Spec == nil {
+			meteringConfig.Spec.ReportingOperator.Spec = &metering.ReportingOperatorSpec{}
+		}
+		meteringConfig.Spec.ReportingOperator.Spec.Image = reportingOperatorImageConfig
+
+	}
+	if meteringOperatorImageRepo != "" || meteringOperatorImageTag != "" {
+		// validate both the metering operator image fields are non-empty
+		meteringOperatorImageConfig := &metering.ImageConfig{
+			Repository: meteringOperatorImageRepo,
+			Tag:        meteringOperatorImageTag,
+		}
+		err := validateImageConfig(*meteringOperatorImageConfig)
+		if err != nil {
+			return nil, fmt.Errorf("invalid metering-operator image config: %v", err)
+		}
+	}
+
+	return &deploy.Config{
+		Namespace:       namespace,
+		Repo:            meteringOperatorImageRepo,
+		Tag:             meteringOperatorImageTag,
+		Platform:        defaultPlatform,
+		DeleteNamespace: defaultDeleteNamespace,
+		ExtraNamespaceLabels: map[string]string{
+			"name": testNamespaceLabel,
+		},
+		OperatorResources: df.OperatorResources,
+		MeteringConfig:    meteringConfig,
+	}, nil
 }

--- a/test/deployframework/framework_test.go
+++ b/test/deployframework/framework_test.go
@@ -1,0 +1,54 @@
+package deployframework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
+	"github.com/operator-framework/operator-metering/pkg/operator/deploy"
+)
+
+func TestNewDeployerConfig(t *testing.T) {
+	df := &DeployFramework{}
+	spec := metering.MeteringConfigSpec{}
+	testNamespace := "test-ns"
+	testMeteringOpRepo := "test-repo-1"
+	testMeteringOpTag := "test-tag-1"
+	testReportingOpRepo := "test-repo-2"
+	testReportingOpTag := "test-tag-2"
+	cfg, err := df.NewDeployerConfig(testNamespace, testMeteringOpRepo, testMeteringOpTag, testReportingOpRepo, testReportingOpTag, spec)
+	require.NoError(t, err)
+
+	expectedCfg := &deploy.Config{
+		Namespace:       testNamespace,
+		Repo:            testMeteringOpRepo,
+		Tag:             testMeteringOpTag,
+		Platform:        defaultPlatform,
+		DeleteNamespace: defaultDeleteNamespace,
+		ExtraNamespaceLabels: map[string]string{
+			"name": testNamespaceLabel,
+		},
+		OperatorResources: nil,
+		MeteringConfig: &metering.MeteringConfig{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      meteringconfigMetadataName,
+				Namespace: testNamespace,
+			},
+			Spec: metering.MeteringConfigSpec{
+				ReportingOperator: &metering.ReportingOperator{
+					Spec: &metering.ReportingOperatorSpec{
+						Image: &metering.ImageConfig{
+							Repository: testReportingOpRepo,
+							Tag:        testReportingOpTag,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equalf(t, cfg, expectedCfg, "meteringconfig should have reporting-operator image tag and namespace overridden")
+}

--- a/test/deployframework/helpers.go
+++ b/test/deployframework/helpers.go
@@ -5,10 +5,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
-	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	metering "github.com/operator-framework/operator-metering/pkg/apis/metering/v1"
 )
 
 func checkPodStatus(pod v1.Pod) (bool, int) {
@@ -85,4 +91,109 @@ func validateImageConfig(image metering.ImageConfig) error {
 	}
 
 	return nil
+}
+
+type PodWaiter struct {
+	Logger logrus.FieldLogger
+	Client kubernetes.Interface
+}
+
+type podStat struct {
+	PodName string
+	Ready   int
+	Total   int
+}
+
+// waitForPods periodically polls the list of pods in the namespace
+// and ensures the metering pods created are considered ready. In order to exit
+// the polling loop, the number of pods listed must match the expected number
+// of targetPodsCount, and all pod containers listed must report a ready status.
+func (pw *PodWaiter) WaitForPods(namespace string, targetPodsCount int) error {
+
+	err := wait.Poll(10*time.Second, 20*time.Minute, func() (done bool, err error) {
+		var readyPods []string
+		var unreadyPods []podStat
+
+		pods, err := pw.Client.CoreV1().Pods(namespace).List(meta.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// TODO(chancez): is this check needed? If so, maybe move outside of
+		// WaitForPods.
+		if len(pods.Items) == 0 {
+			return false, fmt.Errorf("the number of pods in the %s namespace should not be zero", namespace)
+		}
+
+		for _, pod := range pods.Items {
+			podIsReady, readyContainers := checkPodStatus(pod)
+			if podIsReady {
+				readyPods = append(readyPods, pod.Name)
+				continue
+			}
+
+			unreadyPods = append(unreadyPods, podStat{
+				PodName: pod.Name,
+				Ready:   readyContainers,
+				Total:   len(pod.Status.ContainerStatuses),
+			})
+		}
+
+		if pw.Logger != nil {
+			logPollingSummary(pw.Logger, targetPodsCount, readyPods, unreadyPods)
+		}
+
+		return len(pods.Items) == targetPodsCount && len(unreadyPods) == 0, nil
+	})
+	if err != nil {
+		return fmt.Errorf("the pods failed to report a ready status before the timeout period occurred: %v", err)
+	}
+
+	return nil
+}
+
+// GetServiceAccountToken queries the namespace for the service account and attempts
+// to find the secret that contains the serviceAccount token and return it.
+func GetServiceAccountToken(client kubernetes.Interface, namespace, serviceAccountName string) (string, error) {
+	var sa *v1.ServiceAccount
+	var err error
+
+	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		sa, err = client.CoreV1().ServiceAccounts(namespace).Get(serviceAccountName, meta.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("error getting service account %s: %v", reportingOperatorServiceAccountName, err)
+	}
+
+	if len(sa.Secrets) == 0 {
+		return "", fmt.Errorf("service account %s has no secrets", serviceAccountName)
+	}
+
+	var secretName string
+
+	for _, secret := range sa.Secrets {
+		if strings.Contains(secret.Name, "token") {
+			secretName = secret.Name
+			break
+		}
+	}
+
+	if secretName == "" {
+		return "", fmt.Errorf("%s service account has no token", serviceAccountName)
+	}
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(secretName, meta.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed getting %s service account token secret: %v", serviceAccountName, err)
+	}
+
+	return string(secret.Data["token"]), nil
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -71,14 +71,7 @@ func TestMain(m *testing.M) {
 	logger := testhelpers.SetupLogger(logLevel)
 
 	var err error
-	if df, err = deployframework.New(
-		logger,
-		namespacePrefix,
-		deployManifestsDir,
-		kubeConfig,
-		reportingOperatorImageRepo,
-		reportingOperatorImageTag,
-	); err != nil {
+	if df, err = deployframework.New(logger, namespacePrefix, deployManifestsDir, kubeConfig); err != nil {
 		logger.Fatalf("Failed to create a new deploy framework: %v", err)
 	}
 
@@ -120,10 +113,7 @@ func TestInstallMeteringAndReportingProducesData(t *testing.T) {
 								v1.ResourceMemory: resource.MustParse("250Mi"),
 							},
 						},
-						Image: &metering.ImageConfig{
-							Repository: reportingOperatorImageRepo,
-							Tag:        reportingOperatorImageTag,
-						},
+						Image: &metering.ImageConfig{},
 						Config: &metering.ReportingOperatorConfig{
 							LogLevel: "debug",
 							Prometheus: &metering.ReportingOperatorPrometheusConfig{
@@ -236,7 +226,7 @@ func testInstall(
 	rand.Seed(time.Now().UnixNano())
 	namespace := namespacePrefix + "-" + strconv.Itoa(rand.Intn(50))
 
-	deployerCtx, err := df.NewDeployerCtx(meteringOperatorImageRepo, meteringOperatorImageTag, namespace, testOutputDir, targetPods, spec)
+	deployerCtx, err := df.NewDeployerCtx(namespace, meteringOperatorImageRepo, meteringOperatorImageTag, reportingOperatorImageRepo, reportingOperatorImageTag, spec, testOutputDir, targetPods)
 	assert.NoError(t, err, "creating a new deployer context should produce no error")
 
 	rf, err := deployerCtx.Setup()


### PR DESCRIPTION
The first 2 commits are minor refactorings, and 3rd is bigger refactorings to make some stuff more generally re-usable. The final 2 are about setting things up so that creation of the DeployConfig is unit tested.