### PR TITLE
Add support for auto-detecting single-stack IPV4/IPV6 Openshift clusters.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -24,7 +24,7 @@ RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 # put tini into our path
 RUN ln -f -s /tini /usr/bin/tini
 
-RUN pip install --no-cache-dir --upgrade openshift boto3 cryptography
+RUN pip install --no-cache-dir --upgrade openshift boto3 cryptography netaddr
 # In order to use the 'ansible_failed_result' and 'ansible_failed_task' variables in a block/rescue,
 # we need to ensure that the 2.8 version is being used while this is fixed in 2.9 upstream.
 # TODO: revert this change once the issue mentioned above is resolved.

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -6,7 +6,7 @@ FROM openshift/ose-cli:latest as cli
 FROM openshift/ose-ansible-operator:latest
 
 USER root
-RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-boto3 python2-openshift python2-cryptography openssl" \
+RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-netaddr python-boto3 python2-openshift python2-cryptography openssl" \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -36,6 +36,13 @@ operator:
       verbs:
       - get
       - list
+    # grants access to view the networking config
+    - apiGroups:
+      - config.openshift.io
+      resources:
+      - networks
+      verbs:
+      - list
     # used by openshift auth-proxy
     - apiGroups:
       - authorization.k8s.io

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -6,6 +6,8 @@ unsupportedFeatures:
 
 disableOCPFeatures: false
 
+useIPV6Networking: false
+
 storage:
   type: "hive"
   hive: {}

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -359,7 +359,11 @@ _ocp_disabled_overrides:
         securityContext:
           fsGroup: 0
 
+_ocp_enabled_use_ipv6_networking: false
+
 _ocp_enabled_overrides:
+  useIPV6Networking: "{{ _ocp_enabled_use_ipv6_networking }}"
+
   reporting-operator:
     spec:
       config:

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
@@ -1,0 +1,28 @@
+---
+
+# Get the Openshift cluster's networking config object
+- name: Check the IP version infrastructure provisioned
+  k8s_facts:
+    api_version: "config.openshift.io/v1"
+    kind: Network
+    name: cluster
+  register: cluster_network_config
+  when: not meteringconfig_ocp_disabled
+
+# Attempt to auto-detect whether there are any ipv4 addresses in the serviceNetwork array.
+# If there are, treat the cluster as single-stack IPV4, else enable IPV6 networking.
+#
+# TODO: fix this logic when better support for Openshift dual-stack has been developed.
+# Note: the ipv4 Jinja2 filter has a dependency on the "netaddr" python module.
+- name: Detect if cluster is single-stack ipv4
+  block:
+  - set_fact:
+      service_network_contains_ipv4_address: "{{ item | ipv4 }}"
+    loop: "{{ serviceNetworkList.status.serviceNetwork }}"
+
+  - set_fact:
+      _ocp_enabled_use_ipv6_networking: true
+    when: not service_network_contains_ipv4_address
+  vars:
+    serviceNetworkList: "{{ cluster_network_config.resources | first }}"
+  when: cluster_network_config is defined and cluster_network_config.resources is defined and cluster_network_config.resources | length > 0

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -9,6 +9,9 @@
 - name: Configure TLS
   include_tasks: configure_tls.yml
 
+- name: Configure Networking
+  include_tasks: configure_networking.yml
+
 - name: Configure Reporting
   include_tasks: configure_reporting.yml
 

--- a/manifests/deploy/ocp-testing/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/ocp-testing/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -11,6 +11,12 @@ rules:
     - get
     - list
   - apiGroups:
+    - config.openshift.io
+    resources:
+    - networks
+    verbs:
+    - list
+  - apiGroups:
     - authorization.k8s.io
     resources:
     - subjectaccessreviews

--- a/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -297,6 +297,12 @@ spec:
             - get
             - list
           - apiGroups:
+            - config.openshift.io
+            resources:
+            - networks
+            verbs:
+            - list
+          - apiGroups:
             - authorization.k8s.io
             resources:
             - subjectaccessreviews

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -11,6 +11,12 @@ rules:
     - get
     - list
   - apiGroups:
+    - config.openshift.io
+    resources:
+    - networks
+    verbs:
+    - list
+  - apiGroups:
     - authorization.k8s.io
     resources:
     - subjectaccessreviews

--- a/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -297,6 +297,12 @@ spec:
             - get
             - list
           - apiGroups:
+            - config.openshift.io
+            resources:
+            - networks
+            verbs:
+            - list
+          - apiGroups:
             - authorization.k8s.io
             resources:
             - subjectaccessreviews

--- a/manifests/deploy/openshift/telemeter/list.yaml
+++ b/manifests/deploy/openshift/telemeter/list.yaml
@@ -3892,6 +3892,12 @@ objects:
     - get
     - list
   - apiGroups:
+    - config.openshift.io
+    resources:
+    - networks
+    verbs:
+    - list
+  - apiGroups:
     - authorization.k8s.io
     resources:
     - subjectaccessreviews

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -11,6 +11,12 @@ rules:
     - get
     - list
   - apiGroups:
+    - config.openshift.io
+    resources:
+    - networks
+    verbs:
+    - list
+  - apiGroups:
     - authorization.k8s.io
     resources:
     - subjectaccessreviews

--- a/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -295,6 +295,12 @@ spec:
             - get
             - list
           - apiGroups:
+            - config.openshift.io
+            resources:
+            - networks
+            verbs:
+            - list
+          - apiGroups:
             - authorization.k8s.io
             resources:
             - subjectaccessreviews


### PR DESCRIPTION
Dockerfile(s): Add the python `netaddr` module to allow the usage of the `ipv4` Jinja2 filter.

Charts/: This would add a top-level variable that enables IPV6 networking to values.yaml.

Images/: Update the MeteringConfig Ansible role to allow support for inspecting the Networking config.openshift.io object, iterating over the serviceNetwork array and checking if there are any IPV4 addresses. In the case where there's a mixture of IPV4 and IPV6 addresses, treat that configuration as a single-stack IPV4 Openshift cluster. Else, treat it as a single-stack IPV6 Openshift cluster.