### PR TITLE
test/deployframework: Fix the logging message for where the metering-operator local logs are stored.

### DIFF
--- a/test/deployframework/local.go
+++ b/test/deployframework/local.go
@@ -64,7 +64,7 @@ func (lc *LocalCtx) RunMeteringOperatorLocal() error {
 	}
 	defer logFile.Close()
 
-	lc.Logger.Infof("Storing the metering-operator container logs to the '%s' path", logFile)
+	lc.Logger.Infof("Storing the metering-operator container logs to the '%s' path", logFile.Name())
 
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile


### PR DESCRIPTION
Before, the testing suite would log the full `os.File` object returned from creating a file, instead of the path to the file created which contains a lot of unnecessary artifacts.