### PR TITLE
bug 1763303: Fix handling of AdditionalArtifactKeys in AWS billing report manifests

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -32,14 +33,16 @@ type ManifestRetriever interface {
 }
 
 type manifestRetriever struct {
+	logger         log.FieldLogger
 	s3API          s3iface.S3API
 	bucket, prefix string
 }
 
-func NewManifestRetriever(region, bucket, prefix string) ManifestRetriever {
+func NewManifestRetriever(logger log.FieldLogger, region, bucket, prefix string) ManifestRetriever {
 	awsSession := session.Must(session.NewSession())
 	client := s3.New(awsSession, aws.NewConfig().WithRegion(region))
 	return &manifestRetriever{
+		logger: logger,
 		s3API:  client,
 		bucket: bucket,
 		prefix: prefix,
@@ -58,13 +61,26 @@ func (r *manifestRetriever) RetrieveManifests() ([]*Manifest, error) {
 	} else if prefix[len(prefix)-1] != '/' {
 		prefix += "/"
 	}
+	logger := r.logger.WithFields(log.Fields{
+		"bucket": r.bucket,
+		"prefix": prefix,
+	})
 
-	var manifests []*Manifest
-	var manifestErr error
+	var (
+		manifests   []*Manifest
+		manifestErr error
+		page        int
+	)
 	pageFn := func(out *s3.ListObjectsV2Output, lastPage bool) bool {
+		page++
 		keys := r.filterObjects(prefix, out.Contents)
+		if len(keys) == 0 {
+			logger.Debugf("page %d had no manifests", page)
+			return true
+		}
 
 		for _, key := range keys {
+			logger.WithField("key", key).Debugf("retrieving manifest")
 			manifest, err := retrieveManifest(r.s3API, r.bucket, key)
 			if err != nil {
 				manifestErr = fmt.Errorf("can't get manifest from bucket '%s' with key '%s': %v", r.bucket, key, err)

--- a/pkg/aws/manifest.go
+++ b/pkg/aws/manifest.go
@@ -9,18 +9,18 @@ import (
 
 // Manifest is a representation of the file AWS provides with metadata for current usage information.
 type Manifest struct {
-	AssemblyID             string        `json:"assemblyId"`
-	Account                string        `json:"account"`
-	Columns                []Column      `json:"columns"`
-	Charset                string        `json:"charset"`
-	Compression            string        `json:"compression"`
-	ContentType            string        `json:"contentType"`
-	ReportID               string        `json:"reportId"`
-	ReportName             string        `json:"reportName"`
-	BillingPeriod          BillingPeriod `json:"billingPeriod"`
-	Bucket                 string        `json:"bucket"`
-	ReportKeys             []string      `json:"reportKeys"`
-	AdditionalArtifactKeys []string      `json:"additionalArtifactKeys"`
+	AssemblyID             string               `json:"assemblyId"`
+	Account                string               `json:"account"`
+	Columns                []Column             `json:"columns"`
+	Charset                string               `json:"charset"`
+	Compression            string               `json:"compression"`
+	ContentType            string               `json:"contentType"`
+	ReportID               string               `json:"reportId"`
+	ReportName             string               `json:"reportName"`
+	BillingPeriod          BillingPeriod        `json:"billingPeriod"`
+	Bucket                 string               `json:"bucket"`
+	ReportKeys             []string             `json:"reportKeys"`
+	AdditionalArtifactKeys []AdditionalArtifact `json:"additionalArtifactKeys"`
 }
 
 type BillingPeriod struct {
@@ -32,6 +32,11 @@ type BillingPeriod struct {
 type Column struct {
 	Category string `json:"category"`
 	Name     string `json:"name"`
+}
+
+type AdditionalArtifact struct {
+	ArtifactType string `json:"artifactType"`
+	Name         string `json:"name"`
 }
 
 // Paths returns the directories containing usage data. The result will be free of duplicates.

--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -317,7 +317,7 @@ func (op *Reporting) handleAWSBillingDataSource(logger log.FieldLogger, dataSour
 	}
 
 	logger.Debugf("querying bucket %#v for AWS Billing manifests for ReportDataSource %s", source, dataSource.Name)
-	manifestRetriever := aws.NewManifestRetriever(source.Region, source.Bucket, source.Prefix)
+	manifestRetriever := aws.NewManifestRetriever(logger, source.Region, source.Bucket, source.Prefix)
 	manifests, err := manifestRetriever.RetrieveManifests()
 	if err != nil {
 		return err


### PR DESCRIPTION
When testing previous fixes for bug 1763303 on a new billing bucket I
discovered another bug related to how we expect the AdditionalArtifactKeys
field to be represented.

This was not caught previously due to not enabling any additional features in
the AWS billing reports we didn't need, but were set in the new billing report
being used which causes this field to be present in the AWS billing report JSON
manifests.

Also adds a commit to improve logging since I was having trouble figuring out
these issues originally without the improved logging.