### PR TITLE
hack,Makefile: Support overriding the script package path in the update-codegen script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,4 +217,4 @@ update-codegen: $(CODEGEN_OUTPUT_GO_FILES)
 $(CODEGEN_OUTPUT_GO_FILES): $(CODEGEN_SOURCE_GO_FILES)
 
 verify-codegen:
-	./hack/verify-codegen.sh
+	SCRIPT_PACKAGE=$(GO_PKG) ./hack/verify-codegen.sh

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_PACKAGE=github.com/operator-framework/operator-metering
+SCRIPT_PACKAGE=${SCRIPT_PACKAGE:-"github.com/operator-framework/operator-metering"}
 SCRIPT_ROOT="$(realpath $(dirname ${BASH_SOURCE[0]})/..)"
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo k8s.io/code-generator)}
 


### PR DESCRIPTION
Currently the `./hack/update-codegen.sh` script is hardcoded to use the operator-framework/operator-metering package path, which breaks in the case we move this repository to another organization.

This adds support for overriding the `$SCRIPT_PACKAGE` variable, changing it to use the value of the `$GO_PKG` environment variable, and if that variable is unset, e.g. in the case of running the script directly, it defaults to the current github.com/<organization_name>/<repository_name>.

In the case where you want to override the value of the `$GO_PKG` environment variable, you would do something similar to the following:

```bash
make verify GO_PKG="github.com/<some org name>/<some project name>
```