### PR TITLE
Bug 1790601: Fix description of runImmediately

### DIFF
--- a/Documentation/reports.md
+++ b/Documentation/reports.md
@@ -242,9 +242,9 @@ spec:
 ```
 
 ### runImmediately
+When `runImmediately` is set to `true`, the report will be run immediately. This behavior ensures that the report is immediately processed and queued without requiring additional scheduling parameters.
 
-Set `runImmediately` to `true` to run the report immediately with all available data, regardless of the `reportingStart` or `reportingEnd` values, and without checking if there is any data for the report period.
-For reports with a schedule set, it will not wait for each period's reportingEnd to elapse before processing and all reportPeriods between `reportingStart` and `reportingEnd`.
+> *Note*: When `runImmediately` is set to `true` you must set a `reportingEnd` and `reportingStart` value.
 
 ### Inputs
 

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -486,7 +486,7 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *metering.Report) 
 	var runningMsg, runningReason string
 	if report.Spec.RunImmediately {
 		runningReason = meteringUtil.RunImmediatelyReason
-		runningMsg = fmt.Sprintf("Report %s scheduled: runImmediately=true bypassing reporting period [%s to %s].", report.Name, reportPeriod.periodStart, reportPeriod.periodEnd)
+		runningMsg = fmt.Sprintf("Report %s scheduled: runImmediately=true and reporting period [%s to %s].", report.Name, reportPeriod.periodStart, reportPeriod.periodEnd)
 	} else {
 		// Check if it's time to generate the report
 		if reportPeriod.periodEnd.After(now) {


### PR DESCRIPTION
Changes docs and logging around reports `spec.runImmediately: true` to reflect what actually is required and what happens.