### PR TITLE
Adds revision hash that was missing for OLM package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -377,7 +377,7 @@
     "pkg/lib/version",
   ]
   pruneopts = "NUT"
-  revision = ""
+  revision = "a611449366805935939777d0182a86ba43b26cbd"
   version = "0.12.0"
 
 [[projects]]


### PR DESCRIPTION
Improvements needed to Gopkg.lock that are needed to help `go init mod` do its job.