### PR TITLE
Dockerfile: Update metering-ansible-operator image to work with rhel 8.1.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -3,13 +3,12 @@ FROM quay.io/openshift/origin-metering-helm:latest as helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli:latest as cli
 # the base image is the ansible-operator's origin images
-# TODO: stop using the latest tag for base images
 FROM quay.io/openshift/origin-ansible-operator:4.5
 
 USER root
 RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools openssl" \
     && yum clean all && rm -rf /var/cache/yum/* \
-    && yum -y install epel-release \
+    && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm  \
     && yum install --setopt=skip_missing_names_on_install=False -y \
         $INSTALL_PKGS  \
     && yum clean all \
@@ -21,19 +20,15 @@ RUN chmod +x /tini
 
 COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=cli /usr/bin/oc /usr/bin/oc
+# put tini and kubectl into our path
 RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
-# put tini into our path
 RUN ln -f -s /tini /usr/bin/tini
 
 # List of python packages:
 # 1. botocore and boto3 are used by the aws-related modules (aws_s3)
 # 2. netaddr is needed to use the ipv4/ipv6 jinja filter
 # 3. cryptography is used by the openssl_* modules for TLS/authentication purposes
-# TODO: the ansible-operator base image uses setuptools >= 45.2.0 which needs python 3.5 so this is a temporary fix
-RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr "setuptools<=45.1.0"
-# In order to use the 'ansible_failed_result' and 'ansible_failed_task' variables in a block/rescue,
-# we need to ensure that the 2.8 version is being used while this is fixed in 2.9 upstream.
-# TODO: revert this change once the issue mentioned above is resolved.
+RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr
 RUN pip install --upgrade ansible==2.8
 
 ENV HOME /opt/ansible


### PR DESCRIPTION
The ansible-operator base image has switched from rhel 7.7 to rhel 8.1, which includes bumping the python version to python3, and having to change where we pull the epel-release package. 