### PR TITLE
charts,manifests: Add support for upgrading between Metering CSV versions.

### DIFF
--- a/charts/metering-ansible-operator/templates/olm/art.yaml
+++ b/charts/metering-ansible-operator/templates/olm/art.yaml
@@ -9,6 +9,8 @@ updates:
     # replace spec.version value
     - search: 'version: "{{ .Values.olm.csv.version }}"'
       replace: 'version: {FULL_VER}'
+    - search: 'olm.skipRange: ">=4.2.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.2.0 <{FULL_VER}"'
   - file: "metering.package.yaml"
     update_list:
     - search: "currentCSV: metering-operator.v{MAJOR}.{MINOR}.0"

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -318,12 +318,13 @@ olm:
       operatorframework.io/cluster-monitoring: "true"
       categories: "OpenShift Optional, Monitoring"
       certified: "false"
-      capabilities: Basic Install
+      capabilities: Seamless Upgrades
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
       containerImage: "quay.io/openshift/origin-metering-ansible-operator:4.5"
       description: 'Chargeback and reporting tool to provide accountability for how resources are used across a cluster'
       repository: https://github.com/operator-framework/operator-metering
+      olm.skipRange: ">=4.2.0 <4.5.0"
       alm-examples: |-
         [
           {

--- a/manifests/deploy/ocp-testing/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
@@ -202,13 +202,14 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     categories: OpenShift Optional, Monitoring
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.5
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    olm.skipRange: '>=4.2.0 <4.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-metering
     repository: https://github.com/operator-framework/operator-metering

--- a/manifests/deploy/openshift/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
@@ -202,13 +202,14 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     categories: OpenShift Optional, Monitoring
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.5
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    olm.skipRange: '>=4.2.0 <4.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-metering
     repository: https://github.com/operator-framework/operator-metering

--- a/manifests/deploy/openshift/olm/bundle/art.yaml
+++ b/manifests/deploy/openshift/olm/bundle/art.yaml
@@ -8,6 +8,8 @@ updates:
     # replace spec.version value
     - search: 'version: "4.5.0"'
       replace: 'version: {FULL_VER}'
+    - search: 'olm.skipRange: ">=4.2.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.2.0 <{FULL_VER}"'
   - file: "metering.package.yaml"
     update_list:
     - search: "currentCSV: metering-operator.v{MAJOR}.{MINOR}.0"

--- a/manifests/deploy/upstream/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
@@ -209,6 +209,7 @@ metadata:
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    olm.skipRange: '>=4.2.0 <4.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-metering
     repository: https://github.com/operator-framework/operator-metering


### PR DESCRIPTION
This would add the `olm.skipRange` CSV annotation to the metering-operator's CSV which allows users to automatically upgrade to a newer channel once it becomes available in OperatorHub. Before, users would need to manually uninstall the operator and then reinstall when a new version is available, which is not ideal.