### PR TITLE
Support querying unmanaged, existing Presto table metadata. 

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/prestotable.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/prestotable.crd.yaml
@@ -35,7 +35,7 @@ spec:
           type: object
           description: |
             PrestoTableSpec is the desired specification of a PrestoTable custom resource.
-            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
             Optional fields: query, view, createTableAs, properties, and comment.
             More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
           required:
@@ -43,7 +43,6 @@ spec:
           - catalog
           - schema
           - tableName
-          - columns
           properties:
             unmanaged:
               type: boolean
@@ -123,43 +122,3 @@ spec:
                 Note: this is an optional field.
                 More info: https://prestosql.io/docs/current/overview/concepts.html#query
               minLength: 1
-          oneOf:
-          - required:
-            - createTableAs
-            - query
-            properties:
-              createTableAs:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - view
-          - required:
-            - view
-            - query
-            properties:
-              view:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - createTableAs
-          - properties:
-              unmanaged:
-                enum:
-                - true
-            allOf:
-            - not:
-                required:
-                - view
-            - not:
-                required:
-                - createTableAs

--- a/manifests/deploy/ocp-testing/metering-ansible-operator/prestotable.crd.yaml
+++ b/manifests/deploy/ocp-testing/metering-ansible-operator/prestotable.crd.yaml
@@ -35,7 +35,7 @@ spec:
           type: object
           description: |
             PrestoTableSpec is the desired specification of a PrestoTable custom resource.
-            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
             Optional fields: query, view, createTableAs, properties, and comment.
             More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
           required:
@@ -43,7 +43,6 @@ spec:
           - catalog
           - schema
           - tableName
-          - columns
           properties:
             unmanaged:
               type: boolean
@@ -123,44 +122,4 @@ spec:
                 Note: this is an optional field.
                 More info: https://prestosql.io/docs/current/overview/concepts.html#query
               minLength: 1
-          oneOf:
-          - required:
-            - createTableAs
-            - query
-            properties:
-              createTableAs:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - view
-          - required:
-            - view
-            - query
-            properties:
-              view:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - createTableAs
-          - properties:
-              unmanaged:
-                enum:
-                - true
-            allOf:
-            - not:
-                required:
-                - view
-            - not:
-                required:
-                - createTableAs
 

--- a/manifests/deploy/ocp-testing/olm/bundle/4.4/prestotable.crd.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.4/prestotable.crd.yaml
@@ -35,7 +35,7 @@ spec:
           type: object
           description: |
             PrestoTableSpec is the desired specification of a PrestoTable custom resource.
-            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
             Optional fields: query, view, createTableAs, properties, and comment.
             More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
           required:
@@ -43,7 +43,6 @@ spec:
           - catalog
           - schema
           - tableName
-          - columns
           properties:
             unmanaged:
               type: boolean
@@ -123,44 +122,4 @@ spec:
                 Note: this is an optional field.
                 More info: https://prestosql.io/docs/current/overview/concepts.html#query
               minLength: 1
-          oneOf:
-          - required:
-            - createTableAs
-            - query
-            properties:
-              createTableAs:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - view
-          - required:
-            - view
-            - query
-            properties:
-              view:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - createTableAs
-          - properties:
-              unmanaged:
-                enum:
-                - true
-            allOf:
-            - not:
-                required:
-                - view
-            - not:
-                required:
-                - createTableAs
 

--- a/manifests/deploy/openshift/metering-ansible-operator/prestotable.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/prestotable.crd.yaml
@@ -35,7 +35,7 @@ spec:
           type: object
           description: |
             PrestoTableSpec is the desired specification of a PrestoTable custom resource.
-            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
             Optional fields: query, view, createTableAs, properties, and comment.
             More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
           required:
@@ -43,7 +43,6 @@ spec:
           - catalog
           - schema
           - tableName
-          - columns
           properties:
             unmanaged:
               type: boolean
@@ -123,44 +122,4 @@ spec:
                 Note: this is an optional field.
                 More info: https://prestosql.io/docs/current/overview/concepts.html#query
               minLength: 1
-          oneOf:
-          - required:
-            - createTableAs
-            - query
-            properties:
-              createTableAs:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - view
-          - required:
-            - view
-            - query
-            properties:
-              view:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - createTableAs
-          - properties:
-              unmanaged:
-                enum:
-                - true
-            allOf:
-            - not:
-                required:
-                - view
-            - not:
-                required:
-                - createTableAs
 

--- a/manifests/deploy/openshift/olm/bundle/4.4/prestotable.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.4/prestotable.crd.yaml
@@ -35,7 +35,7 @@ spec:
           type: object
           description: |
             PrestoTableSpec is the desired specification of a PrestoTable custom resource.
-            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
             Optional fields: query, view, createTableAs, properties, and comment.
             More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
           required:
@@ -43,7 +43,6 @@ spec:
           - catalog
           - schema
           - tableName
-          - columns
           properties:
             unmanaged:
               type: boolean
@@ -123,44 +122,4 @@ spec:
                 Note: this is an optional field.
                 More info: https://prestosql.io/docs/current/overview/concepts.html#query
               minLength: 1
-          oneOf:
-          - required:
-            - createTableAs
-            - query
-            properties:
-              createTableAs:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - view
-          - required:
-            - view
-            - query
-            properties:
-              view:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - createTableAs
-          - properties:
-              unmanaged:
-                enum:
-                - true
-            allOf:
-            - not:
-                required:
-                - view
-            - not:
-                required:
-                - createTableAs
 

--- a/manifests/deploy/openshift/telemeter/list.yaml
+++ b/manifests/deploy/openshift/telemeter/list.yaml
@@ -3081,49 +3081,9 @@ objects:
           spec:
             description: |
               PrestoTableSpec is the desired specification of a PrestoTable custom resource.
-              Required fields: unmanaged, catalog, schema, tableName, and columns.
+              Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
               Optional fields: query, view, createTableAs, properties, and comment.
               More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
-            oneOf:
-            - allOf:
-              - not:
-                  required:
-                  - view
-              properties:
-                createTableAs:
-                  enum:
-                  - true
-                unmanaged:
-                  enum:
-                  - false
-              required:
-              - createTableAs
-              - query
-            - allOf:
-              - not:
-                  required:
-                  - createTableAs
-              properties:
-                unmanaged:
-                  enum:
-                  - false
-                view:
-                  enum:
-                  - true
-              required:
-              - view
-              - query
-            - allOf:
-              - not:
-                  required:
-                  - view
-              - not:
-                  required:
-                  - createTableAs
-              properties:
-                unmanaged:
-                  enum:
-                  - true
             properties:
               catalog:
                 description: |
@@ -3208,7 +3168,6 @@ objects:
             - catalog
             - schema
             - tableName
-            - columns
             type: object
         required:
         - spec

--- a/manifests/deploy/upstream/metering-ansible-operator/prestotable.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/prestotable.crd.yaml
@@ -35,7 +35,7 @@ spec:
           type: object
           description: |
             PrestoTableSpec is the desired specification of a PrestoTable custom resource.
-            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
             Optional fields: query, view, createTableAs, properties, and comment.
             More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
           required:
@@ -43,7 +43,6 @@ spec:
           - catalog
           - schema
           - tableName
-          - columns
           properties:
             unmanaged:
               type: boolean
@@ -123,44 +122,4 @@ spec:
                 Note: this is an optional field.
                 More info: https://prestosql.io/docs/current/overview/concepts.html#query
               minLength: 1
-          oneOf:
-          - required:
-            - createTableAs
-            - query
-            properties:
-              createTableAs:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - view
-          - required:
-            - view
-            - query
-            properties:
-              view:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - createTableAs
-          - properties:
-              unmanaged:
-                enum:
-                - true
-            allOf:
-            - not:
-                required:
-                - view
-            - not:
-                required:
-                - createTableAs
 

--- a/manifests/deploy/upstream/olm/bundle/4.4/prestotable.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.4/prestotable.crd.yaml
@@ -35,7 +35,7 @@ spec:
           type: object
           description: |
             PrestoTableSpec is the desired specification of a PrestoTable custom resource.
-            Required fields: unmanaged, catalog, schema, tableName, and columns.
+            Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
             Optional fields: query, view, createTableAs, properties, and comment.
             More info: https://github.com/operator-framework/operator-metering/blob/master/Documentation/prestotables.md
           required:
@@ -43,7 +43,6 @@ spec:
           - catalog
           - schema
           - tableName
-          - columns
           properties:
             unmanaged:
               type: boolean
@@ -123,44 +122,4 @@ spec:
                 Note: this is an optional field.
                 More info: https://prestosql.io/docs/current/overview/concepts.html#query
               minLength: 1
-          oneOf:
-          - required:
-            - createTableAs
-            - query
-            properties:
-              createTableAs:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - view
-          - required:
-            - view
-            - query
-            properties:
-              view:
-                enum:
-                - true
-              unmanaged:
-                enum:
-                - false
-            allOf:
-            - not:
-                required:
-                - createTableAs
-          - properties:
-              unmanaged:
-                enum:
-                - true
-            allOf:
-            - not:
-                required:
-                - view
-            - not:
-                required:
-                - createTableAs
 

--- a/pkg/operator/reporting/db.go
+++ b/pkg/operator/reporting/db.go
@@ -81,6 +81,7 @@ type PrestoTableManager interface {
 	CreateTable(catalog, schema, tableName string, columns []presto.Column, comment string, properties map[string]string, ignoreExists bool) error
 	CreateTableAs(catalog, schema, tableName string, columns []presto.Column, comment string, properties map[string]string, ignoreExists bool, query string) error
 	DropTable(catalog, schema, tableName string, ignoreNotExists bool) error
+	QueryMetadata(catalog, schema, tableName string) ([]presto.Column, error)
 
 	CreateView(catalog, schema, viewName, query string) error
 	DropView(catalog, schema, viewName string, ignoreNotExists bool) error
@@ -112,4 +113,8 @@ func (c *PrestoTableManagerImpl) CreateView(catalog, schema, viewName, query str
 
 func (c *PrestoTableManagerImpl) DropView(catalog, schema, viewName string, ignoreNotExists bool) error {
 	return presto.DropView(c.queryer, catalog, schema, viewName, ignoreNotExists)
+}
+
+func (c *PrestoTableManagerImpl) QueryMetadata(catalog, schema, tableName string) ([]presto.Column, error) {
+	return presto.QueryMetadata(c.queryer, catalog, schema, tableName)
 }


### PR DESCRIPTION
Currently, `spec.columns` are a required value in the `PrestoTable` CRD which is not always ideal. In the case of unmanaged tables, you would still need to specify a `spec.columns` configuration despite that table schema already existing in Presto. This would update the way that the reporting-operator handles unmanaged tables, namely natively querying the Presto go-client for the `spec.tableName` table_name, which eliminates the need to specify a column definition.