### PR TITLE
images: Remove the task name for ending the role during an error.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/update_meteringconfig_status.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/update_meteringconfig_status.yml
@@ -9,7 +9,6 @@
     conditions: "{{ [ current_conditions ] }}"
   when: current_conditions is defined
 
-- name: End role due to failure
-  fail:
+- fail:
     msg: "Failing role execution after updating the MeteringConfig.Status"
   when: end_play_after_updating_status is defined and end_play_after_updating_status


### PR DESCRIPTION
When viewing the metering-operator "operator" container logs, there's no field that details whether a task is skipped or not [1], and in most cases we skip the fail module for this task. This can lead to confusion, so removing this task name can help improve clarity.

[1] {"level":"info","ts":1579721726.2411647,"logger":"logging_event_handler","msg":"[playbook task]","name":"operator-metering","namespace":"openshift-metering","gvk":"metering.openshift.io/v1, Kind=MeteringConfig","event_type":"playbook_on_task_start","job":"3510942875414458836","EventData.Name":"meteringconfig : End role due to failure"}