### PR TITLE
Bug 1795267: Allow the metering-operator to get the network openshift config object.

### DIFF
--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -43,6 +43,7 @@ operator:
       - networks
       verbs:
       - list
+      - get
     # used by openshift auth-proxy
     - apiGroups:
       - authorization.k8s.io

--- a/manifests/deploy/ocp-testing/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/ocp-testing/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
     - networks
     verbs:
     - list
+    - get
   - apiGroups:
     - authorization.k8s.io
     resources:

--- a/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -302,6 +302,7 @@ spec:
             - networks
             verbs:
             - list
+            - get
           - apiGroups:
             - authorization.k8s.io
             resources:

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
     - networks
     verbs:
     - list
+    - get
   - apiGroups:
     - authorization.k8s.io
     resources:

--- a/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -302,6 +302,7 @@ spec:
             - networks
             verbs:
             - list
+            - get
           - apiGroups:
             - authorization.k8s.io
             resources:

--- a/manifests/deploy/openshift/telemeter/list.yaml
+++ b/manifests/deploy/openshift/telemeter/list.yaml
@@ -3897,6 +3897,7 @@ objects:
     - networks
     verbs:
     - list
+    - get
   - apiGroups:
     - authorization.k8s.io
     resources:

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
     - networks
     verbs:
     - list
+    - get
   - apiGroups:
     - authorization.k8s.io
     resources:

--- a/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -300,6 +300,7 @@ spec:
             - networks
             verbs:
             - list
+            - get
           - apiGroups:
             - authorization.k8s.io
             resources:


### PR DESCRIPTION
This would add the 'get' verb to the cluster-role RBAC rules as the 'list' verb was insufficient permissions.