### PR TITLE
Bug 1793331: Remove /etc/passwd UID entrypoint scripts.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -47,10 +47,6 @@ COPY charts/openshift-metering ${HELM_CHART_PATH}
 
 COPY manifests/deploy/openshift/olm/bundle /manifests
 
-# to allow running as non-root
-RUN chown -R 1001:0 $HOME && \
-    chmod -R 774 $HOME /etc/passwd
-
 USER 1001
 
 ENTRYPOINT ["/opt/ansible/scripts/entrypoint.sh"]

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -29,10 +29,6 @@ COPY charts/openshift-metering ${HELM_CHART_PATH}
 
 COPY manifests/deploy/openshift/olm/bundle /manifests
 
-# to allow running as non-root
-RUN chown -R 1001:0 $HOME && \
-    chmod -R 774 $HOME /etc/passwd
-
 ENTRYPOINT ["/opt/ansible/scripts/entrypoint.sh"]
 
 USER 1001

--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -77,23 +77,6 @@ data:
     # set datanode options
     export HDFS_DATANODE_OPTS="${HDFS_DATANODE_OPTS} -Dhadoop.security.logger=ERROR,RFAS ${VM_OPTIONS} ${GC_SETTINGS} ${JMX_OPTIONS}"
 
-    # add UID to /etc/passwd if missing
-    if ! whoami &> /dev/null; then
-        if [ -w /etc/passwd ]; then
-            echo "Adding user ${USER_NAME:-hadoop} with current UID $(id -u) to /etc/passwd"
-            # Remove existing entry with user first.
-            # cannot use sed -i because we do not have permission to write new
-            # files into /etc
-            sed  "/${USER_NAME:-hadoop}:x/d" /etc/passwd > /tmp/passwd
-            # add our user with our current user ID into passwd
-            echo "${USER_NAME:-hadoop}:x:$(id -u):0:${USER_NAME:-hadoop} user:${HOME}:/sbin/nologin" >> /tmp/passwd
-            # overwrite existing contents with new contents (cannot replace the
-            # file due to permissions)
-            cat /tmp/passwd > /etc/passwd
-            rm /tmp/passwd
-        fi
-    fi
-
     # symlink our configuration files to the correct location
     ln -s -f /hadoop-config/core-site.xml /etc/hadoop/core-site.xml
     ln -s -f /hadoop-config/hdfs-site.xml /etc/hadoop/hdfs-site.xml

--- a/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
@@ -48,23 +48,6 @@ data:
       importCert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt changeit $JAVA_HOME/lib/security/cacerts
     fi
 
-    # add UID to /etc/passwd if missing
-    if ! whoami &> /dev/null; then
-        if [ -w /etc/passwd ]; then
-            echo "Adding user ${USER_NAME:-hadoop} with current UID $(id -u) to /etc/passwd"
-            # Remove existing entry with user first.
-            # cannot use sed -i because we do not have permission to write new
-            # files into /etc
-            sed  "/${USER_NAME:-hadoop}:x/d" /etc/passwd > /tmp/passwd
-            # add our user with our current user ID into passwd
-            echo "${USER_NAME:-hadoop}:x:$(id -u):0:${USER_NAME:-hadoop} user:${HOME}:/sbin/nologin" >> /tmp/passwd
-            # overwrite existing contents with new contents (cannot replace the
-            # file due to permissions)
-            cat /tmp/passwd > /etc/passwd
-            rm /tmp/passwd
-        fi
-    fi
-
     # symlink our configuration files to the correct location
     if [ -f /hadoop-config/core-site.xml ]; then
       ln -s -f /hadoop-config/core-site.xml /etc/hadoop/core-site.xml

--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -84,21 +84,4 @@ data:
       echo "hive.s3.aws-secret-key=$AWS_SECRET_ACCESS_KEY" >> "$HIVE_CATALOG_CONFIG"
     fi
 
-    # add UID to /etc/passwd if missing
-    if ! whoami &> /dev/null; then
-        if [ -w /etc/passwd ]; then
-            echo "Adding user ${USER_NAME:-presto} with current UID $(id -u) to /etc/passwd"
-            # Remove existing entry with user first.
-            # cannot use sed -i because we do not have permission to write new
-            # files into /etc
-            sed  "/${USER_NAME:-presto}:x/d" /etc/passwd > /tmp/passwd
-            # add our user with our current user ID into passwd
-            echo "${USER_NAME:-presto}:x:$(id -u):0:${USER_NAME:-presto} user:${HOME}:/sbin/nologin" >> /tmp/passwd
-            # overwrite existing contents with new contents (cannot replace the
-            # file due to permissions)
-            cat /tmp/passwd > /etc/passwd
-            rm /tmp/passwd
-        fi
-    fi
-
     exec "$@"

--- a/images/metering-ansible-operator/scripts/entrypoint.sh
+++ b/images/metering-ansible-operator/scripts/entrypoint.sh
@@ -1,21 +1,4 @@
 #!/bin/bash
 
-# add UID to /etc/passwd if missing
-if ! whoami &> /dev/null; then
-    if [ -w /etc/passwd ]; then
-        echo "Adding user ${USER_NAME:-ansible} with current UID $(id -u) to /etc/passwd"
-        # Remove existing entry with user first.
-        # cannot use sed -i because we do not have permission to write new
-        # files into /etc
-        sed  "/${USER_NAME:-ansible}:x/d" /etc/passwd > /tmp/passwd
-        # add our user with our current user ID into passwd
-        echo "${USER_NAME:-ansible}:x:$(id -u):0:${USER_NAME:-hadoop} user:${HOME}:/sbin/nologin" >> /tmp/passwd
-        # overwrite existing contents with new contents (cannot replace the
-        # file due to permissions)
-        cat /tmp/passwd > /etc/passwd
-        rm /tmp/passwd
-    fi
-fi
-
 # we expect tini to be in the $PATH
 exec tini -- /usr/local/bin/ansible-operator run ansible --watches-file=/opt/ansible/watches.yaml "$@"


### PR DESCRIPTION
This was the recommended way to support arbitrary user IDs in pre-4.2 releases as the container UID was generated dynamically and may not have the corresponding /etc/passwd entry. 

In 4.2+ releases, CRI-O automatically updates this /etc/passwd entry with the current container UID so this is now obsolete and insecure.