### PR TITLE
Bug 1871210: Add the required summary label to pass CVP checks. 

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -42,6 +42,7 @@ ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "exec-entrypoint", 
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+      summary="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
       io.openshift.tags="openshift" \
       com.redhat.delivery.appregistry=true \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.metering-ansible-operator.okd
+++ b/Dockerfile.metering-ansible-operator.okd
@@ -46,6 +46,7 @@ ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "exec-entrypoint", 
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+      summary="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
       io.openshift.tags="openshift" \
       com.redhat.delivery.appregistry=true \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -38,6 +38,7 @@ USER 1001
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+      summary="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
       io.openshift.tags="openshift" \
       com.redhat.delivery.appregistry=true \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.metering-ansible-operator.rhel8
+++ b/Dockerfile.metering-ansible-operator.rhel8
@@ -39,6 +39,7 @@ USER 1001
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+      summary="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
       io.openshift.tags="openshift" \
       com.redhat.delivery.appregistry=true \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.reporting-operator
+++ b/Dockerfile.reporting-operator
@@ -19,5 +19,6 @@ CMD ["start"]
 
 LABEL io.k8s.display-name="OpenShift metering-reporting-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages collecting data from monitoring and running reports." \
+      summary="This is a component of OpenShift Container Platform and manages collecting data from monitoring and running reports." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.reporting-operator.okd
+++ b/Dockerfile.reporting-operator.okd
@@ -21,5 +21,6 @@ CMD ["start"]
 
 LABEL io.k8s.display-name="OpenShift metering-reporting-operator" \
     io.k8s.description="This is a component of OpenShift Container Platform and manages collecting data from monitoring and running reports." \
+    summary="This is a component of OpenShift Container Platform and manages collecting data from monitoring and running reports." \
     io.openshift.tags="openshift" \
     maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.reporting-operator.rhel
+++ b/Dockerfile.reporting-operator.rhel
@@ -19,5 +19,6 @@ CMD ["start"]
 
 LABEL io.k8s.display-name="OpenShift metering-reporting-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages collecting data from monitoring and running reports." \
+      summary="This is a component of OpenShift Container Platform and manages collecting data from monitoring and running reports." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"


### PR DESCRIPTION
We've recently been getting hit with CVP check failures, where the inherited_labels verification check is reporting a FAIL-ed status:
```
inherited_labels	FAIL	Check if optional labels provided with 'labels_list' argument, are only inherited	Optional labels are only inherited	N/A
```

If we dig deeper, we get the following log message indicating that we need to set the `summary` label in the parent Dockerfile:
```
        {
            "name": "inherited_labels",
            "ok": false,
            "status": "FAIL",
            "description": "Check if optional labels provided with 'labels_list' argument, are only inherited",
            "message": "Optional labels are only inherited",
            "reference_url": "?????",
            "logs": [
                "optional label inherited: summary"
            ]
        },
```

This also updates the team mailing list so we're consistent throughout operand images too.