### PR TITLE
Dockerfile.reporting-operator: Bump the Golang compiler version to 1.13.

### DIFF
--- a/Dockerfile.reporting-operator
+++ b/Dockerfile.reporting-operator
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.12 as build
+FROM openshift/origin-release:golang-1.13 as build
 
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering

--- a/Dockerfile.reporting-operator.okd
+++ b/Dockerfile.reporting-operator.okd
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.12 as build
+FROM openshift/origin-release:golang-1.13 as build
 
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering

--- a/Dockerfile.reporting-operator.rhel
+++ b/Dockerfile.reporting-operator.rhel
@@ -1,4 +1,4 @@
-FROM openshift/golang-builder:1.12 AS build
+FROM openshift/golang-builder:1.13 AS build
 
 COPY . /go/src/github.com/operator-framework/operator-metering
 WORKDIR /go/src/github.com/operator-framework/operator-metering


### PR DESCRIPTION
ART uses the Golang 1.13 compiler to build our OCP images, so this would bump the version of the compiler used in the reporting-operator Dockerfiles.