### PR TITLE
Dockerfile: Update the metering-ansible-operator to use the Ansible 2.8 and newer versions.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -31,10 +31,7 @@ RUN ln -f -s /tini /usr/bin/tini
 # 3. cryptography is used by the openssl_* modules for TLS/authentication purposes
 # TODO: the ansible-operator base image uses setuptools >= 45.2.0 which needs python 3.5 so this is a temporary fix
 RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr "setuptools<=45.1.0"
-# In order to use the 'ansible_failed_result' and 'ansible_failed_task' variables in a block/rescue,
-# we need to ensure that the 2.8 version is being used while this is fixed in 2.9 upstream.
-# TODO: revert this change once the issue mentioned above is resolved.
-RUN pip install --upgrade ansible==2.8
+RUN pip install --upgrade ansible>=2.8
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering


### PR DESCRIPTION
Previously, we needed to always use the Ansible 2.8 version in the metering-ansible-operator origin Dockerfile as there was a regression in 2.9 with regards to the 'ansible_failed_result' and 'ansible_failed_task' variables being out of scope in a block/rescue task. It would appear this is no longer necessary and we can use the Ansible 2.9 version.

Commit that originally introduced this change: https://github.com/operator-framework/operator-metering/commit/c70e60048fad6fc0839e06401e2375192c84a23b