### PR TITLE
Revert "Add logging of resource installs to k8s_event_module"

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/library/k8s_event.py
+++ b/images/metering-ansible-operator/roles/meteringconfig/library/k8s_event.py
@@ -135,7 +135,7 @@ requirements:
 EXAMPLES = """
 
 - name: Create Kubernetes Event
-  k8s_event:
+  k8s_events
     state: present
     name: test-https-emily109
     namespace: default
@@ -309,7 +309,6 @@ class KubernetesEvent(KubernetesRawModule):
                 pass
 
         event = {
-            "kind": "Event",
             "count": prior_count,
             "eventTime": None,
             "firstTimestamp": first_timestamp,

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting.yml
@@ -18,21 +18,3 @@
   vars:
     kube_minor_version: "{{ (kube_version.stdout | from_json | json_query('serverVersion.minor')).rstrip('+') }}"
     kube_version_at_least_1_14: "{{ ((kube_minor_version | int) >= 14) | bool }}"
-
-- name: Log Events for Configuring Reporting
-  k8s_event:
-    state: present
-    name: Configure Reporting resources
-    namespace: "{{ meta.namespace }}"
-    message: Configure reporting
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"
-

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -195,21 +195,3 @@
       status: "True"
       message: "Finished configuring Hive storage"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Configuring Storage
-  k8s_event:
-    state: present
-    name: Configuring Storage Event
-    namespace: "{{ meta.namespace }}"
-    message: Configure Storage
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"
-

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
@@ -51,21 +51,3 @@
       status: "True"
       message: "Finished configuring TLS"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for validating TLS
-  k8s_event:
-    state: present
-    name: Validate TLS
-    namespace: "{{ meta.namespace }}"
-    message: Validating TLS
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"
-

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
@@ -66,20 +66,3 @@
       status: "True"
       message: "Finished reconciling HDFS resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling HDFS
-  k8s_event:
-    state: present
-    name: Reconcile Hdfs Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile HDFS
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -85,20 +85,3 @@
       status: "True"
       message: "Finished reconciling Hive resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Hive
-  k8s_event:
-    state: present
-    name: Reconcile Hive Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Hive
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
@@ -31,20 +31,3 @@
       status: "True"
       message: "Finished reconciling Metering resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Metering
-  k8s_event:
-    state: present
-    name: Reconcile Metering Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Metering
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
@@ -41,20 +41,3 @@
       status: "True"
       message: "Finished reconciling monitoring resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Monitoring
-  k8s_event:
-    state: present
-    name: Reconcile Monitoring Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Monitoring
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
@@ -84,20 +84,3 @@
       status: "True"
       message: "Finished reconciling Presto resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Presto
-  k8s_event:
-    state: present
-    name: Reconcile Presto Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Presto
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
@@ -74,20 +74,3 @@
       status: "True"
       message: "Finished reconciling reporting resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Reporting
-  k8s_event:
-    state: present
-    name: Reconcile Reporting Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Reporting
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
@@ -92,20 +92,3 @@
       status: "True"
       message: "Finished reconciling reporting-operator resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reporting Operator
-  k8s_event:
-    state: present
-    name: Reconcile Reporting Operator Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Reporting Operator
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
@@ -87,21 +87,3 @@
       status: "True"
       message: "Finished the validation process"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for validating configurations
-  k8s_event:
-    state: present
-    name: Validate Configuration
-    namespace: "{{ meta.namespace }}"
-    message: Validate Configurations
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"
-


### PR DESCRIPTION
Reverts operator-framework/operator-metering#1043

I've seen this module break a couple of Metering installs so let's play it safe and revert this PR until we wrap up the ipv6-related support.