### PR TITLE
charts,manifests: Update the csv's container image field to use the 4.4 tag instead of latest.

### DIFF
--- a/charts/metering-ansible-operator/upstream-values.yaml
+++ b/charts/metering-ansible-operator/upstream-values.yaml
@@ -96,7 +96,7 @@ olm:
       capabilities: Basic Install
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
-      containerImage: "quay.io/coreos/metering-ansible-operator:latest"
+      containerImage: "quay.io/coreos/metering-ansible-operator:4.4"
 
   subscriptionName: metering
   subscriptionChannel: stable

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -311,7 +311,7 @@ olm:
       capabilities: Basic Install
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
-      containerImage: "quay.io/openshift/origin-metering-ansible-operator:latest"
+      containerImage: "quay.io/openshift/origin-metering-ansible-operator:4.4"
       description: 'Chargeback and reporting tool to provide accountability for how resources are used across a cluster'
       repository: https://github.com/operator-framework/operator-metering
       alm-examples: |-

--- a/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -205,7 +205,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Monitoring
     certified: "false"
-    containerImage: quay.io/openshift/origin-metering-ansible-operator:latest
+    containerImage: quay.io/openshift/origin-metering-ansible-operator:4.4
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster

--- a/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -205,7 +205,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Monitoring
     certified: "false"
-    containerImage: quay.io/openshift/origin-metering-ansible-operator:latest
+    containerImage: quay.io/openshift/origin-metering-ansible-operator:4.4
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster

--- a/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -205,7 +205,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Monitoring
     certified: "false"
-    containerImage: quay.io/coreos/metering-ansible-operator:latest
+    containerImage: quay.io/coreos/metering-ansible-operator:4.4
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster


### PR DESCRIPTION
All the images listed in a given CSV use the appropriate release tag, and the `containerImage` field was using `latest` which may be disrupting ART from substituting the image contained in this field to the correct image-registry ones in distgit.