### PR TITLE
Providing a link to shell script file location

### DIFF
--- a/Documentation/dev/mirroring-ocp-images.md
+++ b/Documentation/dev/mirroring-ocp-images.md
@@ -33,7 +33,7 @@ You can also copy the cluster's CA into the correct directory within `/etc/docke
 
 # Mirror images from Brew into your cluster's in-cluster image registry
 
-Make sure you're connected to the Red Hat in-cluster network (VPNed or using an ethernet connection on the Red Hat network) and run the `hack/mirror-ose-images-into-cluster.sh` script in the repo.
+Make sure you're connected to the Red Hat in-cluster network (VPNed or using an ethernet connection on the Red Hat network) and run the [`hack/mirror-ose-images-into-cluster.sh`](../../hack/mirror-ose-images-into-cluster.sh) script in the repo.
 This script does a few things:
 
 - Sets up a namespace for pushing the images into.


### PR DESCRIPTION
Description

Providing a link to shell script file, so that user can navigate directly from documentation


Motive

Better readability of documentation