### PR TITLE
Dockerfile,images: Manage the MeteringConfig status directly.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -25,7 +25,10 @@ RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 RUN ln -f -s /tini /usr/bin/tini
 
 RUN pip install --no-cache-dir --upgrade openshift boto3 cryptography
-RUN pip install --upgrade ansible>=2.8
+# In order to use the 'ansible_failed_result' and 'ansible_failed_task' variables in a block/rescue,
+# we need to ensure that the 2.8 version is being used while this is fixed in 2.9 upstream.
+# TODO: revert this change once the issue mentioned above is resolved.
+RUN pip install --upgrade ansible==2.8
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Configuring Hive storage"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - name: Configure S3 Storage
   block:
     - name: Validate Metering S3 bucket name
@@ -38,6 +46,16 @@
         aws_access_key: "{{ operator_s3_credentials_secret.resources[0].data['aws-access-key-id'] | b64decode | default(omit) }}"
         aws_secret_key: "{{ operator_s3_credentials_secret.resources[0].data['aws-secret-access-key'] | b64decode | default(omit) }}"
       when: s3_credentials_secret_exists
+  rescue:
+    - include_tasks: update_meteringconfig_status.yml
+      vars:
+        current_conditions:
+          type: "Invalid"
+          status: "True"
+          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+        end_play_after_updating_status: true
+      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
   vars:
     s3_credentials_secret_exists: "{{ operator_s3_credentials_secret.resources and operator_s3_credentials_secret.resources | length > 0 }}"
   when: meteringconfig_storage_hive_storage_type == 's3' and meteringconfig_storage_s3_create_bucket
@@ -69,7 +87,16 @@
           - meteringconfig_storage_s3Compatible_credentials_secret_name != ""
         msg: "storage.hive.s3Compatible.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
       when: not meteringconfig_storage_s3Compatible_create_secret
-
+  rescue:
+    - include_tasks: update_meteringconfig_status.yml
+      vars:
+        current_conditions:
+          type: "Invalid"
+          status: "True"
+          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+        end_play_after_updating_status: true
+      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
   when: meteringconfig_storage_hive_storage_type == 's3Compatible'
 
 - name: Get azure storage account name
@@ -90,6 +117,16 @@
     - name: Extract Azure storage account name
       set_fact:
         _azure_secret_account_name: "{{ azure_secret_buf.resources[0].data['azure-storage-account-name'] | b64decode | default(omit)  }}"
+  rescue:
+    - include_tasks: update_meteringconfig_status.yml
+      vars:
+        current_conditions:
+          type: "Invalid"
+          status: "True"
+          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+        end_play_after_updating_status: true
+      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
   when: meteringconfig_storage_hive_storage_type == 'azure' and not meteringconfig_storage_azure_create_secret
 
 - name: Configure Azure Storage
@@ -106,7 +143,16 @@
         that:
           - meteringconfig_storage_azure_credentials_secret_name == ""
         msg: "storage.hive.azure.secretName is only used to reference existing secrets, must be empty if creating new secrets"
-
+  rescue:
+    - include_tasks: update_meteringconfig_status.yml
+      vars:
+        current_conditions:
+          type: "Invalid"
+          status: "True"
+          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+        end_play_after_updating_status: true
+      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
   when: meteringconfig_storage_hive_storage_type == 'azure' and meteringconfig_storage_azure_create_secret
 
 - name: Configure GCS Storage
@@ -130,5 +176,22 @@
           - meteringconfig_storage_gcs_credentials_secret_name != ""
         msg: "storage.hive.gcs.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
       when: not meteringconfig_storage_gcs_create_secret
-
+  rescue:
+    - include_tasks: update_meteringconfig_status.yml
+      vars:
+        current_conditions:
+          type: "Invalid"
+          status: "True"
+          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+        end_play_after_updating_status: true
+      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
   when: meteringconfig_storage_hive_storage_type == 'gcs'
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished configuring Hive storage"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
@@ -2,6 +2,14 @@
 
 - name: Configure TLS
   block:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Running"
+        status: "True"
+        message: "Configuring TLS"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
   - name: Create temporary directory to store all the necessary certificates/keys
     tempfile:
       suffix: certificates
@@ -19,9 +27,27 @@
 
   - name: Configure TLS and authentication in the reporting-operator
     include_tasks: configure_reporting_operator_tls.yml
-
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   always:
   - name: Cleanup the temporary directory which held the certificates and keys
     file:
       path: "{{ certificates_dir.path }}"
       state: absent
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished configuring TLS"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
@@ -1,14 +1,28 @@
 ---
 
-- name: Helm template
-  shell: helm template {{ meteringconfig_chart_path }} --name {{ meta.name }} --namespace {{ meta.namespace}} -x {{ resource.template_file }} -f {{ values_file }}
-  loop: "{{ resources }}"
-  loop_control:
-    loop_var: resource
-    label: "{{ resource.template_file }}"
-  when: resource.create | default(true)
-  no_log: "{{ not meteringconfig_log_helm_template }}"
-  register: template_results
+- name: Helm template resources
+  block:
+  - shell: helm template {{ meteringconfig_chart_path }} --name {{ meta.name }} --namespace {{ meta.namespace}} -x {{ resource.template_file }} -f {{ values_file }}
+    loop: "{{ resources }}"
+    loop_control:
+      loop_var: resource
+      label: "{{ resource.template_file }}"
+    when: resource.create | default(true)
+    no_log: "{{ not meteringconfig_log_helm_template }}"
+    register: template_results
+  rescue:
+    - include_tasks: update_meteringconfig_status.yml
+      vars:
+        failed_result: "{{ ansible_failed_result.results | first }}"
+        end_play_after_updating_status: true
+        current_conditions:
+          type: "Invalid"
+          status: "True"
+          message: |
+            "Failed command: {{ failed_result.cmd | replace('...', '') | to_nice_yaml(indent=8, width=1337) }} "
+            "Error message: {{ failed_result.stderr_lines | to_nice_yaml }}"
+          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      when: ansible_failed_result and ansible_failed_result.results and (ansible_failed_result.results | length > 0)
 
 - name: Add prune label to resources
   vars:
@@ -41,19 +55,45 @@
   no_log: true
 
 - name: Create resources
-  k8s:
-    state: present
-    namespace: "{{ meta.namespace }}"
-    definition: "{{ updated_template_results | flatten }}"
-    merge_type: ['merge', 'strategic-merge']
+  block:
+  - k8s:
+      state: present
+      namespace: "{{ meta.namespace }}"
+      definition: "{{ updated_template_results | flatten }}"
+      merge_type: ['merge', 'strategic-merge']
+  rescue:
+      # Note for ansible_failed_return:
+      # there's no guarantee that more fields besides msg will be available
+      # as the return object varies depending on the type of error encountered
+    - include_tasks: update_meteringconfig_status.yml
+      vars:
+        end_play_after_updating_status: true
+        current_conditions:
+          type: "Invalid"
+          status: "True"
+          message: |
+            "{{ ansible_failed_result.msg }}"
+          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      when: ansible_failed_result is defined and (ansible_failed_result.msg | length > 0)
   when: template_results.changed and resource is not none
 
 - name: Prune resources
-  include_tasks: prune_resources.yml
-  vars:
-    namespace: "{{ meta.namespace }}"
-  loop: "{{ resources }}"
-  loop_control:
-    loop_var: resource
-    label: "{{ resource.template_file }}"
+  block:
+  - include_tasks: prune_resources.yml
+    vars:
+      namespace: "{{ meta.namespace }}"
+    loop: "{{ resources }}"
+    loop_control:
+      loop_var: resource
+      label: "{{ resource.template_file }}"
+  rescue:
+    - include_tasks: update_meteringconfig_status.yml
+      vars:
+        end_play_after_updating_status: true
+        current_conditions:
+          type: "Invalid"
+          status: "True"
+          message: |
+            "{{ ansible_failed_result }}"
+          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: not (resource.create | default(true))

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
 # task file for the MeteringConfig role
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Starting the reconciliation process"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - include_tasks: reconcile.yml
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "False"
+      message: "Awaiting the next reconciliation"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Reconciling HDFS resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - name: Deploy hdfs resources
   include_tasks: deploy_resources.yml
   vars:
@@ -50,3 +58,11 @@
         apis: [ {kind: statefulset, api_version: 'apps/v1'} ]
         prune_label_value: hdfs-namenode-statefulset
         create: "{{ meteringconfig_enable_hdfs }}"
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished reconciling HDFS resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Reconciling Hive resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - name: Deploy hive resources
   include_tasks: deploy_resources.yml
   vars:
@@ -69,3 +77,11 @@
       - template_file: templates/hive/hive-server-statefulset.yaml
         apis: [ {kind: statefulset, api_version: 'apps/v1'} ]
         prune_label_value: hive-server-statefulset
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished reconciling Hive resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Reconciling Metering resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - name: Deploy metering resources
   include_tasks: deploy_resources.yml
   vars:
@@ -15,3 +23,11 @@
         apis: [ {kind: Secret} ]
         prune_label_value: openshift-metering-root-ca-secret
         create: "{{ meteringconfig_create_metering_root_ca_secret }}"
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished reconciling Metering resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Reconciling monitoring resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - name: Deploy monitoring resources
   include_tasks: deploy_resources.yml
   vars:
@@ -26,3 +34,10 @@
         prune_label_value: metering-reporting-operator-service-monitor
         create: "{{ meteringconfig_create_metering_monitoring_resources }}"
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished reconciling monitoring resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Reconciling Presto resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - name: Deploy presto resources
   include_tasks: deploy_resources.yml
   vars:
@@ -64,3 +72,11 @@
       - template_file: templates/presto/presto-worker-statefulset.yaml
         apis: [ {kind: statefulset} ]
         prune_label_value: presto-worker-statefulset
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished reconciling Presto resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Reconciling reporting resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - name: Deploy reporting resources
   include_tasks: deploy_resources.yml
   vars:
@@ -58,3 +66,11 @@
         apis: [ {kind: reportquery, api_version: 'metering.openshift.io/v1'} ]
         prune_label_value: report-queries-pod-memory-aws
         create: "{{ meteringconfig_enable_reporting_aws_billing }}"
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished reconciling reporting resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Reconciling reporting-operator resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
 - name: Deploy reporting-operator resources
   include_tasks: deploy_resources.yml
   vars:
@@ -76,3 +84,11 @@
       - template_file: templates/reporting-operator/reporting-operator-deployment.yaml
         apis: [ {kind: deployment} ]
         prune_label_value: reporting-operator-deployment
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished reconciling reporting-operator resources"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/update_meteringconfig_status.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/update_meteringconfig_status.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Update the MeteringConfig status
+  k8s_status:
+    api_version: metering.openshift.io/v1
+    kind: MeteringConfig
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    conditions: "{{ [ current_conditions ] }}"
+  when: current_conditions is defined
+
+- name: End role due to failure
+  fail:
+    msg: "Failing role execution after updating the MeteringConfig.Status"
+  when: end_play_after_updating_status is defined and end_play_after_updating_status

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
@@ -1,5 +1,16 @@
 ---
 
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Starting the validation process"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
+#
+# Validate OCP-only features were properly disabled
+#
 - name: Validate fields when OCP-only features are disabled
   block:
   - name: Validate that top-level TLS key is unset/disabled
@@ -7,33 +18,72 @@
       that:
         - meteringconfig_spec | json_query('tls.enabled') != true
       msg: "Invalid configuration for non-OKD distributions: You cannot set the tls.enabled key to true when disabling OCP-only features."
+
   - name: Validate that the Prometheus URL is set
     assert:
       that:
         - meteringconfig_spec['reporting-operator'] | json_query('spec.config.prometheus.url') != ""
       msg: "Invalid configuration for non-OKD distributions: You must set the reporting-operator.spec.config.prometheus.url."
+
   - name: Validate that the reporting-operator Openshift Route is not enabled
     assert:
       that:
       - meteringconfig_spec['reporting-operator'] | json_query('spec.route.enabled') != true
       msg: "Invalid configuration for non-OKD distributions: You cannot enable the Openshift-only reporting-operator route."
+
   - name: Validate that the reporting-operator OAuth authProxy is not enabled
     assert:
       that:
       - meteringconfig_spec['reporting-operator'] | json_query('spec.authProxy.enabled') != true
       msg: "Invalid configuration for non-OKD distributions: You cannot enable the Openshift-only reporting-operator authProxy."
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_ocp_disabled
 
-- name: Validate storage configuration
-  assert:
-    that:
-      - meteringconfig_spec | json_query('storage.type') == "hive"
-    msg: "Unsupported spec.storage.type, only 'hive' is  a supported option"
+#
+# Validate the user-provided storage configuration
+#
+- name: Validate the storage configuration
+  block:
+  - name: Validate the user-provided storage type
+    assert:
+      that:
+        - storageType is not undefined and storageType == 'hive'
+      msg: "Unsupported spec.storage.type, only 'hive' is  a supported option"
 
-- name: Validate Hive storage configuration
-  assert:
-    that:
-      - hiveStorageType is not undefined and hiveStorageType in ['s3', 'sharedPVC', 'hdfs', 'azure', 'gcs' , 's3Compatible']
-    msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of 's3', 'azure', 'gcs', 's3Compatible' or 'sharedPVC'"
+  - name: Validate the user-provided Hive storage configuration matches a support option
+    assert:
+      that:
+        - hiveStorageType is not undefined and hiveStorageType in ['s3', 'sharedPVC', 'hdfs', 'azure', 'gcs' , 's3Compatible']
+      msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of hdfs, s3, azure, gcs, s3Compatible or sharedPVC"
   vars:
+    storageType: "{{ meteringconfig_spec_overrides | json_query('storage.type') }}"
     hiveStorageType: "{{ meteringconfig_spec_overrides | json_query('storage.hive.type') }}"
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+
+- include_tasks: update_meteringconfig_status.yml
+  vars:
+    current_conditions:
+      type: "Running"
+      status: "True"
+      message: "Finished the validation process"
+      lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_storage.yml
@@ -1,0 +1,120 @@
+---
+
+#
+# Validate the Hive storage configuration
+#
+- name: Validate the user-provided hive storage type matches a supported storage
+  assert:
+    that:
+      - hiveStorageType is not undefined and hiveStorageType in ['s3', 'sharedPVC', 'hdfs', 'azure', 'gcs' , 's3Compatible']
+    msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of hdfs, s3, azure, gcs, s3Compatible or sharedPVC"
+
+#
+# Validate GCS storage configuration
+#
+- name: Validate a GCS storage configuration
+  block:
+  - name: Validate the user-provied GCS bucket name is non-empty
+    assert:
+      that:
+        - meteringconfig_storage_gcs_bucket_name != ""
+      msg: "storage.hive.gcs.bucket cannot be empty"
+
+  - name: Validate that the GCS secretName is empty when createSecret is true
+    assert:
+      that:
+        - meteringconfig_storage_gcs_credentials_secret_name == ""
+      msg: "storage.hive.gcs.secretName is only used to reference existing secrets, must be empty if creating new secrets"
+    when: meteringconfig_storage_gcs_create_secret
+
+  - name: Validate that the GCS secretName is non-empty when createSecret is false
+    assert:
+      that:
+        - meteringconfig_storage_gcs_credentials_secret_name != ""
+      msg: "storage.hive.gcs.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
+    when: not meteringconfig_storage_gcs_create_secret
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+  when: hiveStorageType == 'gcs'
+
+#
+# Validate Azure storage configuration
+#
+- name: Validate an Azure storage configuration
+  block:
+  - name: Validate the user-provided Azure container name
+    assert:
+      that:
+        - meteringconfig_storage_azure_container_name != ""
+        - meteringconfig_storage_azure_storage_account_name != ""
+      msg: "storage.hive.azure.container and storage.hive.azure.storageAccountName cannot be empty"
+
+  - name: Validate the user-provided Azure credentials
+    assert:
+      that:
+        - meteringconfig_storage_azure_credentials_secret_name == ""
+      msg: "storage.hive.azure.secretName is only used to reference existing secrets, must be empty if creating new secrets"
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+  when: hiveStorageType == 'azure' and not meteringconfig_storage_azure_create_secret
+
+#
+# Validate S3-Compatible storage configuration
+#
+- name: Validate a S3-Compatible storage configuration
+  block:
+  - name: Validate the S3-Compatible bucket name
+    assert:
+      that:
+        - meteringconfig_storage_s3Compatible_bucket_name != ""
+      msg: "storage.hive.s3Compatible.bucket cannot be empty"
+
+  - name: Validating the user-provided S3-Compatible endpoint is non-empty
+    assert:
+      that:
+        - meteringconfig_storage_s3Compatible_endpoint != ""
+      msg: "storage.hive.s3Compatible.endpoint cannot be empty"
+
+  - name: Validate that createSecret is true when the secretName is empty
+    assert:
+      that:
+        - meteringconfig_storage_s3Compatible_credentials_secret_name == ""
+      msg: "storage.hive.s3Compatible.secretName is only used to reference existing secrets, must be empty if creating new secrets"
+    when: meteringconfig_storage_s3Compatible_create_secret
+
+  - name: Validate that createSecret is false when secretName is non-empty
+    assert:
+      that:
+        - meteringconfig_storage_s3Compatible_credentials_secret_name != ""
+      msg: "storage.hive.s3Compatible.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
+    when: not meteringconfig_storage_s3Compatible_create_secret
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+  when: hiveStorageType == 's3Compatible'

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_tls.yml
@@ -29,6 +29,17 @@
       that:
         - meteringconfig_spec.hive.spec.metastore.config.tls.enabled and meteringconfig_spec.hive.spec.metastore.config.auth.enabled
       msg: "Invalid configuration for hive.spec.metastore.config.tls: you cannot enable auth but disable TLS."
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_metastore_tls_secret
 
 - name: Validate user-provided Hive Server TLS fields are non-empty
@@ -56,6 +67,17 @@
       that:
         - meteringconfig_spec.hive.spec.server.config.tls.enabled and meteringconfig_spec.hive.spec.server.config.auth.enabled
       msg: "Invalid configuration for hive.spec.server.config.tls: you cannot enable auth but disable TLS."
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_server_tls_secret
 
 - name: Validate user-provided Hive Server Auth (metastoreTLS) fields are non-empty
@@ -77,4 +99,15 @@
       that:
         - meteringconfig_spec.hive.spec.server.config.metastoreTLS.key != ""
       msg: "hive.spec.server.config.metastoreTLS.key cannot be empty if createSecret: true and secretName != ''"
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_server_auth_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
@@ -22,6 +22,17 @@
       that:
         - meteringconfig_spec.presto.spec.config.tls.key != ""
       msg: "presto.spec.config.tls.key cannot be empty if createSecret: true and secretName != ''"
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_tls_secret
 
 - name: Validate that the user-provided Presto client Auth fields are not empty
@@ -49,6 +60,17 @@
       that:
         - meteringconfig_spec.presto.spec.config.tls.enabled and meteringconfig_spec.presto.spec.config.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_auth_secret
 
 - name: Validate that the user provided Presto/Hive client TLS fields are not empty
@@ -70,4 +92,15 @@
       that:
         - meteringconfig_spec.presto.spec.config.connectors.hive.tls.caCertificate != ""
       msg: "spec.presto.spec.config.connectors.hive.tls.caCertificate cannot be empty when createSecret is set to true"
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_hive_tls_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
@@ -10,6 +10,17 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.presto.tls.caCertificate != ""
       msg: "reporting-operator.spec.config.presto.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_tls_secret
 
 - name: Validate that the user-provided Presto client Auth fields are not empty
@@ -31,6 +42,17 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.presto.tls.enabled and meteringconfig_spec['reporting-operator'].spec.config.presto.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_auth_secret
 
 #
@@ -61,6 +83,17 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.hive.tls.enabled and meteringconfig_spec['reporting-operator'].spec.config.hive.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_secrets
 
 #
@@ -88,3 +121,14 @@
         - meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.data != ""
       msg: "spec.reporting-operator.spec.authProxy.authenticatedEmails: secretName and/or data key(s) cannot be empty when enabled and createSecret is set to true"
     when: meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.enabled and meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.createSecret
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "Failed task name: {{ ansible_failed_task.name }}"
+          "Failed task message: {{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"

--- a/images/metering-ansible-operator/watches.yaml
+++ b/images/metering-ansible-operator/watches.yaml
@@ -5,3 +5,4 @@
   role: /opt/ansible/roles/meteringconfig
   watchDependentResources: false
   reconcilePeriod: 5m
+  manageStatus: false


### PR DESCRIPTION
### Description

This would update the metering-ansible-operator to manage the `MeteringConfig` status directly, as opposed to the ansible-operator doing it for us. That would involve setting the `manageStatus: false` option in the watches.yml file, and using the `k8s_status` periodically throughout the role.

Also included in the PR is an update to the metering-ansible-operator Dockerfile that ensures the Ansible version is set to 2.8 for now as there was a regression in 2.9 where the `ansible_failed_result` and `ansible_failed_task` variables were undefined in a block/rescue task, which is not ideal.