### PR TITLE
Bug 1781499: Fix the invalid tag used in the release-4.2 CSV's container image field.

### DIFF
--- a/charts/metering-ansible-operator/upstream-values.yaml
+++ b/charts/metering-ansible-operator/upstream-values.yaml
@@ -96,7 +96,7 @@ olm:
       capabilities: Basic Install
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
-      containerImage: "quay.io/coreos/metering-ansible-operator:latest"
+      containerImage: "quay.io/coreos/metering-ansible-operator:release-4.2"
 
   subscriptionName: metering
   subscriptionChannel: stable

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -311,7 +311,7 @@ olm:
       capabilities: Basic Install
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
-      containerImage: "quay.io/openshift/origin-metering-ansible-operator:latest"
+      containerImage: "quay.io/openshift/origin-metering-ansible-operator:4.2"
       description: 'Chargeback and reporting tool to provide accountability for how resources are used across a cluster'
       repository: https://github.com/operator-framework/operator-metering
       alm-examples: |-

--- a/manifests/deploy/ocp-testing/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
@@ -205,7 +205,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Monitoring
     certified: "false"
-    containerImage: quay.io/openshift/origin-metering-ansible-operator:latest
+    containerImage: quay.io/openshift/origin-metering-ansible-operator:4.2
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster

--- a/manifests/deploy/openshift/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
@@ -205,7 +205,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Monitoring
     certified: "false"
-    containerImage: quay.io/openshift/origin-metering-ansible-operator:latest
+    containerImage: quay.io/openshift/origin-metering-ansible-operator:4.2
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster

--- a/manifests/deploy/upstream/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.2/meteringoperator.v4.2.0.clusterserviceversion.yaml
@@ -205,7 +205,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Monitoring
     certified: "false"
-    containerImage: quay.io/coreos/metering-ansible-operator:latest
+    containerImage: quay.io/coreos/metering-ansible-operator:release-4.2
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster


### PR DESCRIPTION
Manually opening this PR as the cherry-pick-bot didn't automatically open this PR, so must have messed up somewhere on the BZ-side of things.