### PR TITLE
Bug 1797801: Update the Hive and reporting-operator charts to work with single-stack ipv4 and ipv6.

### DIFF
--- a/charts/openshift-metering/templates/hive/hive-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-configmap.yaml
@@ -31,23 +31,33 @@ data:
       </property>
       <property>
         <name>hive.server2.thrift.bind.host</name>
-{{- if .Values.hive.spec.server.config.tls.enabled }}
+{{- if and .Values.hive.spec.server.config.tls.enabled .Values.useIPV6Networking }}
+        <value>[::1]</value>
+{{- else if .Values.hive.spec.server.config.tls.enabled }}
         <value>127.0.0.1</value>
+{{- else if .Values.useIPV6Networking }}
+        <value>[::]</value>
 {{- else }}
         <value>0.0.0.0</value>
 {{- end }}
       </property>
       <property>
         <name>hive.metastore.thrift.bind.host</name>
-{{- if .Values.hive.spec.metastore.config.tls.enabled }}
+{{- if and .Values.hive.spec.metastore.config.tls.enabled .Values.useIPV6Networking }}
+        <value>[::1]</value>
+{{- else if .Values.hive.spec.metastore.config.tls.enabled }}
         <value>127.0.0.1</value>
+{{- else if .Values.useIPV6Networking }}
+        <value>[::]</value>
 {{- else }}
         <value>0.0.0.0</value>
 {{- end }}
       </property>
       <property>
         <name>hive.metastore.uris</name>
-{{- if .Values.hive.spec.metastore.config.tls.enabled }}
+{{- if and .Values.hive.spec.metastore.config.tls.enabled .Values.useIPV6Networking }}
+        <value>thrift://[::1]:9083</value>
+{{- else if .Values.hive.spec.metastore.config.tls.enabled }}
         <value>thrift://localhost:9083</value>
 {{- else }}
         <value>thrift://hive-metastore:9083</value>

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -204,9 +204,17 @@ spec:
         args:
         - server
         - --listen
+{{- if .Values.useIPV6Networking }}
+        - "[::]:9084"
+{{- else }}
         - 0.0.0.0:9084
+{{- end }}
         - --target
+{{- if .Values.useIPV6Networking }}
+        - "[::1]:9083"
+{{- else }}
         - localhost:9083
+{{- end }}
         - --key
         -  $(HIVE_METASTORE_KEYFILE)
         - --cert

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -230,7 +230,11 @@ spec:
         args:
         - client
         - --listen
+{{- if .Values.useIPV6Networking }}
+        - "[::1]:9083"
+{{- else }}
         - localhost:9083
+{{- end }}
         - --target
         - hive-metastore:9083
         - --keystore
@@ -256,9 +260,17 @@ spec:
         args:
         - server
         - --listen
+{{- if .Values.useIPV6Networking }}
+        - "[::]:10001"
+{{- else }}
         - 0.0.0.0:10001
+{{- end }}
         - --target
+{{- if .Values.useIPV6Networking }}
+        - "[::1]:10000"
+{{- else }}
         - localhost:10000
+{{- end }}
         - --key
         -  $(GHOSTUNNEL_SERVER_KEYFILE)
         - --cert

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -262,7 +262,6 @@ spec:
         - name: REPORTING_OPERATOR_HIVE_USE_AUTH
           value: "false"
 {{- end }}
-
         - name: REPORTING_OPERATOR_LEASE_DURATION
           valueFrom:
             configMapKeyRef:
@@ -301,15 +300,27 @@ spec:
               key: target-namespaces
               optional: true
         - name: REPORTING_OPERATOR_API_LISTEN
-{{- if $operatorValues.spec.authProxy.enabled }}
+{{- if and $operatorValues.spec.authProxy.enabled .Values.useIPV6Networking }}
+          value: "[::1]:8080"
+{{- else if $operatorValues.spec.authProxy.enabled }}
           value: 127.0.0.1:8080
+{{- else if .Values.useIPV6Networking }}
+          value: "[::]:8080"
 {{- else }}
           value: 0.0.0.0:8080
 {{- end }}
         - name: REPORTING_OPERATOR_METRICS_LISTEN
+{{- if .Values.useIPV6Networking }}
+          value: "[::]:8082"
+{{- else }}
           value: 0.0.0.0:8082
+{{- end }}
         - name: REPORTING_OPERATOR_PPROF_LISTEN
+{{- if .Values.useIPV6Networking }}
+          value: "[::1]:6060"
+{{- else }}
           value: 127.0.0.1:6060
+{{- end }}
         resources:
 {{ toYaml $operatorValues.spec.resources | indent 10 }}
         ports:
@@ -374,7 +385,11 @@ spec:
         - -https-address=
         - -http-address=:8081
 {{- end }}
+{{- if .Values.useIPV6Networking }}
+        - -upstream=http://[::1]:8080
+{{- else }}
         - -upstream=http://127.0.0.1:8080
+{{- end }}
         - -htpasswd-file=/etc/proxy/htpasswd/auth
 {{- if $operatorValues.spec.config.tls.api.enabled }}
         - -tls-cert=/etc/tls/tls.crt


### PR DESCRIPTION
This is a follow-up to PR #1077 which introduced support for using S3 as the storage backend in an IPV6 cluster. The changes in this PR update the Hive ghostunnel configuration needed to support both a single-stack configuration, dependent on the value of the top-level .useIPV6Networking.

In the case of the pkg/reporting-operator/cmd.go flags, we typically override the default values through the corresponding environment variable, which is reflected in the reporting-operator deployment changes. It's important to note that this means we need to be more careful when interacting with the CLI explicitly (i.e. in the case of running the reporting-operator locally, or in the e2e suite.)