### PR TITLE
hack,Makefile,test: Support running the e2e suite in a more dev-friendly configuration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,12 @@ e2e: $(TEST2JSON_BIN_OUT) $(DEPLOY_METERING_BIN_OUT)
 e2e-local: reporting-operator-local metering-ansible-operator-docker-build
 	$(MAKE) e2e METERING_RUN_TESTS_LOCALLY=true METERING_OPERATOR_IMAGE_REPO=$(METERING_OPERATOR_IMAGE_REPO) METERING_OPERATOR_IMAGE_TAG=$(METERING_OPERATOR_IMAGE_TAG)
 
+e2e-dev:
+	$(MAKE) e2e METERING_RUN_DEV_TEST_SETUP=true
+
+e2e-dev-local:
+	$(MAKE) e2e-local METERING_RUN_DEV_TEST_SETUP=true
+
 e2e-docker: metering-src-docker-build
 	docker run \
 		--name metering-e2e-docker \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -11,8 +11,12 @@ source "${ROOT_DIR}/hack/lib/tests.sh"
 function cleanup() {
     exit_status=$?
 
-    echo "Removing namespaces with the 'name=metering-testing-ns' label"
-    kubectl delete ns -l "name=metering-testing-ns" || true
+    if [[ "${METERING_RUN_DEV_TEST_SETUP}" = false ]]; then
+        echo "Removing namespaces with the 'name=metering-testing-ns' label"
+        kubectl delete ns -l "name=metering-testing-ns" || true
+    else
+        echo "Skipping the namespace deletion"
+    fi
 
     echo "Exiting hack/e2e.sh"
     exit "$exit_status"
@@ -31,12 +35,15 @@ TEST_LOG_FILE="${TEST_LOG_FILE:-e2e-tests.log}"
 TEST_LOG_FILE_PATH="${TEST_LOG_FILE_PATH:-$TEST_OUTPUT_DIR/$TEST_LOG_FILE}"
 TEST_JUNIT_REPORT_FILE="${TEST_JUNIT_REPORT_FILE:-junit-e2e-tests.xml}"
 TEST_JUNIT_REPORT_FILE_PATH="${TEST_JUNIT_REPORT_FILE_PATH:-$TEST_OUTPUT_DIR/$TEST_JUNIT_REPORT_FILE}"
+METERING_RUN_DEV_TEST_SETUP="${METERING_RUN_DEV_TEST_SETUP:-false}"
+
 
 mkdir -p "$TEST_OUTPUT_DIR"
 
 echo "\$KUBECONFIG=$KUBECONFIG"
 echo "\$METERING_NAMESPACE=$METERING_NAMESPACE"
 echo "\$METERING_RUN_TESTS_LOCALLY=$METERING_RUN_TESTS_LOCALLY"
+echo "\$METERING_RUN_DEV_TEST_SETUP=$METERING_RUN_DEV_TEST_SETUP"
 echo "\$METERING_OPERATOR_IMAGE_REPO=$METERING_OPERATOR_IMAGE_REPO"
 echo "\$REPORTING_OPERATOR_IMAGE_REPO=$REPORTING_OPERATOR_IMAGE_REPO"
 echo "\$METERING_OPERATOR_IMAGE_TAG=$METERING_OPERATOR_IMAGE_TAG"
@@ -60,6 +67,7 @@ go test \
     -log-level="${TEST_LOG_LEVEL}" \
     -run-tests-local="${METERING_RUN_TESTS_LOCALLY}" \
     -repo-path="${METERING_REPO_PATH}" \
+    -run-dev-setup="${METERING_RUN_DEV_TEST_SETUP}" \
     2>&1 | tee "$TEST_LOG_FILE_PATH" ; TEST_EXIT_CODE=${PIPESTATUS[0]}
 
 # if go-junit-report is installed, create a junit report also

--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -44,6 +44,7 @@ const (
 // different metering instances and run tests against them
 type DeployFramework struct {
 	RunLocal          bool
+	RunDevSetup       bool
 	KubeConfigPath    string
 	RepoDir           string
 	OperatorResources *deploy.OperatorResources
@@ -55,7 +56,7 @@ type DeployFramework struct {
 }
 
 // New is the constructor function that creates and returns a new DeployFramework object
-func New(logger logrus.FieldLogger, runLocal bool, nsPrefix, repoDir, kubeconfig string) (*DeployFramework, error) {
+func New(logger logrus.FieldLogger, runLocal, runDevSetup bool, nsPrefix, repoDir, kubeconfig string) (*DeployFramework, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build a kube config from %s: %v", kubeconfig, err)
@@ -95,6 +96,7 @@ func New(logger logrus.FieldLogger, runLocal bool, nsPrefix, repoDir, kubeconfig
 		KubeConfigPath:    kubeconfig,
 		RepoDir:           repoDir,
 		RunLocal:          runLocal,
+		RunDevSetup:       runDevSetup,
 		Logger:            logger,
 		Config:            config,
 		Client:            client,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -30,6 +30,7 @@ var (
 	kubeConfig    string
 	logLevel      string
 	runTestsLocal bool
+	runDevSetup   bool
 
 	meteringOperatorImageRepo  string
 	meteringOperatorImageTag   string
@@ -56,6 +57,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&kubeConfig, "kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
 	flag.StringVar(&logLevel, "log-level", logrus.DebugLevel.String(), "The log level")
 	flag.BoolVar(&runTestsLocal, "run-tests-local", false, "Controls whether the metering and reporting operators are run locally during tests")
+	flag.BoolVar(&runDevSetup, "run-dev-setup", false, "Controls whether the e2e suite uses the dev-friendly configuration")
 	flag.BoolVar(&runAWSBillingTests, "run-aws-billing-tests", runAWSBillingTests, "")
 
 	flag.StringVar(&meteringOperatorImageRepo, "metering-operator-image-repo", meteringOperatorImageRepo, "")
@@ -75,7 +77,7 @@ func TestMain(m *testing.M) {
 	}
 
 	var err error
-	if df, err = deployframework.New(logger, runTestsLocal, namespacePrefix, repoPath, kubeConfig); err != nil {
+	if df, err = deployframework.New(logger, runTestsLocal, runDevSetup, namespacePrefix, repoPath, kubeConfig); err != nil {
 		logger.Fatalf("Failed to create a new deploy framework: %v", err)
 	}
 


### PR DESCRIPTION
As we continue working with the refactored e2e suite, adding any additional e2e manual install tests can be cumbersome. This is because it takes a while to deploy a full install, wait for those resources to become ready to run reporting tests, then teardown any provisioned resources created. In the case where an error has occurred, then you would need to re-run the process outlined above, which is not ideal.

This PR would introduce the option to skip any tasks that uninstall the metering stack, or deletes namespaces containing the e2e label. With this change, you can re-run any failed tests with an existing namespace that already contains ready pods, which leads to quicker turnaround when adding more e2e tests.