### PR TITLE
Bug 1799054: Add support for suggested namespace and cluster monitoring annotations in OLM.

### DIFF
--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -314,6 +314,8 @@ olm:
         version: v1
 
     annotations:
+      operatorframework.io/suggested-namespace: openshift-metering
+      operatorframework.io/cluster-monitoring: true
       categories: "OpenShift Optional, Monitoring"
       certified: "false"
       capabilities: Basic Install

--- a/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -209,6 +209,8 @@ metadata:
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    operatorframework.io/cluster-monitoring: true
+    operatorframework.io/suggested-namespace: openshift-metering
     repository: https://github.com/operator-framework/operator-metering
     support: Red Hat, Inc.
 

--- a/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -209,6 +209,8 @@ metadata:
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    operatorframework.io/cluster-monitoring: true
+    operatorframework.io/suggested-namespace: openshift-metering
     repository: https://github.com/operator-framework/operator-metering
     support: Red Hat, Inc.
 

--- a/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -209,6 +209,8 @@ metadata:
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    operatorframework.io/cluster-monitoring: true
+    operatorframework.io/suggested-namespace: openshift-metering
     repository: https://github.com/operator-framework/operator-metering
     support: Red Hat, Inc.
 


### PR DESCRIPTION
This feature was added to the Openshift console in 4.4 and allows users to install Metering through OperatorHub.io in one step, instead of having to create the namespace first, then installing the Operator.