### PR TITLE
Bug 1793543: Allow support for using S3 buckets in an IPV6 cluster.

### DIFF
--- a/charts/openshift-metering/templates/hadoop/_hadoop_config_helpers.tpl
+++ b/charts/openshift-metering/templates/hadoop/_hadoop_config_helpers.tpl
@@ -57,9 +57,20 @@
 {{- define "core-site-xml" -}}
 <configuration>
   <property>
-      <name>fs.defaultFS</name>
-      <value>{{ .Values.hadoop.spec.config.defaultFS }}</value>
+    <name>fs.defaultFS</name>
+    <value>{{ .Values.hadoop.spec.config.defaultFS }}</value>
   </property>
+{{- if and .Values.hadoop.spec.config.aws.region .Values.useIPV6Networking }}
+  <property>
+    <name>fs.s3a.endpoint</name>
+    <value>https://s3.dualstack.{{ .Values.hadoop.spec.config.aws.region }}.amazonaws.com</value>
+  </property>
+  <property>
+    <name>fs.s3a.path.style.access</name>
+    <value>true</value>
+    <description>Enable S3 path style access.</description>
+  </property>
+{{- end }}
 {{- if .Values.hadoop.spec.config.s3Compatible.endpoint }}
   <property>
     <name>fs.s3a.impl</name>

--- a/charts/openshift-metering/templates/presto/_presto_helpers.tpl
+++ b/charts/openshift-metering/templates/presto/_presto_helpers.tpl
@@ -21,16 +21,18 @@ hive.metastore-timeout={{ .Values.presto.spec.config.connectors.hive.metastoreTi
 {{- if .Values.presto.spec.config.connectors.hive.s3.useInstanceCredentials }}
 hive.s3.use-instance-credentials={{ .Values.presto.spec.config.connectors.hive.s3.useInstanceCredentials }}
 {{- end }}
-
 {{- if .Values.presto.spec.config.connectors.hive.useHadoopConfig}}
 hive.config.resources=/hadoop-config/core-site.xml
+{{- end }}
+
+{{- if and .Values.presto.spec.config.aws.region .Values.useIPV6Networking }}
+hive.s3.endpoint=https://s3.dualstack.{{ .Values.presto.spec.config.aws.region }}.amazonaws.com
+hive.s3.path-style-access=true
 {{- end }}
 {{- if .Values.presto.spec.config.s3Compatible.endpoint }}
 hive.s3.endpoint={{ .Values.presto.spec.config.s3Compatible.endpoint }}
 hive.s3.path-style-access=true
 {{- end }}
-
-
 {{- end }}
 
 {{- define "presto-jmx-catalog-properties" -}}

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -476,6 +476,7 @@ presto:
         secretAccessKey: ""
         createSecret: false
         secretName: ""
+        region: ""
 
       azure:
         storageAccountName: ""
@@ -864,6 +865,7 @@ hadoop:
         secretAccessKey: ""
         createSecret: false
         secretName: ""
+        region: ""
 
       azure:
         storageAccountName: ""

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -79,6 +79,7 @@ _base_storage_overrides:
         config:
           aws:
             secretName: "{{ _storage_spec | json_query('hive.s3.secretName') }}"
+            region: "{{ _storage_spec | json_query('hive.s3.region') }}"
             createSecret: false
     hive:
       spec:
@@ -93,6 +94,8 @@ _base_storage_overrides:
         config:
           # regex_replace to append a trailing slash if missing
           defaultFS: "s3a://{{ _storage_spec | json_query('hive.s3.bucket') | regex_replace('\\/?$', '/') }}"
+          aws:
+            region: "{{ _storage_spec | json_query('hive.s3.region') }}"
         hdfs:
           enabled: false
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -50,8 +50,6 @@ import (
 )
 
 const (
-	connBackoff         = time.Second * 15
-	maxConnRetries      = 3
 	defaultResyncPeriod = time.Minute * 15
 	prestoUsername      = "reporting-operator"
 
@@ -265,7 +263,6 @@ func newReportingOperator(
 	meteringClient cbClientset.Interface,
 	informerNamespace string,
 ) *Reporting {
-
 	informerFactory := factory.NewFilteredSharedInformerFactory(meteringClient, defaultResyncPeriod, informerNamespace, nil)
 
 	prestoTableInformer := informerFactory.Metering().V1().PrestoTables()
@@ -558,7 +555,7 @@ func (op *Reporting) Run(ctx context.Context) error {
 		defer wg.Done()
 		var srvErr error
 		if op.cfg.APITLSConfig.UseTLS {
-			op.logger.Infof("HTTP API server listening with TLS on 127.0.0.1:8080")
+			op.logger.Infof("HTTP API server listening with TLS on %s", op.cfg.APIListen)
 			srvErr = httpServer.ListenAndServeTLS(op.cfg.APITLSConfig.TLSCert, op.cfg.APITLSConfig.TLSKey)
 		} else {
 			op.logger.Infof("HTTP API server listening on %s", op.cfg.APIListen)


### PR DESCRIPTION
AWS exposes a REST API endpoint for dual-stack s3 bucket hostnames. After playing around with both the virtual hosted-style and path-style requests, it appears that we still need to specify the fs.defaultFS and hive.metastore.warehouse.dir in order to talk with Hive Metastore correctly. This implies that we need to specify the s3 bucket name as the defaultFS/warehouseDir components, and use the path-style endpoint (i.e. s3.dualstack.us-east-1.amazonaws.com/<bucket name>) to hit the correct s3 bucket host.

Link to AWS dualstack docs: https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html