### PR TITLE
Dockerfile: Require the setuptools python package to be less than the 45.2.0 version.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -2,7 +2,8 @@
 FROM quay.io/openshift/origin-metering-helm:latest as helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli:latest as cli
-# real base
+# the base image is the ansible-operator's origin images
+# TODO: stop using the latest tag for base images
 FROM quay.io/openshift/origin-ansible-operator:latest
 
 USER root
@@ -28,7 +29,8 @@ RUN ln -f -s /tini /usr/bin/tini
 # 1. botocore and boto3 are used by the aws-related modules (aws_s3)
 # 2. netaddr is needed to use the ipv4/ipv6 jinja filter
 # 3. cryptography is used by the openssl_* modules for TLS/authentication purposes
-RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr
+# TODO: the ansible-operator base image uses setuptools >= 45.2.0 which needs python 3.5 so this is a temporary fix
+RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr "setuptools<=45.1.0"
 # In order to use the 'ansible_failed_result' and 'ansible_failed_task' variables in a block/rescue,
 # we need to ensure that the 2.8 version is being used while this is fixed in 2.9 upstream.
 # TODO: revert this change once the issue mentioned above is resolved.

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -6,7 +6,7 @@ FROM openshift/ose-cli:latest as cli
 FROM openshift/ose-ansible-operator:latest
 
 USER root
-RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-netaddr python-botocore python-boto3 python2-openshift python2-cryptography openssl" \
+RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-netaddr python2-botocore python2-boto3 python2-openshift python2-cryptography openssl" \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \


### PR DESCRIPTION
This a workaround now that base image uses a version of` setuptools` (>= 45.2.0) which requires a python version >= 3.5.
