### PR TITLE
pkg/deploy: Fix the hive-metastore PVC label selector.

### DIFF
--- a/pkg/deploy/uninstall.go
+++ b/pkg/deploy/uninstall.go
@@ -154,7 +154,7 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 func (deploy *Deployer) uninstallMeteringPVCs() error {
 	// Attempt to get a list of PVCs that match the hdfs or hive labels
 	pvcs, err := deploy.client.CoreV1().PersistentVolumeClaims(deploy.config.Namespace).List(metav1.ListOptions{
-		LabelSelector: "app in (hdfs,hive)",
+		LabelSelector: "app in (hdfs,hive-metastore)",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to list all the metering PVCs in the %s namespace: %v", deploy.config.Namespace, err)


### PR DESCRIPTION
When uninstalling the metering associated PVCs, we list all the PVCs in the deploy namespace that match the `app=hdfs` or `app=hive`. This is problematic as the hive-metastore PVC manifest does not match the rest of the Hive components labeling structure (`app=hive,hive=<metastore,server>`) so we are label selecting something that won't ever exist.

In the case where you're using s3 as a storage backend, then a WARNing message will be produced as there's no PVC that matches that label selection:

```bash
$ ./bin/deploy-metering uninstall --namespace openshift-metering
INFO[04-13-2020 19:24:29] Setting the log level to info                 app=deploy
INFO[04-13-2020 19:24:29] Metering Deploy Namespace: openshift-metering  app=deploy
INFO[04-13-2020 19:24:29] Metering Deploy Platform: openshift           app=deploy
INFO[04-13-2020 19:24:29] Deleted the MeteringConfig resource           app=deploy
INFO[04-13-2020 19:24:29] Deleted the metering deployment               app=deploy
INFO[04-13-2020 19:24:29] Deleted the metering serviceaccount           app=deploy
INFO[04-13-2020 19:24:30] Deleted the metering role                     app=deploy
INFO[04-13-2020 19:24:30] Deleted the metering role binding             app=deploy
INFO[04-13-2020 19:24:30] Skipped deleting the metering cluster role resources  app=deploy
WARN[04-13-2020 19:24:30] The Hive/HDFS PVCs don't exist                app=deploy
INFO[04-13-2020 19:24:30] Skipped deleting the metering CRDs            app=deploy
INFO[04-13-2020 19:24:30] Skipped deleting the openshift-metering namespace  app=deploy
INFO[04-13-2020 19:24:30] Finished uninstall metering                   app=deploy
```