### PR TITLE
images: Validate the S3 credentials secret exists before continuing role execution.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -8,22 +8,26 @@
       message: "Configuring Hive storage"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+#
+# Configure S3 section
+#
 - name: Configure S3 Storage
   block:
-    - name: Validate Metering S3 bucket name
+    - name: Validate that the bucket and secret names are non-empty
       assert:
         that:
           - meteringconfig_storage_s3_bucket_name != ""
           - meteringconfig_storage_s3_bucket_region != ""
-        msg: "storage.hive.s3.bucket and storage.hive.s3.region cannot be empty"
+        msg: "storage.hive.s3.bucket and storage.hive.s3.secretName cannot be empty"
 
-    - name: Validate Metering S3 credentials
+    - name: Validate that the bucket region is non-empty when createBucket is set to true
       assert:
         that:
-          - meteringconfig_storage_s3_aws_credentials_secret_name != ""
-        msg: "storage.hive.s3.secretName cannot be empty"
+          - meteringconfig_storage_s3_bucket_region != ""
+        msg: "storage.hive.s3.region cannot be empty when storage.hive.s3.createBucket is true"
+      when: meteringconfig_storage_s3_create_bucket
 
-    - name: Obtaining AWS credentials to configure S3 bucket
+    - name: Attempt to obtain the AWS credentials secret in the "{{ meta.namespace}}" namespace
       k8s_facts:
         api_version: v1
         kind: Secret
@@ -32,7 +36,7 @@
       no_log: true
       register: operator_s3_credentials_secret
 
-    - name: Validate that the s3 credentials secret exists
+    - name: Validate the AWS credentials secret exists in the "{{ meta.namespace }}" namespace
       assert:
         that:
           - s3_credentials_secret_exists
@@ -46,7 +50,7 @@
         dualstack: "{{ s3_use_dualstack_endpoint }}"
         aws_access_key: "{{ operator_s3_credentials_secret.resources[0].data['aws-access-key-id'] | b64decode | default(omit) }}"
         aws_secret_key: "{{ operator_s3_credentials_secret.resources[0].data['aws-secret-access-key'] | b64decode | default(omit) }}"
-      when: s3_credentials_secret_exists
+      when: meteringconfig_storage_s3_create_bucket and s3_credentials_secret_exists
   rescue:
     - include_tasks: update_meteringconfig_status.yml
       vars:
@@ -60,8 +64,11 @@
   vars:
     s3_credentials_secret_exists: "{{ operator_s3_credentials_secret.resources and operator_s3_credentials_secret.resources | length > 0 }}"
     s3_use_dualstack_endpoint: "{{ _ocp_enabled_use_ipv6_networking }}"
-  when: meteringconfig_storage_hive_storage_type == 's3' and meteringconfig_storage_s3_create_bucket
+  when: meteringconfig_storage_hive_storage_type == 's3'
 
+#
+# Configure S3-compatible section
+#
 - name: Configure S3 Compatible Storage
   block:
     - name: Validate Metering s3Compatible bucket name
@@ -101,6 +108,9 @@
       when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
   when: meteringconfig_storage_hive_storage_type == 's3Compatible'
 
+#
+# Configure Azure section
+#
 - name: Get azure storage account name
   block:
     - name: Get Azure storage credentials secret
@@ -157,6 +167,9 @@
       when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
   when: meteringconfig_storage_hive_storage_type == 'azure' and meteringconfig_storage_azure_create_secret
 
+#
+# Configure GCS section
+#
 - name: Configure GCS Storage
   block:
     - name: Validate Metering gcs bucket name


### PR DESCRIPTION
This validation check was already in-place but only validated that this secret exists when `createBucket` was set to true, and not in the case where the default value (false) was used.