### PR TITLE
*: Connect to the thanos-querier API instead of the cluster-wide Prometheus instance.

### DIFF
--- a/charts/openshift-metering/templates/monitoring/monitoring-rbac.yaml
+++ b/charts/openshift-metering/templates/monitoring/monitoring-rbac.yaml
@@ -29,6 +29,6 @@ roleRef:
   name: metering-prometheus-k8s
 subjects:
 - kind: ServiceAccount
-  name: prometheus-k8s
+  name: thanos-querier
   namespace: {{ .Values.monitoring.namespace }}
 {{- end }}

--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -22,7 +22,7 @@ import (
 var (
 	defaultHiveHost      = "hive:10000"
 	defaultPrestoHost    = "presto:8080"
-	defaultPromHost      = "http://prometheus-k8s.monitoring.svc:9090/"
+	defaultPromHost      = "http://thanos-querier-openshift-monitoring.svc:9091/"
 	defaultLeaseDuration = time.Second * 60
 	// cfg is the config for our operator
 	cfg                            operator.Config

--- a/hack/run-reporting-operator-local.sh
+++ b/hack/run-reporting-operator-local.sh
@@ -9,7 +9,7 @@ source "${ROOT_DIR}/hack/common.sh"
 : "${METERING_USE_SERVICE_ACCOUNT_AS_PROM_TOKEN:=true}"
 
 : "${METERING_PROMETHEUS_NAMESPACE:=openshift-monitoring}"
-: "${METERING_PROMETHEUS_SVC:=prometheus-k8s}"
+: "${METERING_PROMETHEUS_SVC:=thanos-querier}"
 : "${METERING_PROMETHEUS_SVC_PORT:=9091}"
 : "${METERING_PROMETHEUS_SCHEME:=https}"
 : "${METERING_PROMETHEUS_PORT_FORWARD:=true}"

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -388,7 +388,7 @@ _ocp_enabled_overrides:
     spec:
       config:
         prometheus:
-          url: "https://prometheus-k8s.openshift-monitoring.svc:9091/"
+          url: "https://thanos-querier.openshift-monitoring.svc:9091/"
 
   presto:
     spec:
@@ -397,7 +397,7 @@ _ocp_enabled_overrides:
           prometheus:
             enabled: true
             config:
-              uri: "https://prometheus-k8s.openshift-monitoring.svc:9091/"
+              uri: "https://thanos-querier.openshift-monitoring.svc:9091/"
 
             auth:
               bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"


### PR DESCRIPTION
In 4.3, the monitoring team updated its architecture to introduce this Thanos Querier component, which provides a way for components like Metering to connect to a single, multi-tenant interface.
By default and when run on Openshift, Metering connects to the cluster-wide, prometheus-k8s service to retrieve the metrics scraped from the cluster. These changes update the metering-ansible-operator Ansible role to connect to the thanos-querier service API instead of the prometheus-k8s service.

In the case of running Metering on a vanilla Kubernetes cluster, nothing has changed - you're still required to configure/provide the Prometheus URL in the `MeteringConfig` custom resource.