### PR TITLE
images/metering-ansible-operator: Configure storage earlier in the role execution.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -3,14 +3,14 @@
 - name: Validate Configurations
   include_tasks: validate.yml
 
+- name: Configure Storage
+  include_tasks: configure_storage.yml
+
 - name: Configure TLS
   include_tasks: configure_tls.yml
 
 - name: Configure Reporting
   include_tasks: configure_reporting.yml
-
-- name: Configure Storage
-  include_tasks: configure_storage.yml
 
 - name: Store MeteringConfig spec into values file
   copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml


### PR DESCRIPTION
Description:

This change would be helpful as we do a lot of validation of the Hive storage configurations in configure_storage.yml. It would be nice to fail earlier in the role execution when a storage component is misconfigured, e.g. when the user-provided s3 credentials secret doesn't exist.