### PR TITLE
pkg/operator: Remove unused code and catch potential errors as needed.

### DIFF
--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -428,7 +428,7 @@ func (op *Reporting) handlePrestoTableDataSource(logger log.FieldLogger, dataSou
 		}
 
 		dsClient := op.meteringClient.MeteringV1().ReportDataSources(dataSource.Namespace)
-		dataSource, err = updateReportDataSource(dsClient, dataSource.Name, func(newDS *metering.ReportDataSource) {
+		_, err = updateReportDataSource(dsClient, dataSource.Name, func(newDS *metering.ReportDataSource) {
 			newDS.Status.TableRef = v1.LocalObjectReference{Name: prestoTable.Name}
 		})
 		if err != nil {

--- a/pkg/operator/hivetables.go
+++ b/pkg/operator/hivetables.go
@@ -264,7 +264,7 @@ func (op *Reporting) handleHiveTable(logger log.FieldLogger, hiveTable *metering
 
 		hiveTable.Status.Partitions = desiredPartitions
 		var err error
-		hiveTable, err = op.meteringClient.MeteringV1().HiveTables(hiveTable.Namespace).Update(hiveTable)
+		_, err = op.meteringClient.MeteringV1().HiveTables(hiveTable.Namespace).Update(hiveTable)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -446,9 +446,6 @@ func (op *Reporting) Run(ctx context.Context) error {
 	}
 
 	hiveQueryer := sql.OpenDB(hiveDB)
-	if err != nil {
-		return err
-	}
 	hiveQueryer.SetConnMaxLifetime(time.Minute)
 	hiveQueryer.SetMaxOpenConns(2)
 	hiveQueryer.SetMaxIdleConns(2)
@@ -497,7 +494,10 @@ func (op *Reporting) Run(ctx context.Context) error {
 
 		prestoURL.Scheme = "https"
 		val.Set("custom_client", "httpClient")
-		presto.RegisterCustomClient("httpClient", httpClient)
+		err = presto.RegisterCustomClient("httpClient", httpClient)
+		if err != nil {
+			return fmt.Errorf("presto: Failed to register a custom HTTP client: %v", err)
+		}
 	}
 
 	prestoURL.RawQuery = val.Encode()


### PR DESCRIPTION
This was found while investigating what parts of the reporting-operator need to be updated to read directly from the presto-prometheus catalog.