### PR TITLE
Bug 1802638: Allow support for creating an S3 bucket on an IPV6 cluster.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -24,7 +24,11 @@ RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 # put tini into our path
 RUN ln -f -s /tini /usr/bin/tini
 
-RUN pip install --no-cache-dir --upgrade openshift boto3 cryptography netaddr
+# List of python packages:
+# 1. botocore and boto3 are used by the aws-related modules (aws_s3)
+# 2. netaddr is needed to use the ipv4/ipv6 jinja filter
+# 3. cryptography is used by the openssl_* modules for TLS/authentication purposes
+RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr
 # In order to use the 'ansible_failed_result' and 'ansible_failed_task' variables in a block/rescue,
 # we need to ensure that the 2.8 version is being used while this is fixed in 2.9 upstream.
 # TODO: revert this change once the issue mentioned above is resolved.

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -6,7 +6,7 @@ FROM openshift/ose-cli:latest as cli
 FROM openshift/ose-ansible-operator:latest
 
 USER root
-RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-netaddr python-boto3 python2-openshift python2-cryptography openssl" \
+RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-netaddr python-botocore python-boto3 python2-openshift python2-cryptography openssl" \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -38,11 +38,12 @@
           - s3_credentials_secret_exists
         msg: "storage.hive.s3.secret does not exist"
 
-    - name: Create Metering S3 bucket
-      s3_bucket:
-        state: present
-        name: "{{ meteringconfig_storage_s3_bucket_name }}"
+    - name: Create the Metering S3 bucket
+      aws_s3:
+        mode: create
+        bucket: "{{ meteringconfig_storage_s3_bucket_name }}"
         region: "{{ meteringconfig_storage_s3_bucket_region }}"
+        dualstack: "{{ s3_use_dualstack_endpoint }}"
         aws_access_key: "{{ operator_s3_credentials_secret.resources[0].data['aws-access-key-id'] | b64decode | default(omit) }}"
         aws_secret_key: "{{ operator_s3_credentials_secret.resources[0].data['aws-secret-access-key'] | b64decode | default(omit) }}"
       when: s3_credentials_secret_exists
@@ -58,6 +59,7 @@
       when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
   vars:
     s3_credentials_secret_exists: "{{ operator_s3_credentials_secret.resources and operator_s3_credentials_secret.resources | length > 0 }}"
+    s3_use_dualstack_endpoint: "{{ _ocp_enabled_use_ipv6_networking }}"
   when: meteringconfig_storage_hive_storage_type == 's3' and meteringconfig_storage_s3_create_bucket
 
 - name: Configure S3 Compatible Storage

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -3,14 +3,14 @@
 - name: Validate Configurations
   include_tasks: validate.yml
 
+- name: Configure Networking
+  include_tasks: configure_networking.yml
+
 - name: Configure Storage
   include_tasks: configure_storage.yml
 
 - name: Configure TLS
   include_tasks: configure_tls.yml
-
-- name: Configure Networking
-  include_tasks: configure_networking.yml
 
 - name: Configure Reporting
   include_tasks: configure_reporting.yml


### PR DESCRIPTION
This is needed as the s3_bucket Ansible module does not support dual-stack endpoints, which is problematic is metering is run in an ipv6 single-stack configuration. In order to use the aws_s3 module which exposes a `dualstack` option, but has a dependency on the `botocore` python package. This commit would install that package so we can utilize this module to support both single-stack ipv4 and single-stack ipv6 configurations.