### PR TITLE
images: Replace all instantiations of the k8s_facts Ansible module with k8s_info.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
@@ -13,7 +13,7 @@
 - name: Check for the existence of Hive TLS-related secrets
   block:
   - name: Check for the existence of the Hive Metastore TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.metastore.config.tls.secretName }}"
@@ -22,7 +22,7 @@
     register: hive_metastore_tls_buf
 
   - name: Check for the existence of the Hive Server Metastore TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.server.config.metastoreTLS.secretName }}"
@@ -31,7 +31,7 @@
     register: hive_server_client_tls_buf
 
   - name: Check for the existence of the Hive Server TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.server.config.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
@@ -2,7 +2,7 @@
 
 # Get the Openshift cluster's networking config object
 - name: Check the IP version infrastructure provisioned
-  k8s_facts:
+  k8s_info:
     api_version: "config.openshift.io/v1"
     kind: Network
     name: cluster

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -13,7 +13,7 @@
 - name: Check for the existence of Presto TLS-related secrets
   block:
   - name: Check for the existence of the Presto TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.tls.secretName }}"
@@ -22,7 +22,7 @@
     register: presto_secret_tls_buf
 
   - name: Check for the existence of the Presto Auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.auth.secretName }}"
@@ -31,7 +31,7 @@
     register: presto_secret_auth_buf
 
   - name: Check for the existence of the Presto-Hive client TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.connectors.hive.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -6,7 +6,7 @@
 - name: Check for the existence of the reporting-operator Presto TLS-related secrets
   block:
   - name: Check for the existence of the reporting-operator Presto client auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.auth.secretName }}"
@@ -52,7 +52,7 @@
 - name: Check for the existence of reporting-operator Hive TLS-related secrets
   block:
   - name: Check for the existence of the reporting-operator Hive client auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.config.hive.auth.secretName }}"
@@ -92,7 +92,7 @@
 - name: Check for the existence of reporting-operator authProxy-related secret data
   block:
   - name: Check for the existence of the reporting-operator authProxy cookie seed secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.authProxy.cookie.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
@@ -7,7 +7,7 @@
 - name: Check for the existence of the Metering Root CA secret
   block:
   - name: Check if Root CA secret already exists
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -28,7 +28,7 @@
       when: meteringconfig_storage_s3_create_bucket
 
     - name: Attempt to obtain the AWS credentials secret in the "{{ meta.namespace}}" namespace
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Secret
         name: "{{ meteringconfig_storage_s3_aws_credentials_secret_name }}"
@@ -114,7 +114,7 @@
 - name: Get azure storage account name
   block:
     - name: Get Azure storage credentials secret
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Secret
         name: "{{ meteringconfig_spec.storage.hive.azure.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Query for {{ resource.apis | map(attribute='kind') | join(', ') }} resources with selector {{ label_selector }} to delete
-  k8s_facts:
+  k8s_info:
     api_version: "{{ to_delete_item.api_version | default(omit) }}"
     kind: "{{ to_delete_item.kind }}"
     namespace: "{{ namespace }}"


### PR DESCRIPTION
The `k8s_fact` command is going to be depreciated in the next couple of Ansible releases, so this is just being pro-active and switching to the now recommended `k8s_info` module.

From the `k8s_info` Ansible documentation [1]: 
"This module was called k8s_facts before Ansible 2.9. The usage did not change."

[1] https://docs.ansible.com/ansible/latest/modules/k8s_info_module.html

