### PR TITLE
images: Remove the task that prints the variables prefixed with 'meteringconfig_*'.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/main.yml
@@ -1,14 +1,4 @@
 ---
-
-- name: Print meteringconfig values
-  debug:
-    msg: "{{ item }}: {{ lookup('vars', item) }}"
-  loop: "{{ vars | dict2items | to_json | from_json | json_query(query) | difference(filtered_vars) }}"
-  vars:
-    filtered_vars:
-      - meteringconfig_spec
-      - meteringconfig_spec_overrides
-      - meteringconfig_default_values
-    query: "[?starts_with(@.key, `meteringconfig_`)].key"
+# task file for the MeteringConfig role
 
 - include_tasks: reconcile.yml


### PR DESCRIPTION
While this task is somewhat helpful for debugging new dev implementations, it slows down the role execution significantly.

There are other ways to handle skipping this task when applicable, like adding a conditional that defaults to false that you would have to manually enable in the `defaults/main.yml` or adding a configuration option the `MeteringConfig` CRD, both of which are not ideal.